### PR TITLE
More helpful error message when predicting with unfitted net

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- More helpful error messages when trying to predict using an uninitialized model.
+
 ### Changed
 
 ### Fixed

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -351,6 +351,7 @@ class NeuralNetBinaryClassifier(NeuralNet, ClassifierMixin):
 
         """
         y_probas = []
+        self.check_is_fitted(attributes=['criterion_'])
         bce_logits_loss = isinstance(
             self.criterion_, torch.nn.BCEWithLogitsLoss)
 

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -25,6 +25,7 @@ from skorch.history import History
 from skorch.setter import optimizer_setter
 from skorch.utils import FirstStepAccumulator
 from skorch.utils import TeeGenerator
+from skorch.utils import check_is_fitted
 from skorch.utils import duplicate_items
 from skorch.utils import get_map_location
 from skorch.utils import is_dataset
@@ -679,6 +680,7 @@ class NeuralNet:
         like dropout by setting ``training=True``.
 
         """
+        self.check_is_fitted()
         with torch.set_grad_enabled(training):
             self.module_.train(training)
             return self.infer(Xi)
@@ -851,6 +853,27 @@ class NeuralNet:
 
         self.partial_fit(X, y, **fit_params)
         return self
+
+    def check_is_fitted(self, attributes=None, *args, **kwargs):
+        """Checks whether the net is initialized
+
+        Parameters
+        ----------
+        attributes : iterable of str or None (default=None)
+          All the attributes that are strictly required of a fitted
+          net. By default, this is the `module_` attribute.
+
+        Other arguments as in
+        ``sklearn.utils.validation.check_is_fitted``.
+
+        Raises
+        ------
+        skorch.exceptions.NotInitializedError
+          When the given attributes are not present.
+
+        """
+        attributes = attributes or ['module_']
+        check_is_fitted(self, attributes, *args, **kwargs)
 
     def forward_iter(self, X, training=False, device='cpu'):
         """Yield outputs of module forward calls on each batch of data.
@@ -1467,19 +1490,19 @@ class NeuralNet:
 
         """
         if f_params is not None:
-            if not hasattr(self, 'module_'):
-                raise NotInitializedError(
-                    "Cannot save parameters of an un-initialized model. "
-                    "Please initialize first by calling .initialize() "
-                    "or by fitting the model with .fit(...).")
+            msg = (
+                "Cannot save parameters of an un-initialized model. "
+                "Please initialize first by calling .initialize() "
+                "or by fitting the model with .fit(...).")
+            self.check_is_fitted(msg=msg)
             torch.save(self.module_.state_dict(), f_params)
 
         if f_optimizer is not None:
-            if not hasattr(self, 'optimizer_'):
-                raise NotInitializedError(
-                    "Cannot save state of an un-initialized optimizer. "
-                    "Please initialize first by calling .initialize() "
-                    "or by fitting the model with .fit(...).")
+            msg = (
+                "Cannot save state of an un-initialized optimizer. "
+                "Please initialize first by calling .initialize() "
+                "or by fitting the model with .fit(...).")
+            self.check_is_fitted(attributes=['optimizer_'], msg=msg)
             torch.save(self.optimizer_.state_dict(), f_optimizer)
 
         if f_history is not None:
@@ -1557,20 +1580,20 @@ class NeuralNet:
             f_optimizer = f_optimizer or formatted_files['f_optimizer']
 
         if f_params is not None:
-            if not hasattr(self, 'module_'):
-                raise NotInitializedError(
-                    "Cannot load parameters of an un-initialized model. "
-                    "Please initialize first by calling .initialize() "
-                    "or by fitting the model with .fit(...).")
+            msg = (
+                "Cannot load parameters of an un-initialized model. "
+                "Please initialize first by calling .initialize() "
+                "or by fitting the model with .fit(...).")
+            self.check_is_fitted(msg=msg)
             state_dict = _get_state_dict(f_params)
             self.module_.load_state_dict(state_dict)
 
         if f_optimizer is not None:
-            if not hasattr(self, 'optimizer_'):
-                raise NotInitializedError(
-                    "Cannot load state of an un-initialized optimizer. "
-                    "Please initialize first by calling .initialize() "
-                    "or by fitting the model with .fit(...).")
+            msg = (
+                "Cannot load state of an un-initialized optimizer. "
+                "Please initialize first by calling .initialize() "
+                "or by fitting the model with .fit(...).")
+            self.check_is_fitted(attributes=['optimizer_'], msg=msg)
             state_dict = _get_state_dict(f_optimizer)
             self.optimizer_.load_state_dict(state_dict)
 

--- a/skorch/tests/conftest.py
+++ b/skorch/tests/conftest.py
@@ -11,6 +11,9 @@ from torch import nn
 F = nn.functional
 
 
+INFERENCE_METHODS = ['predict', 'predict_proba', 'forward', 'forward_iter']
+
+
 ###################
 # shared fixtures #
 ###################

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -12,6 +12,8 @@ import pytest
 import torch
 from torch import nn
 
+from skorch.tests.conftest import INFERENCE_METHODS
+
 
 torch.manual_seed(0)
 
@@ -142,6 +144,20 @@ class TestNeuralNetBinaryClassifier:
     def test_fit(self, net_fit):
         # fitting does not raise anything
         pass
