### PR TITLE
DOC Update parallelism example to work with latest sklearn and dask

### DIFF
--- a/docs/user/parallelism.rst
+++ b/docs/user/parallelism.rst
@@ -32,25 +32,28 @@ packages required to do the work::
   CUDA_VISIBLE_DEVICES=0 dask-worker 127.0.0.1:8786 --nthreads 1
   CUDA_VISIBLE_DEVICES=1 dask-worker 127.0.0.1:8786 --nthreads 1
 
-In your code, use joblib's ``parallel_backend`` to choose the Dask
-backend for grid searches and the like.  Remember to also import the
-``distributed.joblib`` module, as that will register the joblib
-backend.  Let's see how this could look like:
+In your code, use joblib's :func:`~joblib.parallel_backend` context
+manager to activate the Dask backend when you run grid searches and
+the like.  Also instantiate a :class:`dask.distributed.Client` to
+point to the Dask scheduler that you want to use.  Let's see how this
+could look like:
 
 .. code:: python
 
-    import distributed.joblib  # imported for side effects
-    from sklearn.externals.joblib import parallel_backend
+    from dask.distributed import Client
+    from joblib import parallel_backend
+
+    client = Client('127.0.0.1:8786')
 
     X, y = load_my_data()
-    model = get_that_model()      
+    net = get_that_net()
 
     gs = GridSearchCV(
-        model,
-        param_grid={'net__lr': [0.01, 0.03]},
+        net,
+        param_grid={'lr': [0.01, 0.03]},
         scoring='accuracy',
         )
-    with parallel_backend('dask.distributed', scheduler_host='127.0.0.1:8786'):
+    with parallel_backend('dask'):
         gs.fit(X, y)
     print(gs.cv_results_)
 

--- a/examples/rnn_classifer/dask-config.py
+++ b/examples/rnn_classifer/dask-config.py
@@ -7,12 +7,11 @@
             'param_grid': {'__copy__': 'grid_search.param_grid'},
             'scoring': {'__copy__': 'scoring'},
         },
-        'backend': 'dask.distributed',
-        'scheduler_host': '127.0.0.1:8786',
+        'backend': 'dask',
     },
 
-    '_init_distributed': {
-        '__factory__': 'palladium.util.resolve_dotted_name',
-        'dotted_name': 'distributed.joblib.joblib',
+    '_init_client': {
+        '__factory__': 'dask.distributed.Client',
+        'address': '127.0.0.1:8786',
     },
 }


### PR DESCRIPTION
I present to you: "the new way".

The old way now fails in a very awkward way and I had to find out the hard way.  `joblib` defines a thread global to carry the current active "parallel backend".  Now, imagine what happens when you set the backend using `sklearn.externals.joblib.parallel_backend`, but at runtime scikit-learn will happily use the unchanged backend defined in `joblib`.  I guess yay for vendoring packages?