### PR TITLE
Remove support for unpickling old files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `net.set_params(criterion__weight=w)`
 - skorch pickle format changed in order to improve CUDA compatibility, if you have pickled models, please re-pickle them to be able to load them in the future
 - `net.criterion_` and its parameters are now moved to target device when using criteria that inherit from `torch.nn.Module`. Previously the user had to make sure that parameters such as class weight are on the compute device
+- skorch now assumes PyTorch >= 1.1.0. This mainly affects learning rate schedulers, whose inner workings have been changed with version 1.1.0. This update will also invalidate pickled skorch models after a change introduced in PyTorch optimizers.
 
 ### Fixed
 

--- a/README.rst
+++ b/README.rst
@@ -213,10 +213,10 @@ If you want to help developing, run:
 PyTorch
 =======
 
-PyTorch is not covered by the dependencies, since the PyTorch
-version you need is dependent on your system. For installation
-instructions for PyTorch, visit the `PyTorch website
-<http://pytorch.org/>`__.
+PyTorch is not covered by the dependencies, since the PyTorch version
+you need is dependent on your system. For installation instructions
+for PyTorch, visit the `PyTorch website <http://pytorch.org/>`__. The
+current version of skorch assumes PyTorch >= 1.1.0.
 
 In general, this should work (assuming CUDA 9):
 

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1416,32 +1416,12 @@ class NeuralNet:
 
         return state
 
-    # TODO: remove this with the next release
-    def __setstate_050__(self, load_kwargs, state):
-        warnings.warn(
-            "This pickle file will stop working in the next release since "
-            "the data format changed. Please re-pickle the model to avoid "
-            "any issues in the future.", DeprecationWarning)
-        # workaround for cuda_dependent_attributes_ being misused as storage
-        # during __getstate__ in skorch <= 0.5.0.
-        original_cuda_dependent_attributes = self.cuda_dependent_attributes_
-        with tempfile.SpooledTemporaryFile() as f:
-            f.write(state['cuda_dependent_attributes_'])
-            f.seek(0)
-            cuda_attrs = torch.load(f, **load_kwargs)
-        state.update(cuda_attrs)
-        state['cuda_dependent_attributes_'] = original_cuda_dependent_attributes
-        self.__dict__.update(state)
-
     def __setstate__(self, state):
         # get_map_location will automatically choose the
         # right device in cases where CUDA is not available.
         map_location = get_map_location(state['device'])
         load_kwargs = {'map_location': map_location}
         state['device'] = self._check_device(state['device'], map_location)
-
-        if '__cuda_dependent_attributes__' not in state:
-            return self.__setstate_050__(load_kwargs, state)
 
         with tempfile.SpooledTemporaryFile() as f:
             f.write(state['__cuda_dependent_attributes__'])

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -286,41 +286,6 @@ class TestNeuralNet:
             pickle.dump(net_pickleable, f)
         return path
 
-    # TODO: remove with NeuralNet.__setstate_050__
-    @pytest.fixture
-    def pickled_0_5_0_model_path(self):
-        # script to reproduce:
-        # --------------------
-        # git checkout v0.5.0
-        #
-        # python <<EOF
-        # import pickle
-        #
-        # import skorch
-        # import skorch.toy
-        #
-        #
-        # model = skorch.toy.make_classifier()
-        # model = skorch.NeuralNetClassifier(model)
-        # model.initialize()
-        #
-        # with open('model_0.5.0.pkl', 'wb') as f:
-        #     pickle.dump(model, f)
-        # EOF
-        return os.path.join('skorch', 'tests', 'model_0.5.0.pkl')
-
-    # TODO: remove with NeuralNet.__setstate_050__
-    def test_pickle_0_5_0_load_and_store(self, net_cls, pickled_0_5_0_model_path):
-        # Test if we can load models of skorch <= 0.5.0
-        with open(pickled_0_5_0_model_path, 'rb') as f:
-            model = pickle.load(f)
-
-        assert isinstance(model, net_cls)
-
-        # Test if we can re-pickle it (important for backwards compatibility)
-        with tempfile.SpooledTemporaryFile() as f:
-            pickle.dump(model, f)
-
     @pytest.mark.parametrize('cuda_available', {False, torch.cuda.is_available()})
     def test_pickle_load(self, cuda_available, pickled_cuda_net_path):
         with patch('torch.cuda.is_available', lambda *_: cuda_available):


### PR DESCRIPTION
With PyTorch 1.1.0, we can no longer unpickle old models that have an
optimizer (i.e. basically all models). Therefore, we may as well drop
the support for unpickling old files now, when moving to PyTorch
1.1.0.