### PR TITLE
ENH Load_params with a checkpoint initializes when needed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve NeuralNetBinaryClassifier compatibility with certain sklearn metrics (#515)
 - NeuralNetBinaryClassifier automatically squeezes module output if necessary (#515)
 - NeuralNetClassifier now has a classes_ attribute after fit is called, which is inferred from y by default (#465, #486)
+- NeuralNet.load_params with a checkpoint now initializes when needed (#497)
 
 ### Changed
 

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1629,7 +1629,8 @@ class NeuralNet:
             self.history = History.from_file(f_history)
 
         if checkpoint is not None:
-            self.initialize()
+            if not self.initialized_:
+                self.initialize()
             if f_history is None and checkpoint.f_history is not None:
                 self.history = History.from_file(checkpoint.f_history_)
             formatted_files = checkpoint.get_formatted_files(self)

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1614,6 +1614,7 @@ class NeuralNet:
             self.history = History.from_file(f_history)
 
         if checkpoint is not None:
+            self.initialize()
             if f_history is None and checkpoint.f_history is not None:
                 self.history = History.from_file(checkpoint.f_history_)
             formatted_files = checkpoint.get_formatted_files(self)

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -569,7 +569,7 @@ class TestNeuralNet:
 
         new_net = net_cls(
             module_cls, max_epochs=4, lr=0.1,
-            optimizer=torch.optim.Adam, callbacks=[cp]).initialize()
+            optimizer=torch.optim.Adam, callbacks=[cp])
         new_net.load_params(checkpoint=cp)
 
         assert len(new_net.history) == 4
@@ -635,7 +635,7 @@ class TestNeuralNet:
             module_cls, max_epochs=5, lr=0.1,
             optimizer=torch.optim.Adam, callbacks=[
                 ('my_score', scoring), cp
-            ]).initialize()
+            ])
         new_net.load_params(checkpoint=cp)
 
         # original run saved checkpoint at epoch 3

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -545,8 +545,10 @@ class TestNeuralNet:
         assert np.allclose(orig_loss, new_loss)
         assert orig_steps == new_steps
 
+    @pytest.mark.parametrize("explicit_init", [True, False])
     def test_save_and_load_from_checkpoint(
-            self, net_cls, module_cls, data, checkpoint_cls, tmpdir):
+            self, net_cls, module_cls, data, checkpoint_cls, tmpdir,
+            explicit_init):
 
         skorch_dir = tmpdir.mkdir('skorch')
         f_params = skorch_dir.join('params.pt')
@@ -571,6 +573,8 @@ class TestNeuralNet:
         new_net = net_cls(
             module_cls, max_epochs=4, lr=0.1,
             optimizer=torch.optim.Adam, callbacks=[cp])
+        if explicit_init:
+            new_net.initialize()
         new_net.load_params(checkpoint=cp)
 
         assert len(new_net.history) == 4


### PR DESCRIPTION
Closes https://github.com/skorch-dev/skorch/issues/497

This updates `NeuralNet.load_params` with a checkpoint initializes when needed