### PR TITLE
Check init arguments for missing dunder notation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- More careful check for wrong parameter names being passed to NeuralNet
+- More careful check for wrong parameter names being passed to NeuralNet (#500)
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- More careful check for wrong parameter names being passed to NeuralNet
+
 ### Changed
 
 - Improve numerical stability when using `NLLLoss` in `NeuralNetClassifer` (#491)

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1326,7 +1326,7 @@ class NeuralNet:
                     if not key.startswith(prefix + '__'):
                         missing_dunder_kwargs.append((prefix, key))
                     break
-            else:  # if no break
+            else:  # no break means key didn't match a prefix
                 unexpected_kwargs.append(key)
 
         msgs = []

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -229,7 +229,7 @@ class NeuralNet:
         initialized = kwargs.pop('initialized_', False)
         virtual_params = kwargs.pop('virtual_params_', dict())
 
-        kwargs = self.check_kwargs(kwargs)
+        kwargs = self._check_kwargs(kwargs)
         vars(self).update(kwargs)
 
         self.history = history
@@ -1272,7 +1272,7 @@ class NeuralNet:
         params.update(params_cb)
         return params
 
-    def check_kwargs(self, kwargs):
+    def _check_kwargs(self, kwargs):
         """Check argument names passed at initialization.
 
         Raises
@@ -1285,6 +1285,12 @@ class NeuralNet:
         -------
         kwargs: dict
           Return the passed keyword arguments.
+
+        Example
+        -------
+        >>> net = NeuralNetClassifier(MyModule, iterator_train_shuffle=True)
+        TypeError: Got an unexpected argument iterator_train_shuffle,
+        did you mean iterator_train__shuffle?
 
         """
         unexpected_kwargs = []

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -178,13 +178,21 @@ class TestNeuralNet:
                     "should deal with the new arguments explicitely.")
         assert e.value.args[0] == expected
 
+    @pytest.mark.parametrize('name, suggestion', [
+        ('iterator_train_shuffle', 'iterator_train__shuffle'),
+        ('optimizer_momentum', 'optimizer__momentum'),
+        ('modulenum_units', 'module__num_units'),
+        ('criterionreduce', 'criterion__reduce'),
+        ('callbacks_mycb__foo', 'callbacks__mycb__foo'),
+    ])
     def test_net_init_missing_dunder_in_prefix_argument(
-            self, net_cls, module_cls):
+            self, net_cls, module_cls, name, suggestion):
         # forgot to use double-underscore notation
         with pytest.raises(TypeError) as e:
-            net_cls(module_cls, iterator_train_shuffle=True)
-        expected = ("Got an unexpected argument iterator_train_shuffle, "
-                    "did you mean iterator_train__shuffle?")
+            net_cls(module_cls, **{name: 123})
+
+        tmpl = "Got an unexpected argument {}, did you mean {}?"
+        expected = tmpl.format(name, suggestion)
         assert e.value.args[0] == expected
 
     def test_net_init_missing_dunder_in_2_prefix_arguments(

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -178,6 +178,48 @@ class TestNeuralNet:
                     "should deal with the new arguments explicitely.")
         assert e.value.args[0] == expected
 
+    def test_net_init_missing_dunder_in_prefix_argument(
+            self, net_cls, module_cls):
+        # forgot to use double-underscore notation
+        with pytest.raises(TypeError) as e:
+            net_cls(module_cls, iterator_train_shuffle=True)
+        expected = ("Got an unexpected argument iterator_train_shuffle, "
+                    "did you mean iterator_train__shuffle?")
+        assert e.value.args[0] == expected
+
+    def test_net_init_missing_dunder_in_2_prefix_arguments(
+            self, net_cls, module_cls):
+        # forgot to use double-underscore notation in 2 arguments
+        with pytest.raises(TypeError) as e:
+            net_cls(
+                module_cls,
+                max_epochs=7,  # correct
+                iterator_train_shuffle=True,  # uses _ instead of __
+                optimizerlr=0.5,  # missing __
+            )
+        expected = ("Got an unexpected argument iterator_train_shuffle, "
+                    "did you mean iterator_train__shuffle?\n"
+                    "Got an unexpected argument optimizerlr, "
+                    "did you mean optimizer__lr?")
+        assert e.value.args[0] == expected
+
+    def test_net_init_missing_dunder_and_unknown(
+            self, net_cls, module_cls):
+        # unknown argument and forgot to use double-underscore notation
+        with pytest.raises(TypeError) as e:
+            net_cls(
+                module_cls,
+                foobar=123,
+                iterator_train_shuffle=True,
+            )
+        expected = ("__init__() got unexpected argument(s) foobar. "
+                    "Either you made a typo, or you added new arguments "
+                    "in a subclass; if that is the case, the subclass "
+                    "should deal with the new arguments explicitely.\n"
+                    "Got an unexpected argument iterator_train_shuffle, "
+                    "did you mean iterator_train__shuffle?")
+        assert e.value.args[0] == expected
+
     def test_fit(self, net_fit):
         # fitting does not raise anything
         pass


### PR DESCRIPTION
Fixes #500 

This catches wrong keyword arguments such as `optimizerlr` or `iterator_train_shuffle` and suggests the correct name.