+
+    @pytest.mark.parametrize('method', INFERENCE_METHODS)
+    def test_not_fitted_raises(self, net_cls, module_cls, data, method):
+        from skorch.exceptions import NotInitializedError
+        net = net_cls(module_cls)
+        X = data[0]
+        with pytest.raises(NotInitializedError) as exc:
+            # we call `list` because `forward_iter` is lazy
+            list(getattr(net, method)(X))
+
+        msg = ("This NeuralNetBinaryClassifier instance is not initialized "
+               "yet. Call 'initialize' or 'fit' with appropriate arguments "
+               "before using this method.")
+        assert exc.value.args[0] == msg
 
     @flaky(max_runs=3)
     def test_net_learns(self, net_cls, module_cls, data):

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -18,16 +18,18 @@ import tempfile
 
 import numpy as np
 import pytest
+from sklearn.base import clone
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics import accuracy_score
 from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
-from sklearn.base import clone
 import torch
 from torch import nn
 from flaky import flaky
 
+from skorch.exceptions import NotInitializedError
+from skorch.tests.conftest import INFERENCE_METHODS
 from skorch.utils import flatten
 from skorch.utils import to_numpy
 from skorch.utils import is_torch_data_type
@@ -182,6 +184,32 @@ class TestNeuralNet:
     def test_fit(self, net_fit):
         # fitting does not raise anything
         pass
+
+    @pytest.mark.parametrize('method', INFERENCE_METHODS)
+    def test_not_fitted_raises(self, net_cls, module_cls, data, method):
+        from skorch.exceptions import NotInitializedError
+        net = net_cls(module_cls)
+        X = data[0]
+        with pytest.raises(NotInitializedError) as exc:
+            # we call `list` because `forward_iter` is lazy
+            list(getattr(net, method)(X))
+
+        msg = ("This NeuralNetClassifier instance is not initialized yet. "
+               "Call 'initialize' or 'fit' with appropriate arguments "
+               "before using this method.")
+        assert exc.value.args[0] == msg
+
+    def test_not_fitted_other_attributes(self, module_cls):
+        # pass attributes to check for explicitly
+        with patch('skorch.net.check_is_fitted') as check:
+            from skorch import NeuralNetClassifier
+
+            net = NeuralNetClassifier(module_cls)
+            attributes = ['foo', 'bar_']
+
+            net.check_is_fitted(attributes=attributes)
+            args = check.call_args_list[0][0][1]
+            assert args == attributes
 
     @flaky(max_runs=3)
     def test_net_learns(self, net_cls, module_cls, data):

--- a/skorch/tests/test_regressor.py
+++ b/skorch/tests/test_regressor.py
@@ -9,6 +9,8 @@ import numpy as np
 import pytest
 import torch
 
+from skorch.tests.conftest import INFERENCE_METHODS
+
 
 torch.manual_seed(0)
 
@@ -59,6 +61,20 @@ class TestNeuralNetRegressor:
     def test_fit(self, net_fit):
         # fitting does not raise anything
         pass
+
+    @pytest.mark.parametrize('method', INFERENCE_METHODS)
+    def test_not_fitted_raises(self, net_cls, module_cls, data, method):
+        from skorch.exceptions import NotInitializedError
+        net = net_cls(module_cls)
+        X = data[0]
+        with pytest.raises(NotInitializedError) as exc:
+            # we call `list` because `forward_iter` is lazy
+            list(getattr(net, method)(X))
+
+        msg = ("This NeuralNetRegressor instance is not initialized "
+               "yet. Call 'initialize' or 'fit' with appropriate arguments "
+               "before using this method.")
+        assert exc.value.args[0] == msg
 
     @flaky(max_runs=3)
     def test_net_learns(self, net, net_cls, data, module_cls):

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -20,6 +20,7 @@ from torch.nn.utils.rnn import PackedSequence
 from torch.utils.data.dataset import Subset
 
 from skorch.exceptions import DeviceWarning
+from skorch.exceptions import NotInitializedError
 
 
 class Ansi(Enum):
@@ -481,6 +482,31 @@ def get_map_location(target_device, fallback_device='cpu'):
             ), DeviceWarning)
         map_location = torch.device(fallback_device)
     return map_location
+
+
+def check_is_fitted(estimator, attributes, msg=None, all_or_any=all):
+    """Checks whether the net is initialized.
+
+    Note: This is a re-implementation of
+    sklearn.utils.validation.check_is_fitted, using exactly the same
+    arguments and logic. The only exception is that this function
+    raises a ``skorch.exception.NotInitializedError`` instead of an
+    ``sklearn.exceptions.NotFittedError``.
+
+    """
+    if msg is None:
+        msg = ("This %(name)s instance is not initialized yet. Call "
+               "'initialize' or 'fit' with appropriate arguments "
+               "before using this method.")
+
+    if not hasattr(estimator, 'fit'):
+        raise TypeError("%s is not an estimator instance." % (estimator))
+
+    if not isinstance(attributes, (list, tuple)):
+        attributes = [attributes]
+
+    if not all_or_any([hasattr(estimator, attr) for attr in attributes]):
+        raise NotInitializedError(msg % {'name': type(estimator).__name__})
 
 
 class TeeGenerator:


### PR DESCRIPTION
Fixes #487 

* Use check_is_fitted similar to what is used in sklearn, except that
  a skorch.exceptions.NotInitializedError is raised.
* Only assumes the presence of 'module_' so that nets remain hackable,
  except where a different attribute is specifically required.
* Re-wrote existing checks to now use check_is_fitted.