### PR TITLE
Increase notebook version to >=5.7.8 in nuclei example

### DIFF
--- a/examples/nuclei_image_segmentation/requirements.txt
+++ b/examples/nuclei_image_segmentation/requirements.txt
@@ -3,4 +3,4 @@ torch==0.4.0
 torchvision==0.2.1
 matplotlib==2.2.2
 kaggle==1.4.2
-notebook==5.6.0
+notebook>=5.7.8

--- a/examples/nuclei_image_segmentation/requirements.txt
+++ b/examples/nuclei_image_segmentation/requirements.txt
@@ -1,6 +1,4 @@
-skorch==0.3.0
-torch==0.4.0
-torchvision==0.2.1
-matplotlib==2.2.2
-kaggle==1.4.2
+torchvision>=0.2.1
+matplotlib>=2.2.2
+kaggle>=1.4.2
 notebook>=5.7.8


### PR DESCRIPTION
This is because of a github security note. 5.7.8 seems to be the most recent version of notebook. I haven't actually checked what changed but I assume that the notebook should still work as expected.