### PR TITLE
Add `classes_` attribute `NeuralNetClassifier`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make NeuralNetBinaryClassifier work with sklearn.calibration.CalibratedClassifierCV
 - Improve NeuralNetBinaryClassifier compatibility with certain sklearn metrics (#515)
 - NeuralNetBinaryClassifier automatically squeezes module output if necessary (#515)
+- NeuralNetClassifier now has a classes_ attribute after fit is called, which is inferred from y by default (#465, #486)
 
 ### Changed
 

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -10,6 +10,7 @@ from flaky import flaky
 import numpy as np
 import pytest
 import torch
+from sklearn.base import clone
 from torch import nn
 
 from skorch.tests.conftest import INFERENCE_METHODS
@@ -56,6 +57,9 @@ class TestNeuralNet:
         # side effects on other tests.
         X, y = data
         return net.fit(X, y)
+
+    def test_clone(self, net_fit):
+        clone(net_fit)
 
     def test_predict_and_predict_proba(self, net_fit, data):
         X = data[0]
@@ -147,6 +151,11 @@ class TestNeuralNet:
         expected = "NeuralNetClassifier has no attribute 'classes_'"
         assert msg == expected
 
+    def test_with_calibrated_classifier_cv(self, net_fit, data):
+        from sklearn.calibration import CalibratedClassifierCV
+        cccv = CalibratedClassifierCV(net_fit, cv=2)
+        cccv.fit(*data)
+
 
 class TestNeuralNetBinaryClassifier:
     @pytest.fixture(scope='module')
@@ -191,6 +200,9 @@ class TestNeuralNetBinaryClassifier:
     def test_fit(self, net_fit):
         # fitting does not raise anything
         pass
+
+    def test_clone(self, net_fit):
+        clone(net_fit)
 
     @pytest.mark.parametrize('method', INFERENCE_METHODS)
     def test_not_fitted_raises(self, net_cls, module_cls, data, method):

--- a/skorch/tests/test_regressor.py
+++ b/skorch/tests/test_regressor.py
@@ -7,6 +7,7 @@ Only contains tests that are specific for regressor subclasses.
 from flaky import flaky
 import numpy as np
 import pytest
+from sklearn.base import clone
 import torch
 
 from skorch.tests.conftest import INFERENCE_METHODS
@@ -57,6 +58,9 @@ class TestNeuralNetRegressor:
         # side effects on other tests.
         X, y = data
         return net.fit(X, y)
+
+    def test_clone(self, net_fit):
+        clone(net_fit)
 
     def test_fit(self, net_fit):
         # fitting does not raise anything


### PR DESCRIPTION
This is inferred from y default but can be overridden by passing
`classes` explicitly during initialization.

Also, add more rigorous tests to classifiers and regressor.
That is to catch errors with specific attributes being set on those
that are not set on `NeuralNet` itself. This can potentially mess with
cloning, which is why it should be tested explicitly.

Addresses #465, #486
