### PR TITLE
Be backward compatible with torch 1.0

### DIFF
--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -13,7 +13,11 @@ from torch.optim.lr_scheduler import LambdaLR
 from torch.optim.lr_scheduler import MultiStepLR
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torch.optim.lr_scheduler import StepLR
-from torch.optim.lr_scheduler import CyclicLR as TorchCyclicLR
+try:
+    from torch.optim.lr_scheduler import CyclicLR as TorchCyclicLR
+except ImportError:
+    # Backward compatibility with torch >= 1.0 && < 1.1
+    TorchCyclicLR = None
 from torch.optim.optimizer import Optimizer
 from skorch.callbacks import Callback
 
@@ -150,7 +154,7 @@ class LRScheduler(Callback):
         ):
             self.lr_scheduler_.batch_step(self.batch_idx_)
 
-        if isinstance(self.lr_scheduler_, TorchCyclicLR):
+        if TorchCyclicLR and isinstance(self.lr_scheduler_, TorchCyclicLR):
             self.lr_scheduler_.step(self.batch_idx_)
 
         if training:


### PR DESCRIPTION
When using the newest skorch version with torch 1.0.0 the following exception is thrown:

```
  File "/projects/Code/models.py", line 8, in <module>
    from skorch.callbacks import BatchScoring
  File "/projects/Code/skorch/skorch/__init__.py", line 7, in <module>
    from .net import NeuralNet
  File "/projects/Code/skorch/skorch/net.py", line 14, in <module>
    from skorch.callbacks import EpochTimer
  File "/projects/Code/skorch/skorch/callbacks/__init__.py", line 14, in <module>
    from .lr_scheduler import *
  File "/projects/Code/skorch/skorch/callbacks/lr_scheduler.py", line 16, in <module>
    from torch.optim.lr_scheduler import CyclicLR as TorchCyclicLR
ImportError: cannot import name 'CyclicLR'
```

Since 1.1.0 is not that old we should probably support 1.0.x for some time.