### PR TITLE
Bugfix: sklearn 0.22

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Make skorch compatible with sklearn 0.22
 
 ## [0.7.0] - 2019-11-29
 

--- a/pylintrc
+++ b/pylintrc
@@ -56,6 +56,7 @@ disable =
     no-self-use,
     super-on-old-class,
     too-many-function-args,
+    import-outside-toplevel,
 
 
 [REPORTS]

--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -1,7 +1,6 @@
 """Contains learning rate scheduler callbacks"""
 
 import sys
-import warnings
 
 # pylint: disable=unused-import
 import numpy as np

--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -463,13 +463,20 @@ class TestMultiIndexing:
         assert (result == X[:100]).all()
 
     def test_index_with_float_array_raises(self, multi_indexing):
+        # sklearn < 0.22 raises IndexError with msg0
+        # sklearn >= 0.22 raises ValueError with msg1
         X = np.zeros(10)
         i = np.arange(3, 0.5)
-        with pytest.raises(IndexError) as exc:
+
+        with pytest.raises((IndexError, ValueError)) as exc:
             multi_indexing(X, i)
 
-        assert exc.value.args[0] == (
-            "arrays used as indices must be of integer (or boolean) type")
+        msg0 = "arrays used as indices must be of integer (or boolean) type"
+        msg1 = ("No valid specification of the columns. Only a scalar, list or "
+                "slice of all integers or all strings, or boolean mask is allowed")
+
+        result = exc.value.args[0]
+        assert result in (msg0, msg1)
 
     def test_boolean_index_2d(self, multi_indexing):
         X = np.arange(9).reshape(3, 3)

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -9,18 +9,24 @@ from contextlib import contextmanager
 from enum import Enum
 from functools import partial
 from itertools import tee
+from packaging import version
 import pathlib
 import warnings
 
 import numpy as np
 from scipy import sparse
-from sklearn.utils import safe_indexing
+import sklearn
 import torch
 from torch.nn.utils.rnn import PackedSequence
 from torch.utils.data.dataset import Subset
 
 from skorch.exceptions import DeviceWarning
 from skorch.exceptions import NotInitializedError
+
+if version.parse(sklearn.__version__) >= version.parse('0.22.0'):
+    from sklearn.utils import _safe_indexing as safe_indexing
+else:
+    from sklearn.utils import safe_indexing
 
 
 class Ansi(Enum):
@@ -176,7 +182,8 @@ def _indexing_ndframe(data, i):
 
 
 def _indexing_other(data, i):
-    if isinstance(i, (int, np.integer, slice)):
+    # sklearn's safe_indexing doesn't work with tuples since 0.22
+    if isinstance(i, (int, np.integer, slice, tuple)):
         return data[i]
     return safe_indexing(data, i)
 

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -15,8 +15,6 @@ import warnings
 import numpy as np
 from scipy import sparse
 from sklearn.utils import safe_indexing
-from sklearn.exceptions import NotFittedError
-from sklearn.utils.validation import check_is_fitted as sklearn_check_is_fitted
 import torch
 from torch.nn.utils.rnn import PackedSequence
 from torch.utils.data.dataset import Subset
@@ -494,15 +492,13 @@ def check_is_fitted(estimator, attributes, msg=None, all_or_any=all):
         msg = ("This %(name)s instance is not initialized yet. Call "
                "'initialize' or 'fit' with appropriate arguments "
                "before using this method.")
-    try:
-        sklearn_check_is_fitted(
-            estimator=estimator,
-            attributes=attributes,
-            msg=msg,
-            all_or_any=all_or_any,
-        )
-    except NotFittedError as e:
-        raise NotInitializedError(str(e))
+
+
+    if not isinstance(attributes, (list, tuple)):
+        attributes = [attributes]
+
+    if not all_or_any([hasattr(estimator, attr) for attr in attributes]):
+        raise NotInitializedError(msg % {'name': type(estimator).__name__})
 
 
 class TeeGenerator:


### PR DESCRIPTION
Currently, skorch won't work with sklearn 0.22 because some code was changed that is more geared towards sklearn-internal use, which we, however, relied upon.

A list of failures:

1. `check_is_fitted` was changed (see #570) in a way that we won't raise a `NotInitializedError` anymore despite the net not being initialized. This is now solved by basically porting the old `check_is_fitted` behavior to skorch.

2. `safe_indexing` was changed (probably [here](https://github.com/scikit-learn/scikit-learn/pull/14475)) in a way that it no longer works with tuples as indices; the following code works in sklearn 0.21 but not in 0.22:

```python
from sklearn.utils import safe_indexing  # or _safe_indexing
import numpy as np


X = np.zeros((5, 3))
i = ([2, 4, 1, 0, 3], [1, 0, 2, 2, 1])
safe_indexing(X, i)
```

This is solved by not using `safe_indexing` in case of tuples anymore.

3. Our `convert_sklearn_metric_function` now fails with `make_scorer(...)` because that returns an sklearn `_PredictScorer` object (or similar), which we don't detect. This is now detected.

The changes were tested with scikit-learn=0.21.3 and scikit-learn==0.22 (no GPU).

Furthermore, pylint now complains about imports that are not at top level (basically about all our tests), which is why I blankly removed that warning.