### PR TITLE
Update environment.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 dist: xenial
 python:
-  - "3.7"
+  - "3.7.3"
   - "3.6"
   - "3.5"
 env:

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - numpy-base=1.16.4
   - openssl=1.1.1c
   - pip=10.0.1
-  - python=3.6.9
+  - python=3.7.4
   - readline=7.0
   - scikit-learn=0.21.2
   - scipy=1.3.0

--- a/environment.yml
+++ b/environment.yml
@@ -1,20 +1,38 @@
 name: skorch
 channels:
-- defaults
+  - defaults
 dependencies:
-- mkl
-- openssl=1.0.2l=0
-- pip=10.0.1
-- python=3.6.2=0
-- readline=6.2=2
-- scikit-learn>=0.19.0
-- scipy>=1.1.0
-- setuptools=27.2.0=py36_0
-- sqlite=3.13.0=0
-- tk=8.5.18=0
-- wheel=0.32.2
-- xz=5.2.2=1
-- zlib=1.2.8=3
-- tqdm=4.14.0
-- pip:
-  - tabulate==0.7.7
+  - _libgcc_mutex=0.1
+  - blas=1.0
+  - ca-certificates=2019.5.15
+  - certifi=2019.6.16
+  - intel-openmp=2019.4
+  - joblib=0.13.2
+  - libedit=3.1.20181209
+  - libffi=3.2.1
+  - libgcc-ng=9.1.0
+  - libgfortran-ng=7.3.0
+  - libstdcxx-ng=9.1.0
+  - mkl=2019.4
+  - mkl-service=2.0.2
+  - mkl_fft=1.0.12
+  - mkl_random=1.0.2
+  - ncurses=6.1
+  - numpy=1.16.4
+  - numpy-base=1.16.4
+  - openssl=1.1.1c
+  - pip=10.0.1
+  - python=3.6.9
+  - readline=7.0
+  - scikit-learn=0.21.2
+  - scipy=1.3.0
+  - setuptools=41.0.1
+  - six=1.12.0
+  - sqlite=3.29.0
+  - tabulate=0.8.3
+  - tk=8.6.8
+  - tqdm=4.32.1
+  - wheel=0.33.4
+  - xz=5.2.4
+  - zlib=1.2.11
+

--- a/environment.yml
+++ b/environment.yml
@@ -10,9 +10,6 @@ dependencies:
   - joblib=0.13.2
   - libedit=3.1.20181209
   - libffi=3.2.1
-  - libgcc-ng=9.1.0
-  - libgfortran-ng=7.3.0
-  - libstdcxx-ng=9.1.0
   - mkl=2019.4
   - mkl-service=2.0.2
   - mkl_fft=1.0.12

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -16,6 +16,7 @@ import sys
 from contextlib import ExitStack
 
 import numpy as np
+from packaging import version
 import pytest
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics import accuracy_score
@@ -1409,6 +1410,10 @@ class TestNeuralNet:
     )
   ),
 )"""
+        if version.parse(torch.__version__) >= version.parse('1.2'):
+            expected = expected.replace("Softmax()", "Softmax(dim=-1)")
+            expected = expected.replace("Dropout(p=0.5)",
+                                        "Dropout(p=0.5, inplace=False)")
         assert result == expected
 
     def test_repr_fitted_works(self, net_cls, module_cls, data):
@@ -1436,6 +1441,10 @@ class TestNeuralNet:
     )
   ),
 )"""
+        if version.parse(torch.__version__) >= version.parse('1.2'):
+            expected = expected.replace("Softmax()", "Softmax(dim=-1)")
+            expected = expected.replace("Dropout(p=0.5)",
+                                        "Dropout(p=0.5, inplace=False)")
         assert result == expected
 
     def test_fit_params_passed_to_module(self, net_cls, data):

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -1152,7 +1152,6 @@ class TestNeuralNet:
         # now initialized
         assert 'callbacks__myscore__scoring' in params
 
-    @pytest.mark.xfail
     def test_get_params_with_uninit_callbacks(self, net_cls, module_cls):
         from skorch.callbacks import EpochTimer
 


### PR DESCRIPTION
For some reason, the old one didn't work for me anymore. I got the following errors:

```bash
$ conda --version
conda 4.7.10
$ conda env create
ResolvePackageNotFound: 
  - setuptools==27.2.0=py36_0
  - xz==5.2.2=1
  - zlib==1.2.8=3
  - readline==6.2=2
  - sqlite==3.13.0=0
  - openssl==1.0.2l=0
  - tqdm=4.14.0
  - tk==8.5.18=0
  - python==3.6.2=0
```

Could someone please confirm this?

If this is true, I wonder why this happens. Shouldn't conda allow reproducible builds? Were all those packages removed?
