### PR TITLE
Updated all referenecs to old github repo #479

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,10 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Helper functions to build command line interfaces with almost no
   boilerplate, [example][1811191713] that shows usage
 
-[1810251445]: https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/Basic_Usage.ipynb
-[1810261633]: https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/Advanced_Usage.ipynb
-[1811011230]: https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/MNIST.ipynb
-[1811191713]: https://github.com/dnouri/skorch/tree/master/examples/cli
+[1810251445]: https://colab.research.google.com/github/skorch-dev/skorch/blob/master/notebooks/Basic_Usage.ipynb
+[1810261633]: https://colab.research.google.com/github/skorch-dev/skorch/blob/master/notebooks/Advanced_Usage.ipynb
+[1811011230]: https://colab.research.google.com/github/skorch-dev/skorch/blob/master/notebooks/MNIST.ipynb
+[1811191713]: https://github.com/skorch-dev/skorch/tree/master/examples/cli
 
 ### Changed
 
@@ -106,7 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `NeuralNetwork.load_params` now supports loading from `Checkpoint` instances
 - Added documentation for [saving and loading][4]
 
-[1]: https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/examples/nuclei_image_segmentation/Nuclei_Image_Segmentation.ipynb
+[1]: https://nbviewer.jupyter.org/github/skorch-dev/skorch/blob/master/examples/nuclei_image_segmentation/Nuclei_Image_Segmentation.ipynb
 [2]: https://skorch.readthedocs.io/en/latest/toy.html
 [3]: https://skorch.readthedocs.io/en/latest/callbacks.html#skorch.callbacks.ParamMapper
 [4]: https://skorch.readthedocs.io/en/latest/user/save_load.html
@@ -136,6 +136,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the net was configured to use the CPU (#354, #358)
 
 
-[Unreleased]: https://github.com/dnouri/skorch/compare/v0.5.0...HEAD
-[0.4.0]: https://github.com/dnouri/skorch/compare/v0.3.0...v0.4.0
-[0.5.0]: https://github.com/dnouri/skorch/compare/v0.4.0...v0.5.0
+[Unreleased]: https://github.com/skorch-dev/skorch/compare/v0.5.0...HEAD
+[0.4.0]: https://github.com/skorch-dev/skorch/compare/v0.3.0...v0.4.0
+[0.5.0]: https://github.com/skorch-dev/skorch/compare/v0.4.0...v0.5.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -260,7 +260,7 @@ def project_linkcode_resolve(domain, info):
     return _linkcode_resolve(domain, info,
             package='skorch',
             revision=_linkcode_git_revision,
-            url_fmt='https://github.com/dnouri/skorch/'
+            url_fmt='https://github.com/skorch-dev/skorch/'
                     'blob/{revision}/'
                     '{package}/{path}#L{lineno}')
 

--- a/docs/user/REST.rst
+++ b/docs/user/REST.rst
@@ -4,7 +4,7 @@ REST Service
 
 In this section we'll take the RNN sentiment classifer from the
 example `Predicting sentiment on the IMDB dataset
-<https://github.com/dnouri/skorch/blob/master/examples/rnn_classifer/RNN_sentiment_classification.ipynb>`_
+<https://github.com/skorch-dev/skorch/blob/master/examples/rnn_classifer/RNN_sentiment_classification.ipynb>`_
 and use it to demonstrate how to easily expose your PyTorch module on
 the web using skorch and another library called `Palladium
 <https://github.com/ottogroup/palladium>`_.
@@ -47,7 +47,6 @@ defines the dataset and model:
     }
 
 You can save this configuration as ``palladium-config.py``.
-    
 The ``dataset_loader_train`` and ``dataset_loader_test`` entries
 define where the data comes from.  They refer to a Python class
 defined inside the ``model`` module.  Let's create a file and call it
@@ -106,7 +105,6 @@ we'll create next:
     from skorch import NeuralNetClassifier
     import torch
 
