### PR TITLE
Several improvements to NeuralNetBinaryClassifier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - More careful check for wrong parameter names being passed to NeuralNet (#500)
 - More helpful error messages when trying to predict using an uninitialized model
+- Make NeuralNetBinaryClassifier work with sklearn.calibration.CalibratedClassifierCV
+- Improve NeuralNetBinaryClassifier compatibility with certain sklearn metrics
+- NeuralNetBinaryClassifier automatically squeezes module output if necessary
 
 ### Changed
 
 - Improve numerical stability when using `NLLLoss` in `NeuralNetClassifer` (#491)
+- NeuralNetBinaryClassifier.predict_proba now returns a 2-dim array; to access the "old" y_proba, take y_proba[:, 1]
 
 ### Fixed
 


### PR DESCRIPTION
* more fit runs because of flaky output (fixes #514)
* add a classes_ attribute for things like CalibratedClassifierCV (fixes #465)
* make y_proba 2-dim, which works better with certain sklearn metrics (fixes #442)
* automatically squeezes output if module returns (n,1) shape (fixes #502)

This could break backwards compatibility if someone relies on y_proba to be 1d.