### PR TITLE
Tiny bit of more info in the CyclicLR deprecation warning 😅

### DIFF
--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -347,6 +347,7 @@ class CyclicLR:
         # TODO: Remove class in 0.7
         warnings.warn(
             "skorch.callbacks.CyclicLR is deprecated, please use "
+            "skorch.callbacks.LRScheduler together with "
             "torch.optim.lr_scheduler.CyclicLR instead",
             DeprecationWarning
         )


### PR DESCRIPTION
The warning was pretty ambiguous.  First, you may think that you
should use torch.optim.lr_scheduler.CyclicLR as the net's optimizer,
which will fail.  Second, you may think that you can use
torch.optim.lr_scheduler.CyclicLR as a callback, which will obviously
fail, too.  I'm hoping this will save someone some time.  :-)