### PR TITLE
Fix wrongful LR scheduler step order warnings

### DIFF
--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -93,6 +93,7 @@ class LRScheduler(Callback):
             step = sch.step
         lrs = []
         for _ in range(steps):
+            opt.step() # suppress warning about .step call order
             lrs.append(opt.param_groups[0]['lr'])
             step()
 

--- a/skorch/tests/callbacks/test_lr_scheduler.py
+++ b/skorch/tests/callbacks/test_lr_scheduler.py
@@ -270,6 +270,7 @@ class TestWarmRestartLR():
             optimizer, min_lr, max_lr, base_period, period_mult
         )
         for epoch in range(epochs):
+            optimizer.step() # suppress warning about .step call order
             scheduler.step(epoch)
             for param_group, target in zip(optimizer.param_groups, targets):
                 assert param_group['lr'] == pytest.approx(target[epoch])


### PR DESCRIPTION
With PyTorch 1.1.0 the optimizer step order was fixed (see af04b559445a76da33a2750ff630dee2749402d3) and a warning is issued when the order is violated. Since some LR scheduler tests don't call the optimizer at all this warning is falsely issued. We can fix this by calling `optimizer.step` anyway.

Relates to #467 and #561.