-   
     def create_pipeline(
         vocab_size=1000,
         max_len=50,
@@ -132,14 +130,13 @@ You've noticed that this function's job is to create the model and
 return it.  Here, we're defining a pipeline that wraps skorch's
 ``NeuralNetClassifier``, which in turn is a wrapper around our PyTorch
 module, as it's defined in the `predicting sentiment tutorial
-<https://github.com/dnouri/skorch/blob/master/examples/rnn_classifer/RNN_sentiment_classification.ipynb>`_.
+<https://github.com/skorch-dev/skorch/blob/master/examples/rnn_classifer/RNN_sentiment_classification.ipynb>`_.
 We'll also add the RNNClassifier to ``model.py``:
 
 .. code:: python
 
     from torch import nn
     F = nn.functional
-          
 
     class RNNClassifier(nn.Module):
         def __init__(

--- a/docs/user/REST.rst
+++ b/docs/user/REST.rst
@@ -47,6 +47,7 @@ defines the dataset and model:
     }
 
 You can save this configuration as ``palladium-config.py``.
+
 The ``dataset_loader_train`` and ``dataset_loader_test`` entries
 define where the data comes from.  They refer to a Python class
 defined inside the ``model`` module.  Let's create a file and call it
@@ -105,6 +106,7 @@ we'll create next:
     from skorch import NeuralNetClassifier
     import torch
 
+
     def create_pipeline(
         vocab_size=1000,
         max_len=50,
@@ -137,6 +139,7 @@ We'll also add the RNNClassifier to ``model.py``:
 
     from torch import nn
     F = nn.functional
+
 
     class RNNClassifier(nn.Module):
         def __init__(

--- a/docs/user/callbacks.rst
+++ b/docs/user/callbacks.rst
@@ -20,7 +20,7 @@ The base class for each callback is :class:`.Callback`. If you would
 like to write your own callbacks, you should inherit from this class.
 A guide and practical example on how to write your own callbacks is
 shown in this `notebook
-<https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/notebooks/Advanced_Usage.ipynb#Writing-a-custom-callback>`_.
+<https://nbviewer.jupyter.org/github/skorch-dev/skorch/blob/master/notebooks/Advanced_Usage.ipynb#Writing-a-custom-callback>`_.
 In general, remember this:
 
 
@@ -153,7 +153,7 @@ In general, the scoring callbacks are useful when the default scores
 determined by the :class:`.NeuralNet` are not enough. They allow you
 to easily add new metrics to be logged during training. For an example
 of how to add a new score to your model, look `at this notebook
-<https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/notebooks/Basic_Usage.ipynb#Callbacks>`_.
+<https://nbviewer.jupyter.org/github/skorch-dev/skorch/blob/master/notebooks/Basic_Usage.ipynb#Callbacks>`_.
 
 The first argument to both callbacks is ``name`` and should be a
 string. This determines the column name of the score shown by the

--- a/docs/user/helper.rst
+++ b/docs/user/helper.rst
@@ -203,4 +203,4 @@ as usual).
 
 .. _fire: https://github.com/google/python-fire
 .. _numpydoc: https://github.com/numpy/numpydoc
-.. _example: https://github.com/dnouri/skorch/tree/master/examples/cli
+.. _example: https://github.com/skorch-dev/skorch/tree/master/examples/cli

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -33,7 +33,7 @@ If you just want to use skorch, use:
 
 .. code:: bash
 
-    git clone https://github.com/dnouri/skorch.git
+    git clone https://github.com/skorch-dev/skorch.git
     cd skorch
     conda env create
     source activate skorch
@@ -44,7 +44,7 @@ If you want to help developing, run:
 
 .. code:: bash
 
-    git clone https://github.com/dnouri/skorch.git
+    git clone https://github.com/skorch-dev/skorch.git
     cd skorch
     conda env create
     source activate skorch
@@ -62,7 +62,7 @@ If you just want to use skorch, use:
 
 .. code:: bash
 
-    git clone https://github.com/dnouri/skorch.git
+    git clone https://github.com/skorch-dev/skorch.git
     cd skorch
     # create and activate a virtual environment
     pip install -r requirements.txt
@@ -73,7 +73,7 @@ If you want to help developing, run:
 
 .. code:: bash
 
-    git clone https://github.com/dnouri/skorch.git
+    git clone https://github.com/skorch-dev/skorch.git
     cd skorch
     # create and activate a virtual environment
     pip install -r requirements.txt

--- a/docs/user/tutorials.rst
+++ b/docs/user/tutorials.rst
@@ -5,20 +5,20 @@ Tutorials
 
 The following are examples and notebooks on how to use skorch.
 
-* `Basic Usage <https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/notebooks/Basic_Usage.ipynb>`_ - Explores the basics of the skorch API. `Run in Google Colab 💻 <https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/Basic_Usage.ipynb>`_
+* `Basic Usage <https://nbviewer.jupyter.org/github/skorch-dev/skorch/blob/master/notebooks/Basic_Usage.ipynb>`_ - Explores the basics of the skorch API. `Run in Google Colab 💻 <https://colab.research.google.com/github/skorch-dev/skorch/blob/master/notebooks/Basic_Usage.ipynb>`_
 
-* `MNIST with scikit-learn and skorch <https://github.com/dnouri/skorch/blob/master/notebooks/MNIST.ipynb>`_ - Define and train a simple neural network with PyTorch and use it with skorch. `Run in Google Colab 💻 <https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/MNIST.ipynb>`_
+* `MNIST with scikit-learn and skorch <https://github.com/skorch-dev/skorch/blob/master/notebooks/MNIST.ipynb>`_ - Define and train a simple neural network with PyTorch and use it with skorch. `Run in Google Colab 💻 <https://colab.research.google.com/github/skorch-dev/skorch/blob/master/notebooks/MNIST.ipynb>`_
 
-* `Benchmarks skorch vs pure PyTorch <https://github.com/dnouri/skorch/blob/master/examples/benchmarks/mnist.py>`_ - Compares the performance of skorch and using pure PyTorch on MNIST.
+* `Benchmarks skorch vs pure PyTorch <https://github.com/skorch-dev/skorch/blob/master/examples/benchmarks/mnist.py>`_ - Compares the performance of skorch and using pure PyTorch on MNIST.
 
-* `Transfer Learning with skorch <https://github.com/dnouri/skorch/blob/master/notebooks/Transfer_Learning.ipynb>`_ - Train a neutral network using transfer learning with skorch. `Run in Google Colab 💻 <https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/Transfer_Learning.ipynb>`_
+* `Transfer Learning with skorch <https://github.com/skorch-dev/skorch/blob/master/notebooks/Transfer_Learning.ipynb>`_ - Train a neutral network using transfer learning with skorch. `Run in Google Colab 💻 <https://colab.research.google.com/github/skorch-dev/skorch/blob/master/notebooks/Transfer_Learning.ipynb>`_
 
-* `Image Segmentation with UNets <https://github.com/dnouri/skorch/blob/master/examples/nuclei_image_segmentation>`_ - Use transfer learning to train a UNet model for image segmentation.
+* `Image Segmentation with UNets <https://github.com/skorch-dev/skorch/blob/master/examples/nuclei_image_segmentation>`_ - Use transfer learning to train a UNet model for image segmentation.
 
-* `Using skorch with Dask <https://github.com/dnouri/skorch/tree/master/examples/rnn_classifer>`_ - Using Dask to parallelize grid search across GPUs.
+* `Using skorch with Dask <https://github.com/skorch-dev/skorch/tree/master/examples/rnn_classifer>`_ - Using Dask to parallelize grid search across GPUs.
 
-* `World level language modeling RNN <https://github.com/dnouri/skorch/tree/master/examples/word_language_model>`_ - Uses skorch to train a language model.
+* `World level language modeling RNN <https://github.com/skorch-dev/skorch/tree/master/examples/word_language_model>`_ - Uses skorch to train a language model.
 
-* `Seq2Seq Translation using skorch <https://github.com/dnouri/skorch/tree/master/examples/translation>`_ - Translation with a seqeuence to sequence network.
+* `Seq2Seq Translation using skorch <https://github.com/skorch-dev/skorch/tree/master/examples/translation>`_ - Translation with a seqeuence to sequence network.
 
-* `Advanced Usage <https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/notebooks/Advanced_Usage.ipynb>`_ - Dives deep into the inner works of skorch. `Run in Google Colab 💻 <https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/Advanced_Usage.ipynb>`_
+* `Advanced Usage <https://nbviewer.jupyter.org/github/skorch-dev/skorch/blob/master/notebooks/Advanced_Usage.ipynb>`_ - Dives deep into the inner works of skorch. `Run in Google Colab 💻 <https://colab.research.google.com/github/skorch-dev/skorch/blob/master/notebooks/Advanced_Usage.ipynb>`_

--- a/examples/nuclei_image_segmentation/README.md
+++ b/examples/nuclei_image_segmentation/README.md
@@ -1,6 +1,6 @@
 # Nuclei Image Segmentation With UNets
 
-This tutorial can be viewed at [nbviewer](https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/examples/nuclei_image_segmentation/Nuclei_Image_Segmentation.ipynb).
+This tutorial can be viewed at [nbviewer](https://nbviewer.jupyter.org/github/skorch-dev/skorch/blob/master/examples/nuclei_image_segmentation/Nuclei_Image_Segmentation.ipynb).
 
 ## Setup
 

--- a/notebooks/Advanced_Usage.ipynb
+++ b/notebooks/Advanced_Usage.ipynb
@@ -14,10 +14,10 @@
     "This notebook shows some more advanced features of `skorch`. More examples will be added with time.\n",
     "\n",
     "<table align=\"left\"><td>\n",
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/Advanced_Usage.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/skorch-dev/skorch/blob/master/notebooks/Advanced_Usage.ipynb\">\n",
     "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>  \n",
     "</td><td>\n",
-    "<a target=\"_blank\" href=\"https://github.com/dnouri/skorch/blob/master/notebooks/Advanced_Usage.ipynb\"><img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a></td></table>"
+    "<a target=\"_blank\" href=\"https://github.com/skorch-dev/skorch/blob/master/notebooks/Advanced_Usage.ipynb\"><img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a></td></table>"
    ]
   },
   {

--- a/notebooks/Basic_Usage.ipynb
+++ b/notebooks/Basic_Usage.ipynb
@@ -14,10 +14,10 @@
     "*`skorch`* is designed to maximize interoperability between `sklearn` and `pytorch`. The aim is to keep 99% of the flexibility of `pytorch` while being able to leverage most features of `sklearn`. Below, we show the basic usage of `skorch` and how it can be combined with `sklearn`.\n",
     "\n",
     "<table align=\"left\"><td>\n",
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/Basic_Usage.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/skorch-dev/skorch/blob/master/notebooks/Basic_Usage.ipynb\">\n",
     "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>  \n",
     "</td><td>\n",
-    "<a target=\"_blank\" href=\"https://github.com/dnouri/skorch/blob/master/notebooks/Basic_Usage.ipynb\"><img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a></td></table>"
+    "<a target=\"_blank\" href=\"https://github.com/skorch-dev/skorch/blob/master/notebooks/Basic_Usage.ipynb\"><img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a></td></table>"
    ]
   },
   {
@@ -977,7 +977,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For information on how to write custom callbacks, have a look at the [Advanced_Usage](https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/notebooks/Advanced_Usage.ipynb) notebook."
+    "For information on how to write custom callbacks, have a look at the [Advanced_Usage](https://nbviewer.jupyter.org/github/skorch-dev/skorch/blob/master/notebooks/Advanced_Usage.ipynb) notebook."
    ]
   },
   {

--- a/notebooks/MNIST-torchvision.ipynb
+++ b/notebooks/MNIST-torchvision.ipynb
@@ -9,17 +9,17 @@
     "This notebooks shows how to define and train a simple Neural-Network with PyTorch and use it via skorch with the help of torchvision.\n",
     "\n",
     "<table align=\"left\"><td>\n",
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/MNIST.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/skorch-dev/skorch/blob/master/notebooks/MNIST.ipynb\">\n",
     "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>  \n",
     "</td><td>\n",
-    "<a target=\"_blank\" href=\"https://github.com/dnouri/skorch/blob/master/notebooks/MNIST.ipynb\"><img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a></td></table>"
+    "<a target=\"_blank\" href=\"https://github.com/skorch-dev/skorch/blob/master/notebooks/MNIST.ipynb\"><img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a></td></table>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note**: If you are running this in [a colab notebook](https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/MNIST.ipynb), we recommend you enable a free GPU by going:\n",
+    "**Note**: If you are running this in [a colab notebook](https://colab.research.google.com/github/skorch-dev/skorch/blob/master/notebooks/MNIST.ipynb), we recommend you enable a free GPU by going:\n",
     "\n",
     "> **Runtime**   →   **Change runtime type**   →   **Hardware Accelerator: GPU**\n",
     "\n",

--- a/notebooks/MNIST.ipynb
+++ b/notebooks/MNIST.ipynb
@@ -9,17 +9,17 @@
     "This notebooks shows how to define and train a simple Neural-Network with PyTorch and use it via skorch with SciKit-Learn.\n",
     "\n",
     "<table align=\"left\"><td>\n",
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/MNIST.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/skorch-dev/skorch/blob/master/notebooks/MNIST.ipynb\">\n",
     "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>  \n",
     "</td><td>\n",
-    "<a target=\"_blank\" href=\"https://github.com/dnouri/skorch/blob/master/notebooks/MNIST.ipynb\"><img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a></td></table>"
+    "<a target=\"_blank\" href=\"https://github.com/skorch-dev/skorch/blob/master/notebooks/MNIST.ipynb\"><img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a></td></table>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note**: If you are running this in [a colab notebook](https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/MNIST.ipynb), we recommend you enable a free GPU by going:\n",
+    "**Note**: If you are running this in [a colab notebook](https://colab.research.google.com/github/skorch-dev/skorch/blob/master/notebooks/MNIST.ipynb), we recommend you enable a free GPU by going:\n",
     "\n",
     "> **Runtime**   →   **Change runtime type**   →   **Hardware Accelerator: GPU**\n",
     "\n",

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,7 +1,7 @@
 # Notebooks
 
-* [Basic usage](https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/notebooks/Basic_Usage.ipynb)
-* [Advanced usage](https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/notebooks/Advanced_Usage.ipynb)
-* [MNIST](https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/notebooks/MNIST.ipynb)
-* [MNIST using torchvision](https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/notebooks/MNIST-torchvision.ipynb)
-* [Transfer Learning](https://nbviewer.jupyter.org/github/dnouri/skorch/blob/master/notebooks/Transfer_Learning.ipynb)
+* [Basic usage](https://nbviewer.jupyter.org/github/skorch-dev/skorch/blob/master/notebooks/Basic_Usage.ipynb)
+* [Advanced usage](https://nbviewer.jupyter.org/github/skorch-dev/skorch/blob/master/notebooks/Advanced_Usage.ipynb)
+* [MNIST](https://nbviewer.jupyter.org/github/skorch-dev/skorch/blob/master/notebooks/MNIST.ipynb)
+* [MNIST using torchvision](https://nbviewer.jupyter.org/github/skorch-dev/skorch/blob/master/notebooks/MNIST-torchvision.ipynb)
+* [Transfer Learning](https://nbviewer.jupyter.org/github/skorch-dev/skorch/blob/master/notebooks/Transfer_Learning.ipynb)

--- a/notebooks/Transfer_Learning.ipynb
+++ b/notebooks/Transfer_Learning.ipynb
@@ -16,17 +16,17 @@
     "We will be using `torchvision` for this tutorial. Instructions on how to install `torchvision` for your platform can be found at https://pytorch.org.\n",
     "\n",
     "<table align=\"left\"><td>\n",
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/Transfer_Learning.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/skorch-dev/skorch/blob/master/notebooks/Transfer_Learning.ipynb\">\n",
     "    <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>  \n",
     "</td><td>\n",
-    "<a target=\"_blank\" href=\"https://github.com/dnouri/skorch/blob/master/notebooks/Transfer_Learning.ipynb\"><img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a></td></table>"
+    "<a target=\"_blank\" href=\"https://github.com/skorch-dev/skorch/blob/master/notebooks/Transfer_Learning.ipynb\"><img width=32px src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a></td></table>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note**: If you are running this in [a colab notebook](https://colab.research.google.com/github/dnouri/skorch/blob/master/notebooks/Transfer_Learning.ipynb), we recommend you enable a free GPU by going:\n",
+    "**Note**: If you are running this in [a colab notebook](https://colab.research.google.com/github/skorch-dev/skorch/blob/master/notebooks/Transfer_Learning.ipynb), we recommend you enable a free GPU by going:\n",
     "\n",
     "> **Runtime**   →   **Change runtime type**   →   **Hardware Accelerator: GPU**\n",
     "\n",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     license='new BSD 3-Clause',
     packages=find_packages(),
     include_package_data=True,
-    url="https://github.com/dnouri/skorch",
+    url="https://github.com/skorch-dev/skorch",
     zip_safe=False,
     install_requires=install_requires,
     extras_require={

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1384,7 +1384,7 @@ class NeuralNet:
             if key.endswith('_'):
                 raise ValueError(
                     "Something went wrong here. Please open an issue on "
-                    "https://github.com/dnouri/skorch/issues detailing what "
+                    "https://github.com/skorch-dev/skorch/issues detailing what "
                     "caused this error.")
             setattr(self, key, val)
 

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -119,7 +119,7 @@ class TestNeuralNet:
         # This test comes from [issue #317], and makes sure that models
         # can be trained after copying (which is really pickling).
         #
-        # [issue #317]:https://github.com/dnouri/skorch/issues/317
+        # [issue #317]:https://github.com/skorch-dev/skorch/issues/317
         X, y = data
         n1 = net_cls(module_cls)
         n1.partial_fit(X, y, epochs=1)


### PR DESCRIPTION
The following url prefixes where changed :
Old: https://colab.research.google.com/github/dnouri
New: https://colab.research.google.com/github/skorch-dev/

Old: https://github.com/dnouri/skorch
New: https://github.com/skorch-dev/skorch

Old: https://nbviewer.jupyter.org/github/dnouri
New: https://nbviewer.jupyter.org/github/skorch-dev