### PR TITLE
Add a wrapper class for datasets to work with sklearn

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adds FAQ entry regarding the initialization behavior of `NeuralNet` when passed instantiated models. (#409)
 - Added CUDA pickle test including an artifact that supports testing on CUDA-less CI machines
+- Wrapper class for torch Datasets to make them work with some sklearn features (e.g. grid search). (#443)
 
 ### Changed
 

--- a/docs/user/FAQ.rst
+++ b/docs/user/FAQ.rst
@@ -64,6 +64,20 @@ coresponding `data section
 in the notebook.
 
 
+How do I use sklearn GridSeachCV when my data is in a dataset?
+-----------------------------------------------------------------
+
+skorch supports datasets as input but sklearn doesn't. If it's
+possible, you should provide your data in a non-dataset format,
+e.g. as a numpy array or torch tensor, extracted from your original
+dataset.
+
+Sometimes, this is not possible, e.g. when your data doesn't fit into
+memory. To get around that, try to wrap your dataset into a
+:class:`.SliceDatasetX`. This is a data container that partly behaves
+like a dataset, partly like an ndarray. Further information can be
+found here: :ref:`slicedictx`.
+
 I want to use sample_weight, how can I do this?
 -----------------------------------------------
 

--- a/docs/user/helper.rst
+++ b/docs/user/helper.rst
@@ -19,6 +19,35 @@ length of the arrays and not the number of keys, and you get a
 with :class:`.SliceDict`, this works.
 
 
+.. _slicedictx:
+
+SliceDatasetX
+-------------
+
+A :class:`.SliceDatasetX` is a wrapper for
+:class:`torch.utils.data.Dataset`\s that makes them behave a little
+bit like :class:`numpy.ndarray`\s. That way, you can slice your
+dataset with lists and arrays, and you get a ``shape`` attribute.
+These properties are useful because if your data is in a dataset, you
+would normally not be able to use sklearn
+:class:`~sklearn.model_selection.GridSearchCV` and similar things;
+with :class:`.SliceDatasetX`, this works.
+
+Note that even if your dataset already contains the y values, you must
+still provide them separately for sklearn. Most of the time, it should
+be pretty straightforward to extract the y values from your dataset,
+so that this won't be an issue. Something like this should do the job:
+
+.. code:: python
+
+    ds = MyCustomDataset()
+    # assume that y is the second value returned by indexing into ds
+    y_from_ds = np.asarray([ds[i][1] for i in range(len(ds))])
+    # wrap the dataset into the new helper class
+    ds_sliceable = SliceDatasetX(ds)
+    gs.fit(ds_sliceable, y_from_ds)
+
+
 Command line interface helpers
 ------------------------------
 


### PR DESCRIPTION
When wrapping a torch dataset with `SliceDatasetX`, it can be passed to sklearn grid search et al.

Fixes #443 