### PR TITLE
Small changes to net that make grad accumulation easier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve numerical stability when using `NLLLoss` in `NeuralNetClassifer` (#491)
+- Refactor code to make gradient accumulation easier to implement (#506)
 
 ### Fixed
 

--- a/docs/user/FAQ.rst
+++ b/docs/user/FAQ.rst
@@ -295,7 +295,7 @@ gradient accumulation yourself:
 
     ACC_STEPS = 2  # number of steps to accumulate before updating weights
 
-    class GradAccNet(net_cls):
+    class GradAccNet(NeuralNetClassifier):
         """Net that accumulates gradients"""
         def __init__(self, *args, acc_steps=ACC_STEPS, **kwargs):
             super().__init__(*args, **kwargs)

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -731,8 +731,6 @@ class NeuralNet:
                 self.notify('on_batch_begin', X=Xi, y=yi_res, training=True)
                 step = self.train_step(Xi, yi, **fit_params)
                 train_batch_count += 1
-                if not step:
-                    continue
                 self.history.record_batch('train_loss', step['loss'].item())
                 self.history.record_batch('train_batch_size', get_len(Xi))
                 self.notify('on_batch_end', X=Xi, y=yi_res, training=True, **step)

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -730,11 +730,12 @@ class NeuralNet:
                 yi_res = yi if not y_train_is_ph else None
                 self.notify('on_batch_begin', X=Xi, y=yi_res, training=True)
                 step = self.train_step(Xi, yi, **fit_params)
-                if step:
-                    self.history.record_batch('train_loss', step['loss'].item())
-                    self.history.record_batch('train_batch_size', get_len(Xi))
-                    self.notify('on_batch_end', X=Xi, y=yi_res, training=True, **step)
                 train_batch_count += 1
+                if not step:
+                    continue
+                self.history.record_batch('train_loss', step['loss'].item())
+                self.history.record_batch('train_batch_size', get_len(Xi))
+                self.notify('on_batch_end', X=Xi, y=yi_res, training=True, **step)
             self.history.record("train_batch_count", train_batch_count)
 
             if dataset_valid is None:
@@ -747,10 +748,10 @@ class NeuralNet:
                 yi_res = yi if not y_valid_is_ph else None
                 self.notify('on_batch_begin', X=Xi, y=yi_res, training=False)
                 step = self.validation_step(Xi, yi, **fit_params)
+                valid_batch_count += 1
                 self.history.record_batch('valid_loss', step['loss'].item())
                 self.history.record_batch('valid_batch_size', get_len(Xi))
                 self.notify('on_batch_end', X=Xi, y=yi_res, training=False, **step)
-                valid_batch_count += 1
             self.history.record("valid_batch_count", valid_batch_count)
 
             self.notify('on_epoch_end', **on_epoch_kwargs)

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -593,7 +593,6 @@ class NeuralNet:
 
         """
         self.module_.train()
-        self.optimizer_.zero_grad()
         y_pred = self.infer(Xi, **fit_params)
         loss = self.get_loss(y_pred, yi, X=Xi, training=True)
         loss.backward()
@@ -656,6 +655,7 @@ class NeuralNet:
             step_accumulator.store_step(step)
             return step['loss']
         self.optimizer_.step(step_fn)
+        self.optimizer_.zero_grad()
         return step_accumulator.get_step()
 
     def evaluation_step(self, Xi, training=False):
@@ -730,9 +730,10 @@ class NeuralNet:
                 yi_res = yi if not y_train_is_ph else None
                 self.notify('on_batch_begin', X=Xi, y=yi_res, training=True)
                 step = self.train_step(Xi, yi, **fit_params)
-                self.history.record_batch('train_loss', step['loss'].item())
-                self.history.record_batch('train_batch_size', get_len(Xi))
-                self.notify('on_batch_end', X=Xi, y=yi_res, training=True, **step)
+                if step:
+                    self.history.record_batch('train_loss', step['loss'].item())
+                    self.history.record_batch('train_batch_size', get_len(Xi))
+                    self.notify('on_batch_end', X=Xi, y=yi_res, training=True, **step)
                 train_batch_count += 1
             self.history.record("train_batch_count", train_batch_count)
 

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2238,19 +2238,15 @@ class TestNeuralNet:
                 Only optimize every 2nd batch.
 
                 """
-                step_accumulator = self.get_train_step_accumulator()
                 # note that n_train_batches starts at 1 for each epoch
                 n_train_batches = len(self.history[-1, 'batches'])
-
-                def step_fn():
-                    step = self.train_step_single(Xi, yi, **fit_params)
-                    step_accumulator.store_step(step)
-                    return step['loss']
+                step = self.train_step_single(Xi, yi, **fit_params)
+                step['loss'] = step['loss'] / 2
 
                 if n_train_batches % 2 == 0:
-                    self.optimizer_.step(step_fn)
+                    self.optimizer_.step()
                     self.optimizer_.zero_grad()
-                return step_accumulator.get_step()
+                return step
 
         max_epochs = 5
         net = GradAccNet(module_cls, max_epochs=max_epochs)

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2232,6 +2232,10 @@ class TestNeuralNet:
                 mock_optimizer.zero_grad.side_effect = self.true_optimizer_.zero_grad
                 self.optimizer_ = mock_optimizer
 
+            def get_loss(self, *args, **kwargs):
+                loss = super().get_loss(*args, **kwargs)
+                return loss / 2  # because only every 2nd step is optimized
+
             def train_step(self, Xi, yi, **fit_params):
                 """Perform gradient accumulation
 
@@ -2241,7 +2245,6 @@ class TestNeuralNet:
                 # note that n_train_batches starts at 1 for each epoch
                 n_train_batches = len(self.history[-1, 'batches'])
                 step = self.train_step_single(Xi, yi, **fit_params)
-                step['loss'] = step['loss'] / 2
 
                 if n_train_batches % 2 == 0:
                     self.optimizer_.step()


### PR DESCRIPTION
In #506, there was a discussion about how to implement gradient accumulation with skorch. Unfortunately, it seemed to me that it is not easily possible. However, I believe that a small number of tweaks are enough to make it possible:

* move `self.optimizer_.zero_grad()` from `train_step_single` to `train_step` (might break some code but only of very advanced users)
* since `step` can now be None for train in `fit_loop`, add a conditional to only record things if step is not None (ugly but not back breaking)

I hope that this actually does what I read about gradient accumulation, since I have never used it myself. Maybe @fabiocapsouza can comment on that.

Overall, if this should really be enough, I think the changes would be worth implementing, given that popular architectures like BERT use it. However, I wouldn't elevate it to "first class" in skorch (yet), i.e. make it possible to control via a parameter. Instead, I would probably document how to do something similar to the test (possibly in the FAQ).

PS: Not quite sure what to do with `train_batch_count`? Only increment it each time the optimizer is called or for each batch? I guess the latter is more fitting?