### PR TITLE
CLEAN : rm duplicate code in fit_loop.

### DIFF
--- a/skorch/net.py
+++ b/skorch/net.py
@@ -728,17 +728,17 @@ class NeuralNet:
         for _ in range(epochs):
             self.notify('on_epoch_begin', **on_epoch_kwargs)
 
-            self.single_epoch(dataset_train, training=True, prefix="train",
+            self.run_single_epoch(dataset_train, training=True, prefix="train",
                               step_fn=self.train_step, **fit_params)
 
             if dataset_valid is not None:
-                self.single_epoch(dataset_valid, training=False, prefix="valid",
+                self.run_single_epoch(dataset_valid, training=False, prefix="valid",
                                   step_fn=self.validation_step, **fit_params)
 
             self.notify("on_epoch_end", **on_epoch_kwargs)
         return self
 
-    def single_epoch(self, dataset, training, prefix, step_fn, **fit_params):
+    def run_single_epoch(self, dataset, training, prefix, step_fn, **fit_params):
         """Compute a single epoch of train or validation.
 
         Parameters

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -729,11 +729,11 @@ class NeuralNet:
             self.notify('on_epoch_begin', **on_epoch_kwargs)
 
             self.run_single_epoch(dataset_train, training=True, prefix="train",
-                              step_fn=self.train_step, **fit_params)
+                                  step_fn=self.train_step, **fit_params)
 
             if dataset_valid is not None:
                 self.run_single_epoch(dataset_valid, training=False, prefix="valid",
-                                  step_fn=self.validation_step, **fit_params)
+                                      step_fn=self.validation_step, **fit_params)
 
             self.notify("on_epoch_end", **on_epoch_kwargs)
         return self


### PR DESCRIPTION
For the third time, I found that I had to modify fit_loop (once for skipping some validation steps when doing few shot learning, an other time for a workaround of #245 ). Every time I'm a bit hesitant because it's a large function so my changes will likely break for new versions of skorch. I think this should be made a little cleaner + in addition there's a large chunk of duplicate code, which is bad practice. I think it should be split in 2 simple functions.

Nothing very important but it's a bit better. I also give `epoch` as argument because this is something I usually need and makes sense to give to a function that computes a single epoch (e.g. for logging).