### PR TITLE
[MRG] ENH Uses checkpoint internally

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Include requirements in MANIFEST.in
 - Add `criterion_` to `NeuralNet.cuda_dependent_attributes_` to avoid issues with criterion
   weight tensors from, e.g., `NLLLoss` (#426)
+- `TrainEndCheckpoint` can be cloned by `sklearn.base.clone`. (#459)
 
 
 ## [0.5.0] - 2018-12-13

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -7,6 +7,7 @@ from unittest.mock import call
 
 import numpy as np
 import pytest
+from sklearn.base import clone
 
 
 class TestCheckpoint:
@@ -891,3 +892,8 @@ class TestTrainEndCheckpoint:
             call(f_optimizer='exp1/train_end_optimizer_10.pt'),
             call(f_history='exp1/train_end_history.json')
         ])
+
+    def test_cloneable(self, finalcheckpoint_cls):
+        # reproduces bug #459
+        cp = finalcheckpoint_cls()
+        clone(cp)  # does not raise


### PR DESCRIPTION
Resolves https://github.com/skorch-dev/skorch/issues/459

This PR updates `TrainEndCheckpoint` to use class composition (instead of inheritance) when using `Checkpoint` methods.