### PR TITLE
Tensorboard logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - More helpful error messages when trying to predict using an uninitialized model.
+- Add TensorBoard callback for automatic logging to tensorboard
 
 ### Changed
 

--- a/skorch/tests/callbacks/test_logging.py
+++ b/skorch/tests/callbacks/test_logging.py
@@ -1,4 +1,7 @@
+"""Tests for callbacks/logging.py"""
+
 from functools import partial
+import os
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -141,8 +144,8 @@ class TestPrintLog:
         assert columns == expected
 
     def test_keys_ignored_as_str(self, print_log_cls):
-        print_log = print_log_cls(keys_ignored='a-key')
-        assert print_log.keys_ignored == ['a-key']
+        print_log = print_log_cls(keys_ignored='a-key').initialize()
+        assert print_log.keys_ignored_ == {'a-key', 'batches'}
 
         print_log.initialize()
         assert print_log.keys_ignored_ == set(['a-key', 'batches'])
@@ -274,3 +277,202 @@ class TestProgressBar:
         assert tqdm_mock.call_count == 2
         for i, total in enumerate(expected_total):
             assert tqdm_mock.call_args_list[i][1]['total'] == total
+
+
+class TestTensorBoard:
+    @pytest.fixture
+    def net_cls(self):
+        from skorch import NeuralNetClassifier
+        return NeuralNetClassifier
+
+    @pytest.fixture
+    def data(self, classifier_data):
+        X, y = classifier_data
+        # accelerate training since we don't care for the loss
+        X, y = X[:40], y[:40]
+        return X, y
+
+    @pytest.fixture
+    def tensorboard_cls(self):
+        from skorch.callbacks import TensorBoard
+        return TensorBoard
+
+    @pytest.fixture
+    def summary_writer_cls(self):
+        from torch.utils.tensorboard import SummaryWriter
+        return SummaryWriter
+
+    @pytest.fixture
+    def mock_writer(self, summary_writer_cls):
+        mock = Mock(spec=summary_writer_cls)
+        return mock
+
+    @pytest.fixture
+    def net_fitted(
+            self,
+            net_cls,
+            classifier_module,
+            data,
+            tensorboard_cls,
+            mock_writer,
+    ):
+        return net_cls(
+            classifier_module,
+            callbacks=[tensorboard_cls(mock_writer)],
+            max_epochs=3,
+        ).fit(*data)
+
+    def test_graph_added_once(self, net_fitted, mock_writer):
+        # graph should just be added once
+        assert mock_writer.add_graph.call_count == 1
+
+    def test_include_graph_false(
+            self,
+            net_cls,
+            classifier_module,
+            data,
+            tensorboard_cls,
+            mock_writer,
+    ):
+        net_cls(
+            classifier_module,
+            callbacks=[tensorboard_cls(mock_writer, include_graph=False)],
+            max_epochs=2,
+        ).fit(*data)
+        assert mock_writer.add_graph.call_count == 0
+
+    def test_writer_closed_automatically(self, net_fitted, mock_writer):
+        assert mock_writer.close.call_count == 1
+
+    def test_writer_not_closed(
+            self,
+            net_cls,
+            classifier_module,
+            data,
+            tensorboard_cls,
+            mock_writer,
+    ):
+        net_cls(
+            classifier_module,
+            callbacks=[tensorboard_cls(mock_writer, close_after_train=False)],
+            max_epochs=2,
+        ).fit(*data)
+        assert mock_writer.close.call_count == 0
+
+    def test_keys_from_history_logged(self, net_fitted, mock_writer):
+        add_scalar = mock_writer.add_scalar
+
+        # 3 epochs with 4 keys
+        assert add_scalar.call_count == 3 * 4
+        keys = {call_args[1]['tag'] for call_args in add_scalar.call_args_list}
+        expected = {'dur', 'Loss/train_loss', 'Loss/valid_loss', 'Loss/valid_acc'}
+        assert keys == expected
+
+    def test_ignore_keys(
+            self,
+            net_cls,
+            classifier_module,
+            data,
+            tensorboard_cls,
+            mock_writer,
+    ):
+        # ignore 'dur' and 'valid_loss', 'unknown' doesn't exist but
+        # this should not cause a problem
+        tb = tensorboard_cls(
+            mock_writer, keys_ignored=['dur', 'valid_loss', 'unknown'])
+        net_cls(
+            classifier_module,
+            callbacks=[tb],
+            max_epochs=3,
+        ).fit(*data)
+        add_scalar = mock_writer.add_scalar
+
+        keys = {call_args[1]['tag'] for call_args in add_scalar.call_args_list}
+        expected = {'Loss/train_loss', 'Loss/valid_acc'}
+        assert keys == expected
+
+    def test_keys_ignored_is_string(self, tensorboard_cls, mock_writer):
+        tb = tensorboard_cls(mock_writer, keys_ignored='a-key').initialize()
+        expected = {'a-key', 'batches'}
+        assert tb.keys_ignored_ == expected
+
+    def test_other_key_mapper(
+            self,
+            net_cls,
+            classifier_module,
+            data,
+            tensorboard_cls,
+            mock_writer,
+    ):
+        # just map all keys to uppercase
+        tb = tensorboard_cls(mock_writer, key_mapper=lambda s: s.upper())
+        net_cls(
+            classifier_module,
+            callbacks=[tb],
+            max_epochs=3,
+        ).fit(*data)
+        add_scalar = mock_writer.add_scalar
+
+        keys = {call_args[1]['tag'] for call_args in add_scalar.call_args_list}
+        expected = {'DUR', 'TRAIN_LOSS', 'VALID_LOSS', 'VALID_ACC'}
+        assert keys == expected
+
+    @pytest.fixture
+    def add_scalar_maybe(self, tensorboard_cls, mock_writer):
+        tb = tensorboard_cls(mock_writer)
+        return tb.add_scalar_maybe
+
+    @pytest.fixture
+    def history(self):
+        return [
+            {'loss': 0.1, 'epoch': 1, 'foo': ['invalid', 'type']},
+            {'loss': 0.2, 'epoch': 2, 'foo': ['invalid', 'type']},
+        ]
+
+    def test_add_scalar_maybe_uses_last_epoch_values(
+            self, add_scalar_maybe, mock_writer, history):
+        add_scalar_maybe(history, key='loss', tag='myloss', global_step=2)
+        call_kwargs = mock_writer.add_scalar.call_args_list[0][1]
+        assert call_kwargs['tag'] == 'myloss'
+        assert call_kwargs['scalar_value'] == 0.2
+        assert call_kwargs['global_step'] == 2
+
+    def test_add_scalar_maybe_infers_epoch(
+            self, add_scalar_maybe, mock_writer, history):
+        # don't indicate 'global_step' value
+        add_scalar_maybe(history, key='loss', tag='myloss')
+        call_kwargs = mock_writer.add_scalar.call_args_list[0][1]
+        assert call_kwargs['global_step'] == 2
+
+    def test_add_scalar_maybe_unknown_key_does_not_raise(
+            self, tensorboard_cls, summary_writer_cls, history):
+        tb = tensorboard_cls(summary_writer_cls())
+        # does not raise:
+        tb.add_scalar_maybe(history, key='unknown', tag='bar')
+
+    def test_add_scalar_maybe_wrong_type_does_not_raise(
+            self, tensorboard_cls, summary_writer_cls, history):
+        tb = tensorboard_cls(summary_writer_cls())
+        # value of 'foo' is a list but that does not raise:
+        tb.add_scalar_maybe(history, key='foo', tag='bar')
+
+    def test_fit_with_real_summary_writer(
+            self,
+            net_cls,
+            classifier_module,
+            data,
+            tensorboard_cls,
+            summary_writer_cls,
+            tmp_path,
+    ):
+        path = str(tmp_path)
+
+        net = net_cls(
+            classifier_module,
+            callbacks=[tensorboard_cls(summary_writer_cls(path))],
+            max_epochs=5,
+        )
+        net.fit(*data)
+
+        # is not empty
+        assert os.listdir(path)


### PR DESCRIPTION
Fixes #510 

This includes the changes as proposed by @taketwo, namely to automatically log everything except keys that were opted out, the same as `PrintLog`.

I would like to update one of the existing notebooks to showcase the use. My candidate would be [MNIST-torchvision](https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/notebooks/MNIST-torchvision.ipynb), or do you think this would be too much for this notebook, @ottonemo? Of course, it's difficult to show the tensorboard inside the Jupyter notebook, I would probably add a screenshot.