### PR TITLE
Raise helpful error if dict passed to scoring callback

### DIFF
--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -81,6 +81,7 @@ class ScoringBase(Callback):
     def _get_name(self):
         """Find name of scoring function."""
         if self.name is not None:
+            print("name", self.name)
             return self.name
         if self.scoring_ is None:
             return 'score'
@@ -90,6 +91,8 @@ class ScoringBase(Callback):
             return self.scoring_.func.__name__
         if isinstance(self.scoring_, _BaseScorer):
             return self.scoring_._score_func.__name__
+        if isinstance(self.scoring_, dict):
+            raise ValueError("Dict not supported for scoring. If you wan't to use multiple scores pass multiple callbacks")
         return self.scoring_.__name__
 
     def initialize(self):

--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -81,7 +81,6 @@ class ScoringBase(Callback):
     def _get_name(self):
         """Find name of scoring function."""
         if self.name is not None:
-            print("name", self.name)
             return self.name
         if self.scoring_ is None:
             return 'score'

--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -92,7 +92,8 @@ class ScoringBase(Callback):
         if isinstance(self.scoring_, _BaseScorer):
             return self.scoring_._score_func.__name__
         if isinstance(self.scoring_, dict):
-            raise ValueError("Dict not supported for scoring. If you wan't to use multiple scores pass multiple callbacks")
+            raise ValueError("Dict not supported as scorer for multi-metric scoring."
+                             " Register multiple scoring callbacks instead.")
         return self.scoring_.__name__
 
     def initialize(self):

--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -457,6 +457,24 @@ class TestEpochScoring:
         for c1, c2 in zip(cbs['a1'].y_trues_, cbs['a2'].y_trues_):
             assert id(c1) == id(c2)
 
+    def test_multiple_scorings_with_dict(
+            self, net_cls, module_cls, train_split, caching_scoring_cls, data,
+    ):
+        net = net_cls(
+            module=module_cls,
+            callbacks=[
+                caching_scoring_cls({'a1': 'accuracy', 'a2': 'accuracy'}),
+            ],
+            train_split=train_split,
+            max_epochs=2,
+        )
+
+        # on_train_end clears cache, overwrite so we can inspect the contents.
+        with patch('skorch.callbacks.scoring.EpochScoring.on_train_end',
+                   lambda *x, **y: None):
+            with pytest.raises(ValueError):
+                net.fit(*data)
+
     def test_subclassing_epoch_scoring(
             self, classifier_module, classifier_data):
         # This test's purpose is to check that it is possible to

--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -469,8 +469,9 @@ class TestEpochScoring:
             max_epochs=2,
         )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as excinfo:
                 net.fit(*data)
+        assert "multi-metric scoring" in str(excinfo.value)
 
     def test_subclassing_epoch_scoring(
             self, classifier_module, classifier_data):

--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -469,10 +469,9 @@ class TestEpochScoring:
             max_epochs=2,
         )
 
-msg = "Dict not supported as scorer for multi-metric scoring"
-        with pytest.raises(ValueError, match=msg) as excinfo:
+        msg = "Dict not supported as scorer for multi-metric scoring"
+        with pytest.raises(ValueError, match=msg):
                 net.fit(*data)
-        assert "multi-metric scoring" in str(excinfo.value)
 
     def test_subclassing_epoch_scoring(
             self, classifier_module, classifier_data):

--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -458,8 +458,8 @@ class TestEpochScoring:
             assert id(c1) == id(c2)
 
     def test_multiple_scorings_with_dict(
-            self, net_cls, module_cls, train_split, caching_scoring_cls, data,
-    ):
+            self, net_cls, module_cls, train_split, caching_scoring_cls, data):
+        # This test checks if an exception is raised when a dictionary is passed as scorer.
         net = net_cls(
             module=module_cls,
             callbacks=[
@@ -469,10 +469,7 @@ class TestEpochScoring:
             max_epochs=2,
         )
 
-        # on_train_end clears cache, overwrite so we can inspect the contents.
-        with patch('skorch.callbacks.scoring.EpochScoring.on_train_end',
-                   lambda *x, **y: None):
-            with pytest.raises(ValueError):
+        with pytest.raises(ValueError):
                 net.fit(*data)
 
     def test_subclassing_epoch_scoring(

--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -458,18 +458,19 @@ class TestEpochScoring:
             assert id(c1) == id(c2)
 
     def test_multiple_scorings_with_dict(
-            self, net_cls, module_cls, train_split, caching_scoring_cls, data):
+            self, net_cls, module_cls, train_split, scoring_cls, data):
         # This test checks if an exception is raised when a dictionary is passed as scorer.
         net = net_cls(
             module=module_cls,
             callbacks=[
-                caching_scoring_cls({'a1': 'accuracy', 'a2': 'accuracy'}),
+                scoring_cls({'a1': 'accuracy', 'a2': 'accuracy'}),
             ],
             train_split=train_split,
             max_epochs=2,
         )
 
-        with pytest.raises(ValueError) as excinfo:
+msg = "Dict not supported as scorer for multi-metric scoring"
+        with pytest.raises(ValueError, match=msg) as excinfo:
                 net.fit(*data)
         assert "multi-metric scoring" in str(excinfo.value)
 


### PR DESCRIPTION
Introduces fix for issue #542 informing the user of the incompatibility in regards to multi-metric evaluation with scikit-learn.  