### PR TITLE
Add notebook with DCGAN on MNIST

### DIFF
--- a/notebooks/dcgan.ipynb
+++ b/notebooks/dcgan.ipynb
@@ -1,0 +1,605 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DCGan with skorch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Code is adapted from [pytorch examples](https://github.com/pytorch/examples/tree/master/dcgan)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "%pylab inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.parallel\n",
+    "import torch.optim as optim\n",
+    "import torch.utils.data\n",
+    "import torchvision.datasets as dset\n",
+    "import torchvision.transforms as transforms\n",
+    "import torchvision.utils as vutils"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/vinh/anaconda3/envs/skorch/lib/python3.6/site-packages/sklearn/utils/deprecation.py:144: FutureWarning: The sklearn.metrics.scorer module is  deprecated in version 0.22 and will be removed in version 0.24. The corresponding classes / functions should instead be imported from sklearn.metrics. Anything that cannot be imported from sklearn.metrics is now part of the private API.\n",
+      "  warnings.warn(message, FutureWarning)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from skorch import NeuralNet\n",
+    "from skorch.utils import noop\n",
+    "from skorch.callbacks import BatchScoring"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "torch.manual_seed(0)\n",
+    "device = torch.device(\"cuda:0\") if torch.cuda.is_available() else 'cpu'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nz = 100  # size of the latent z vector\n",
+    "ngf = 32  # units of generator\n",
+    "ndf = 32  # units of discriminator\n",
+    "nc = 1  # number of channels\n",
+    "batch_size = 64\n",
+    "lr = 0.0002\n",
+    "beta1 = 0.5  # for adam\n",
+    "max_epochs = 25\n",
+    "ngpu = 1\n",
+    "img_size = 32  # 32 is easier than 28 to work with\n",
+    "workers = 2  # for dataloader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = './mnist'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = dset.MNIST(\n",
+    "    root=path,\n",
+    "    download=True,\n",
+    "    transform=transforms.Compose([\n",
+    "        transforms.Resize(img_size),\n",
+    "        transforms.ToTensor(),\n",
+    "        transforms.Normalize((0.5,), (0.5,)),\n",
+    "    ]),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# custom weights initialization called on generator and discriminator\n",
+    "def weights_init(m):\n",
+    "    classname = m.__class__.__name__\n",
+    "    if classname.find('Conv') != -1:\n",
+    "        m.weight.data.normal_(0.0, 0.02)\n",
+    "    elif classname.find('BatchNorm') != -1:\n",
+    "        m.weight.data.normal_(1.0, 0.02)\n",
+    "        m.bias.data.fill_(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Generator(nn.Module):\n",
+    "    def __init__(self, nz, ngf, ngpu):\n",
+    "        super().__init__()\n",
+    "        self.nz = nz\n",
+    "        self.ngf = ngf\n",
+    "        self.ngpu = ngpu\n",
+    "\n",
+    "        self.main = nn.Sequential(\n",
+    "            # input is Z, going into a convolution\n",
+    "            nn.ConvTranspose2d(     nz, ngf * 4, 4, 1, 0, bias=False),\n",
+    "            nn.BatchNorm2d(ngf * 4),\n",
+    "            nn.ReLU(True),\n",
+    "            # state size. (ngf*4) x 4 x 4\n",
+    "            nn.ConvTranspose2d(ngf * 4, ngf * 2, 4, 2, 1, bias=False),\n",
+    "            nn.BatchNorm2d(ngf * 2),\n",
+    "            nn.ReLU(True),\n",
+    "            # state size. (ngf*2) x 8 x 8\n",
+    "            nn.ConvTranspose2d(ngf * 2, ngf, 4, 2, 1, bias=False),\n",
+    "            nn.BatchNorm2d(ngf),\n",
+    "            nn.ReLU(True),\n",
+    "            # state size. (ngf) x 16 x 16\n",
+    "            nn.ConvTranspose2d(ngf,     nc, 4, 2, 1, bias=False),\n",
+    "            nn.Tanh(),\n",
+    "            # state size. (nc) x 32 x 32\n",
+    "        )\n",
+    "\n",
+    "    def forward(self, input):\n",
+    "        if input.is_cuda and self.ngpu > 1:\n",
+    "            output = nn.parallel.data_parallel(self.main, input, range(self.ngpu))\n",
+    "        else:\n",
+    "            output = self.main(input)\n",
+    "        return output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Discriminator(nn.Module):\n",
+    "    def __init__(self, nc, ndf, ngpu):\n",
+    "        super().__init__()\n",
+    "        self.nc = nc\n",
+    "        self.ndf = ndf\n",
+    "        self.ngpu = ngpu\n",
+    "\n",
+    "        self.main = nn.Sequential(\n",
+    "            # state size. (ndf) x 32 x 32\n",
+    "            nn.Conv2d(nc, ndf, 4, 2, 1, bias=False),\n",
+    "            nn.LeakyReLU(0.2, inplace=True),\n",
+    "            # state size. (ndf) x 16 x 16\n",
+    "            nn.Conv2d(ndf, ndf * 2, 4, 2, 1, bias=False),\n",
+    "            nn.BatchNorm2d(ndf * 2),\n",
+    "            nn.LeakyReLU(0.2, inplace=True),\n",
+    "            # state size. (ndf*2) x 8 x 8\n",
+    "            nn.Conv2d(ndf * 2, ndf * 4, 4, 2, 1, bias=False),\n",
+    "            nn.BatchNorm2d(ndf * 4),\n",
+    "            nn.LeakyReLU(0.2, inplace=True),\n",
+    "            # state size. (ndf*4) x 4 x 4\n",
+    "            nn.Conv2d(ndf * 4, 1, 4, 1, 0, bias=False),\n",
+    "            nn.Sigmoid()\n",
+    "        )\n",
+    "\n",
+    "    def forward(self, input):\n",
+    "        if input.is_cuda and self.ngpu > 1:\n",
+    "            output = nn.parallel.data_parallel(self.main, input, range(self.ngpu))\n",
+    "        else:\n",
+    "            output = self.main(input)\n",
+    "\n",
+    "        return output.view(-1, 1).squeeze(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Dcgan(nn.Module):\n",
+    "    def __init__(self, nc, nz, ndf, ngf, ngpu):\n",
+    "        super().__init__()\n",
+    "        \n",
+    "        self.nc = nc\n",
+    "        self.nz = nz\n",
+    "        self.ndf = ndf\n",
+    "        self.ngf = ngf\n",
+    "        self.ngpu = ngpu\n",
+    "\n",
+    "        self.discriminator = Discriminator(\n",
+    "            nc=self.nc,\n",
+    "            ndf=self.ndf,\n",
+    "            ngpu=self.ngpu,\n",
+    "        )\n",
+    "        self.discriminator.apply(weights_init)\n",
+    "        self.generator = Generator(\n",
+    "            nz=self.nz,\n",
+    "            ngf=self.ngf,\n",
+    "            ngpu=self.ngpu,\n",
+    "        )\n",
+    "        self.discriminator.apply(weights_init)\n",
+    "        \n",
+    "    def forward(self, X, y=None):\n",
+    "        # real data\n",
+    "        output_real = self.discriminator(X)\n",
+    "\n",
+    "        # generated data\n",
+    "        noise = torch.randn(X.shape[0], self.nz, 1, 1, device=X.device)\n",
+    "        fake = self.generator(noise)\n",
+    "        output_fake = self.discriminator(fake)\n",
+    "        output_fake_det = self.discriminator(fake.detach())\n",
+    "\n",
+    "        return output_real, output_fake, output_fake_det, fake"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class DcganCriterion(nn.Module):\n",
+    "    def __init__(self, real_label=1, fake_label=0):\n",
+    "        super().__init__()\n",
+    "        self.criterion = nn.BCELoss()\n",
+    "\n",
+    "    def forward(self, y_pred, y_true=None):\n",
+    "        output_real, output_fake, output_fake_det, _ = y_pred\n",
+    "        batch_size = len(output_real)\n",
+    "        device = output_real.device\n",
+    "        label_real = torch.ones((batch_size,),device=device)\n",
+    "        label_fake = torch.zeros((batch_size,),device=device)\n",
+    "\n",
+    "        # discriminator real\n",
+    "        loss_discriminator_real = self.criterion(output_real, label_real)\n",
+    "\n",
+    "        # discriminator fake\n",
+    "        loss_discriminator_fake = self.criterion(output_fake_det, label_fake)\n",
+    "\n",
+    "        # generator\n",
+    "        loss_generator = self.criterion(output_fake, label_real)\n",
+    "\n",
+    "        # return individual losses to log them separately\n",
+    "        return loss_discriminator_real, loss_discriminator_fake, loss_generator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### add in extra logging"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The changes below are not strictly necessary, they are just there to log the discriminator and generator loss."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class DcganNet(NeuralNet):\n",
+    "    def get_loss(self, y_pred, y_true, X=None, training=False):\n",
+    "        loss_discriminator_real, loss_discriminator_fake, loss_generator = self.criterion_(y_pred, y_true)\n",
+    "        prefix = 'train_' if training else 'valid_'\n",
+    "\n",
+    "        loss_discriminator = loss_discriminator_real + loss_discriminator_fake\n",
+    "        self.history.record_batch(prefix + 'dis', loss_discriminator.item())\n",
+    "        self.history.record_batch(prefix + 'gen', loss_generator.item())\n",
+    "        \n",
+    "        return loss_discriminator_real + loss_discriminator_fake + loss_generator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train_loss_gen(net, X=None, y=None):\n",
+    "    return net.history[-1, 'batches', -1, 'train_gen']\n",
+    "def train_loss_dis(net, X=None, y=None):\n",
+    "    return net.history[-1, 'batches', -1, 'train_dis']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def valid_loss_gen(net, X=None, y=None):\n",
+    "    return net.history[-1, 'batches', -1, 'valid_gen']\n",
+    "def valid_loss_dis(net, X=None, y=None):\n",
+    "    return net.history[-1, 'batches', -1, 'valid_dis']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "extra_callbacks = [\n",
+    "    ('train_loss_gen', BatchScoring(train_loss_gen, on_train=True, target_extractor=noop)),\n",
+    "    ('train_loss_dis', BatchScoring(train_loss_dis, on_train=True, target_extractor=noop)),\n",
+    "    ('valid_loss_gen', BatchScoring(valid_loss_gen, on_train=False, target_extractor=noop)),\n",
+    "    ('valid_loss_dis', BatchScoring(valid_loss_dis, on_train=False, target_extractor=noop)),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train net"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "net = DcganNet(\n",
+    "    Dcgan,\n",
+    "    module__nz=nz,\n",
+    "    module__ndf=ndf,\n",
+    "    module__ngf=ngf,\n",
+    "    module__nc=nc,\n",
+    "    module__ngpu=ngpu,\n",
+    "\n",
+    "    criterion=DcganCriterion,\n",
+    "    optimizer=optim.Adam,\n",
+    "    lr=lr,\n",
+    "    optimizer__betas=(beta1, 0.999),\n",
+    "    batch_size=batch_size,\n",
+    "    max_epochs=max_epochs,\n",
+    "\n",
+    "    train_split=False,  # comment out for internal train/valid split\n",
+    "    iterator_train__shuffle=True,\n",
+    "    iterator_train__num_workers=workers,\n",
+    "    iterator_valid__num_workers=workers,\n",
+    "    \n",
+    "    callbacks=extra_callbacks,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  epoch    train_loss    train_loss_dis    train_loss_gen       dur\n",
+      "-------  ------------  ----------------  ----------------  --------\n",
+      "      1        \u001b[36m1.5962\u001b[0m            \u001b[32m0.9756\u001b[0m            \u001b[35m0.6206\u001b[0m  359.4358\n",
+      "      2        1.6466            1.0542            \u001b[35m0.5925\u001b[0m  286.3734\n",
+      "      3        1.6066            0.9977            0.6089  281.0857\n",
+      "      4        \u001b[36m1.5888\u001b[0m            \u001b[32m0.9710\u001b[0m            0.6179  276.5708\n",
+      "      5        \u001b[36m1.5427\u001b[0m            \u001b[32m0.8983\u001b[0m            0.6443  284.5098\n",
+      "      6        \u001b[36m1.5258\u001b[0m            \u001b[32m0.8704\u001b[0m            0.6554  281.8785\n",
+      "      7        \u001b[36m1.5147\u001b[0m            \u001b[32m0.8559\u001b[0m            0.6588  280.2213\n",
+      "      8        \u001b[36m1.4994\u001b[0m            \u001b[32m0.8325\u001b[0m            0.6669  282.9186\n",
+      "      9        1.4996            \u001b[32m0.8322\u001b[0m            0.6674  276.6854\n",
+      "     10        \u001b[36m1.4873\u001b[0m            \u001b[32m0.8156\u001b[0m            0.6717  282.6022\n",
+      "     11        \u001b[36m1.4643\u001b[0m            \u001b[32m0.7832\u001b[0m            0.6811  274.0600\n",
+      "     12        1.4859            0.8149            0.6710  281.7605\n",
+      "     13        1.4707            0.7934            0.6773  278.4907\n",
+      "     14        \u001b[36m1.4568\u001b[0m            \u001b[32m0.7734\u001b[0m            0.6834  273.9474\n",
+      "     15        1.4665            0.7893            0.6772  283.6250\n",
+      "     16        \u001b[36m1.4519\u001b[0m            \u001b[32m0.7677\u001b[0m            0.6842  283.1487\n",
+      "     17        \u001b[36m1.4412\u001b[0m            \u001b[32m0.7537\u001b[0m            0.6874  271.1781\n",
+      "     18        1.4443            0.7582            0.6861  273.5917\n",
+      "     19        \u001b[36m1.4381\u001b[0m            \u001b[32m0.7504\u001b[0m            0.6877  283.8451\n",
+      "     20        1.4400            0.7540            0.6860  280.5815\n",
+      "     21        \u001b[36m1.4250\u001b[0m            \u001b[32m0.7335\u001b[0m            0.6915  280.9077\n",
+      "     22        1.4357            0.7469            0.6887  278.1683\n",
+      "     23        1.4256            0.7357            0.6899  278.2118\n",
+      "     24        1.4308            0.7427            0.6881  279.7564\n",
+      "     25        \u001b[36m1.4203\u001b[0m            \u001b[32m0.7285\u001b[0m            0.6918  282.7555\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<class '__main__.DcganNet'>[initialized](\n",
+       "  module_=Dcgan(\n",
+       "    (discriminator): Discriminator(\n",
+       "      (main): Sequential(\n",
+       "        (0): Conv2d(1, 32, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (1): LeakyReLU(negative_slope=0.2, inplace=True)\n",
+       "        (2): Conv2d(32, 64, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (3): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "        (4): LeakyReLU(negative_slope=0.2, inplace=True)\n",
+       "        (5): Conv2d(64, 128, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (6): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "        (7): LeakyReLU(negative_slope=0.2, inplace=True)\n",
+       "        (8): Conv2d(128, 1, kernel_size=(4, 4), stride=(1, 1), bias=False)\n",
+       "        (9): Sigmoid()\n",
+       "      )\n",
+       "    )\n",
+       "    (generator): Generator(\n",
+       "      (main): Sequential(\n",
+       "        (0): ConvTranspose2d(100, 128, kernel_size=(4, 4), stride=(1, 1), bias=False)\n",
+       "        (1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "        (2): ReLU(inplace=True)\n",
+       "        (3): ConvTranspose2d(128, 64, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (4): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "        (5): ReLU(inplace=True)\n",
+       "        (6): ConvTranspose2d(64, 32, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (7): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "        (8): ReLU(inplace=True)\n",
+       "        (9): ConvTranspose2d(32, 1, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (10): Tanh()\n",
+       "      )\n",
+       "    )\n",
+       "  ),\n",
+       ")"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "net.fit(dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_, _, _, fake_imgs = net.forward(torch.utils.data.Subset(dataset, torch.arange(0, 10)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([10, 1, 32, 32])"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fake_imgs.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAKwAAAaACAYAAAD1j7evAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nOy9abCV1ZX//10go6DI6BVQNCKKQxQNjmXiQOKQRGMbp/6n0ykTK2nt0kpSFUy6Up3+9QtNdZnqqq6KTUcqWGVrMNpKGSdEHKPgBMggsyh4mYQLDghcWP8X57nk7LX3Oc9zn3POc86+fD9Vt+5Zz3n286zz3HX3WXvvtdcSVQUhsdCr2QoQ0h1osCQqaLAkKmiwJCposCQqaLAkKmoyWBG5TESWi8gqEZlaL6UIqYTknYcVkd4AVgCYAmA9gDcA3KiqS+unHiEuh9TQdjKAVaq6BgBE5CEAVwGoaLAioiJS9aKNWMhIu2fe+zbquq2M/cyhZ7B///6arquqUNXgw63FYEcD+LBMXg/g7DSl+vbte0AOfTB7zMq9enXfiznkEP9j2gfd2dnpyCFDs8f69OnjyKHPk+W6aWT5x8jTxuoSamOP9e7d25HtMwCA3bt3O/K+ffuqXsPexz6zcmox2EyIyC0Abmn0fcjBQS0GuwHA2DJ5THLMQVWnAZgGAL169Up1Cez7tkcNtbc9he3pqv3HViLL15q9bp7ePwuhXrkeva69bug+ad94tvesdCyN8ntX+xaq5Qm/AWC8iBwrIn0B3ABgVg3XIySV3D2sqnaKyG0AngHQG8B0VV1SN80ICVCTD6uqTwJ4sk66EJIKV7pIVOReOMh1MxEtn9II3dsOXLIMfrIMHjLo1u37kHxkmYuvNA/LHpZEBQ2WRAUNlkRFw1e6uov1Wa2/k2edmrQWtYwF2MOSqKDBkqigwZKoaKoPW6+gjjzX4Jxqa2HjYSvBHpZEBQ2WRAUNlkQFDZZERVMHXaG9PXkCWdI2xuVZbAjtA0uLvs+iGxc+ahtYs4clUUGDJVFBgyVRUbgPW+7DZdkB291rVrpuGva+/fr188459NBDq943y25Re59du3Z55+QJWt+7d29qm1Ym69+dPSyJChosiQoaLImKlgt+qUdQSj2uEfJhTz31VEeeNGmSI/fv399rk5bDa8eOHV6bV155xZG/+OIL75wtW7ZUvU6ebDdFwQBuctBAgyVRQYMlUUGDJVFR+KAra2R50YwdO9aRb7vtNu+cq6++2pGHDRvmyFk+jx2YhQZ3aelDAWDTpk2O/Pjjjzvy//zP/3htVq1a5cihwVyz4I4D0iOhwZKooMGSqCg8e2F5YHSjJrdtBsS2tjbvnEGDBjnyz3/+c0c+44wzvDZf+tKXHNkWn+jo6PDa2ICZww47zJFDPqwNHg/9jfbs2ePI27Ztc+S33nrLa/PYY4858syZMx35888/99rUA7t4khYcv2/fPmYvJD0DGiyJilSDFZHpIrJZRBaXHRsqIrNFZGXy+4jGqklIiSzzsH8E8F8A7i87NhXAHFW9K6kxOxXAL7LcsNwfq1cAt/VZrX9q51gB4Mc//rEjX3TRRY48dOhQr43dNGkDUFauXJna5oQTTnDkwYMHe22sXxvyc+11Dz/8cEcO+eADBw505HXr1jnyCy+84LVpRDBSaF45a9B9ag+rqi8B2GYOXwVgRvJ6BoCrQUgB5PVhR6lqe/J6I4BRddKHkKrUvDSrqioiFb83WLqT1JO8PewmEWkDgOT35konquo0VT1LVc/KeS9CDpC3h50F4PsA7kp+P1799PoRcs7tgGPChAmOfOWVV3ptvv71rzuyHfyEBhvvv/++Iz/5pFtTb86cOV4be10bQDNkyBCvjV1QGTXK97jGjBnjyHZBYuTIkV4bOxj953/+Z0e2wTGAvxjy6aefOnKeQVktaVazTGs9COA1ABNEZL2I3IySoU4RkZUALk1kQhpOag+rqjdWeOuSOutCSCpc6SJRUWgAt4ggLfjFTipbf6dPnz5em2OOOcaRL7/8cke+7rrrvDbDhw93ZBvIsnz5cq/NX/7yF0e2wSQhH/CII9xFwM8++8yRQ76mzeISyihjFzouvfRSRz7yyCO9NtaHvfjiix35iiuu8NrYz2yDvvNknAn5q+V/12oZdNjDkqigwZKooMGSqCh8E2J5oEqWuTd7jg2IBvxAD+uz2sBrwA8esb7lX//6V6/NE0884ciLFi1y5FBQhw2K3rp1qyNn8eNDmcpXr17tyPY5WZ8WAEaPHu3I9ll+85vf9Nq8+uqrjpwlw0za3Cwzv5CDBhosiQoaLIkKGiyJisIHXeWTwll2zdrdBDbQBfAnyW1gSGjQYgc2dhDz/PPPe20WLlxY9Roh7DmhFPFphCbS33jjDUf++OOPHTm0iHH77bc7sg3MOf3007021157rSPfd999jmwHq0D6oCr03LKk2wfYw5LIoMGSqKDBkqgo1IdVVS9jSXcJLRwce+yxjjxgwADvvhbre7355puObHeUAq2Vht1+pvXr1zvy3LlzvTbjx493ZBtMPmLECK/NlClTHNlmlLE7h4F8WRFZ9oj0SGiwJCposCQqmlr2KERapjsbwAH487B27jbkH7333nuOvGbNGkcOZSK01806d1gEWbKrWL/dZpQJzVcfffTRjmyzjodKPeXxYcv1ZQZu0mOgwZKooMGSqKDBkqiIruzRzp07vWNr1651ZBtgEkpXaQdqNjvMu+++67X55JNPHHn79u2OnCUYplHY3cR2hyzg79Dt27evI4dSudvr2MWTPIspdvBq72Ozyzhtu303QpoIDZZEBQ2WREXLLRxYv9YGyyxbtsxrY7OTnHzyyY583nnneW3sBLjN0PLrX//aa2PLBL322muObIPAAT+w2n6+epWdstcJ7Ui2KePtBL/1aUPHbIBMqE0aIR+2PK1/KPj8QNtu342QJkKDJVFBgyVRQYMlUVH4oKvWQUZoUtkOdp577jlHtrWxAD9Vu514P/HEE702F154oSPbaHsb8QUUF+FlrxvanWtTjGYhbTHEDuQAP9LNXiO0qFF+LBQ11gV7WBIVNFgSFVmKcowVkbkislRElojI7clx1pslhZPFh+0E8DNVfVtEBgN4S0RmA/hH5Kw3WwshH7C9vd2Rn376aUcOpU+3WU5sSs5QIIjd7WAXG0KT6I1aKLALAzbAJ5SK/qijjnJk67eHdLP+qPXTqwWqVNI15MNW81vLyVJrtl1V305efwJgGYDRYL1Z0gS65cOKyDgAZwCYB9abJU0g87SWiAwC8AiAO1R1p4lrrVhvlrVmST3JZLAi0gclY31AVR9NDm8SkTZVba9Wb1ZVpwGYllynPg6cwc452gCZ//iP//DafO1rX3NkW0YoNA/74YcfOrLNDpPFn6sX1mc96aSTHDlUrtRmfrR+Y2i367x58xzZznnnyV5o084Dbir9akHhWWYJBMB9AJap6j1lb3XVmwUKrjdLDl6y9LDnA/gegHdFZEFy7Jco1ZedmdSeXQfAr95GSJ3JUmv2FQCVyr2w3iwpFK50kaho6q7ZEHkm1m0bWzfWpqIEgIcfftiRZ8+e7cg27Tzg11W1u3VDg656LBSEnpmtr3vBBRc48rnnnuu1sQM1O8h6//33vTa2NtmmTZscuV51usoXMarZCHtYEhU0WBIVNFgSFS23a7YorJ9rfTMrNxMbpAIAp5xyiiPbhZBx48Z5bawPbuvgPvjgg16bxx93p9dt9ps8PnooKLzcn2a6TdJjoMGSqKDBkqiIbhPiwUgoAH3SpEmObAPSQwHodp7YZl+cPn2618aeUw+s7wy4c+XVSmOxhyVRQYMlUUGDJVFBgyVRcdAuHLQydqFgwoQJ3jn2mK3BaxcJAH+w8/zzzztyqDZZIwil2ywfJHLQRXoMNFgSFTRYEhXRlT3q7j0aeZ9GYdPZ20AXwM9EaANKQhlybODKQw89lNqmEYQWNUJ+bQj2sCQqaLAkKmiwJCp6ZPBLTD5rlg2G559/vneOzSpuNxiWZ1LpwmbEWbx4sSM3yoe1nzH0mbPemz0siQoaLIkKGiyJChosiQoGvzSZ0ADE7gx46623vHPs5LtdbFi+fLnXxtbktZlfQrrkGcDa61hdQ7uA0zICdcEelkQFDZZEBQ2WRIUUOckuIlpE8EtGXRy5lRYbbPkkm+od8BcXbIBMKC37s88+68g21X7oGWSZ9LeEfNRyQiWOyoO2Ozs7sX///uCN2MOSqKDBkqjIUpSjv4jMF5GFSenO3yTHjxWReSKySkT+JCJ+GUBC6kyqD5tUkTlUVT9Nyh+9AuB2AD8F8KiqPiQi9wJYqKq/T7mWlgfqZvEbG+VbpgUMh95PC9AoKiAd8Dcd2uww27Zt89rYLC5Z9LXPoX///o5sg24A30e1geMhH7d8TrizsxOqms+H1RJdM9l9kh8FcDGAPyfHWbqTFEImH1ZEeicljzYDmA1gNYAOVe1KcL8epfqzhDSUTAarqvtU9XQAYwBMBuCXCayAiNwiIm+KyJs5dSTkAN2aJVDVDgBzAZwLYIiIdC0SjwGwoUKbaap6lqqeVZOmhCBD8IuIjACwV1U7RGQAgCkA7kbJcK8F8BBylu7MslPSDgzqURYpC6GBgR1M2J2qoVTo9YjiDw26bOCKLcEUapNnscSeY8schf6GNh2/JZSVply3aosTWaK12gDMEJHeKPXIM1X1CRFZCuAhEfl3AO+gVI+WkIZS+NJs+X9klmW+RvWwab17aLomrUdtVA8b0tUes58x9Gyz6Gux17HfPHYZOXTdLM+gvA2XZkmPoegedgtKlb+HA/C3dbYm1LVxVNL3GFUdEWpQqMEeuKnIm7HMGlDXxpFHX7oEJCposCQqmmWw05p03zxQ18bRbX2b4sMSkhe6BCQqCjVYEblMRJYnQd9Ti7x3FkRkuohsFpHFZceGishsEVmZ/D6imTp2ISJjRWSuiCxNAutvT463nL513QSgqoX8AOiNUljicQD6AlgIYGJR98+o44UAJgFYXHbstwCmJq+nAri72XomurQBmJS8HgxgBYCJragvAAEwKHndB8A8AOcAmAnghuT4vQB+knqtApU+F8AzZfKdAO5s9sMM6DnOGOxyAG1lRrK82TpW0PtxlAKTWlpfAAMBvA3gbJQWDQ4J2UelnyJdgtEAPiyTYwn6HqWq7cnrjQBGNVOZECIyDsAZKPVcLalvvTYBcNDVDbTUFbTUtIqIDALwCIA7VHVn+XutpK/WsAmgnCINdgOAsWVyxaDvFmOTiLQBQPJ7c5P1OUCyKfQRAA+o6qPJ4ZbVF8i3CaCcIg32DQDjk5FhXwA3AJhV4P3zMgulAHUgZ6B6I0h2M98HYJmq3lP2VsvpKyIjRGRI8rprE8Ay/G0TAJBV14Id7itQGs2uBvCrZg8AAvo9CKAdwF6UfKqbAQwDMAfASgDPARjabD0TXS9A6et+EYAFyc8VragvgNNQCvJfBGAxgF8nx48DMB/AKgAPA+iXdi2udJGo4KCLRAUNlkQFDZZEBQ2WRAUNlkQFDZZEBQ2WRAUNlkQFDZZEBQ2WREVNBtvqW15IzyN3LEGSzXAFSpE361GKxrpRVZfWTz1CXGopjjwZwCpVXQMAIvIQgKsAVDRYEen2f0crF4DLQ1rhYMDP9hf6zPZYnkyQWajH88+iW/k5+/fvh1YoylGLwYa2vJyd1qj8DxT68GmV97KkiLSE7pPnOmmE/jA2CbI10COO8De12mre5VUCu7BGbdNghj6zTUacJQ2m1TeLwdpz7DNIe042WbOjT+rda0REbgFwS6PvQw4OajHYTFteVHUakpQ0IqLl/315er5GfSXVg5BuaV/vtoZViCyJkrM8F3udLG3SeuEsqeltba9QgubQt0iIWmYJYt3yQiImdw+rqp0ichuAZ1BKkjFdVZfUTTNCAtTkw6rqkwCerJMuhKTClS4SFU2tIpNlfrGVadQcpZ1KCg18GjEtVy/sZ7KDLDvNZdm7dy+ryJCeAQ2WRAUNlkRF4T5suX8Tk78K5FuAiO0zFkFo4aD82e7bt69iLAF7WBIVNFgSFTRYEhUNj9ayxOLT1StgpqfF89aDWp4Be1gSFTRYEhU0WBIVNFgSFYUPulp14aBRgyM7Sd7dDXlAtr1Xeciimz0niy5pe7hC1yhvs3fv3orXZg9LooIGS6KCBkuiggsHCfXQK09eglAiDatLyKezfqAN6A4FmAwePNiRTzrpJEf+/PPPvTY2R8DAgQMd+fDDD/fa7Nq1y5G3b9/uyKGdwkOHDj3wetWqVd77XbCHJVFBgyVRQYMlUVG4D9uTyeLDDhgwwJH79evntbHHQn7usGHDHHnkyJGOfMwxx3htRo92q7uff/75jmzzcwHAcccd58jWZw1tKLR+786dTpFxLFiwwGvz5z//+cDr9vZ27/0u2MOSqKDBkqigwZKooMGSqOCgqwbS0koCwJFHHunIV111lSNffPHFXptx48Y5ct++fb1zyifaAX9CPzSAsosJdrEhlE3GDqrsNUILLp999pkj20HX6tWrvTYbNvwtUyuDX0iPgQZLooIGS6Ki8Mwvhd2sAVif1RbUuOSSS7w2P/zhDx35K1/5iiPbQhmA7wt//PHH3jk2wOTQQw91ZLtAAfg+6tKlbsGf559/3mtj/Wc7qR/Sf9GiRY780UcfOfKWLVuq6sbshaTHQIMlUZFqsCIyXUQ2i8jismNDRWS2iKxMfvvFpghpAKk+rIhcCOBTAPer6inJsd8C2KaqdyU1Zo9Q1V+k3iyi7IWheUwbUGJ91m9+85tem8mTJ1e9z1tvveUdswHPa9as8c6xc5k7duxw5NBGP+tzr1+/3pHXrVvntbG+spVD97Hn2HnVjMXp8vmwqvoSgG3m8FUAZiSvZwC4OlUDQupAXh92lKp2DRc3AhhVJ30IqUrNS7OqqtWmq1i6k9STvD3sJhFpA4Dk9+ZKJ6rqNFU9S1XPynkvQg6Qt4edBeD7AO5Kfj+etWGrDrTsBPmkSZO8c66+2nXVbcR+KMp/2zbX/X/jjTcc+f/+7/+8NmvXrnVkGzwC+Dtc7aJGqCK23clgB3dZ6r02+++XZVrrQQCvAZggIutF5GaUDHWKiKwEcGkiE9JwUntYVb2xwlv+OiQhDYYrXSQqDorglyzlMc8++2xHvummm7w2dqHAXiMUpPLkk27t6Hnz5jnya6+95rWx/mkosDrt75bl79rK5T9Z9oj0CGiwJCposCQqemQGbuuzhgJZ2traHPn73/++I0+ZMsVrY4OkbVDKY4895rX53//9X0e2c52h4BEbfL17927vnFDgdBrNnkOtB+xhSVTQYElU0GBJVNBgSVT0yMwvdtAVSldpM7DY3QI2Oh/wd38uXLjQkZ966imvjQ1+sYO9L33pS14bG7hirwEAHR0djmzTsIcGcxx0EVIwNFgSFTRYEhU9woe1GfVs5pSJEyd6bW699VZHtosCIR/QZj2x5XlCQdOnnnqqI99+++2OfM4553htli9f7shvv/22d84TTzzhyDbbyqeffuq1aZYPm6VcaTnV9GQPS6KCBkuiggZLoiK60p2hMjvW/zzqqKMc+Xvf+57XxpaxtMEkoazXZ5xxhiPb0pfWPw1dZ8iQIY4cCqK2vrDNMgj4GwptgE9o7jlPBpZ6kOU+Wf1c9rAkKmiwJCposCQqaLAkKgrfNVs+yZ/n3qFBlx1w2BJAxx9/vNfmO9/5jiPbLC6nnHKK18YO1EK6WOxntIMLm5oS8AeAtowQAKxYscKRn3vuOUcOBeLYxYVmDcJC2J0o3DVLegQ0WBIVNFgSFdEFv4SCUuzku92Z+s4773htbAC0Td0eyvxywgknOPKgQYOq6gGEg1DKCfmNNsjb3gfwsyuOHDmy6n0AP8jb6hbKXGP9XOuDNyorTSXYw5KooMGSqKDBkqigwZKoaLmFg6L0sdFMdpdsaOHg6KOPdmQbMRVKuZ42ILSRZgDw5S9/2ZG//vWve+eMGuUW7rGD0ZUrV3pt3n//fUfOUgPWRo5t2rTJkUO1vWwKJ5vyPrQzo5z9+/dz4YD0DLLUOBgrInNFZKmILBGR25PjLN9JCidLD9sJ4GeqOhHAOQBuFZGJAKYCmKOq4wHMSWRCGkq3fVgReRzAfyU/X1PV9qRW1wuqOiGlbcvWmrUT4lmCbKx/GlrUsNjrhu5jd9pOner3Beedd54j24CfUIpO+7xtkE0ohaddYNmwYYMjWz8Y8NPkv/nmm1WvYXXr7Oysjw8rIuMAnAFgHli+kzSBzEuzIjIIwCMA7lDVnaanrFi+k6U7ST3J1MOKSB+UjPUBVX00OZypfCdLd5J6ktrDSqkrvQ/AMlW9p+ytXOU7Y/FhQ7pZv9Cek+Xz2HNCPqydEw75o/aYDWwJlfu087B2Hjk0J7xx40ZHtvO7NjgG8IPS7X1sph7AfS7VdtBmcQnOB/A9AO+KyILk2C9RMtSZSSnPdQCuy3AtQmoiS+nOVwBUMnmW7ySFwpUuEhU0WBIV0e04aBTW0c+SOifPoNEOOIYPH+6dc+655zryMccc451jU3++8MILjvzyyy97bV5//XVHtgsddnAE+LsSQgNAi11gybIok7XuLXtYEhU0WBIVNFgSFU31YUN+YlGLCTYNps0OE/ItbaDH1q1bHTmUxcVOxn/3u9915F/+8pdeG7twsHbtWu+cP/7xj448c+ZMR7Y+LpDdT6yVtJ22IbJmBGIPS6KCBkuiggZLoqJwHzYt+CXN36mXj2vnAr/97W87cijN/IgRIxzZBpzs2LEj9T42ZbwNvAaAF1980ZH/5V/+xTvHlkZK29jXTNIyOHYH9rAkKmiwJCposCQqaLAkKpq6cBCKPLfHsuxEzTMQs0Ecr7zyiiN/61vf8tqMGTPGkQcMGODIQ4cO9drYgdi2bdsc+dFHH4Xl6aefdmSbSQXIFoTSqtSS8Yc9LIkKGiyJChosiYrCsxeWT6RnWTjIsjM1z2ew97Ep10Mp421tWRuoHJq8t/6nlVevXu21scdCaedbacdxPWDZI9IjocGSqKDBkqgo3Ict91VCQRBpgRF5yuxkwQap2NJDgB/UbduEfFh7zJYWCpXltFkEe5q/GqJ8/p0ZuEmPgQZLooIGS6KCBkuioqmDriz3zpIGk8QPB12kR0KDJVFBgyVR0fLZC+mz1o+ixgN5dsVmbcMelkQFDZZERZZas/1FZL6ILExqzf4mOX6siMwTkVUi8icR6Zt2LUJqJXUeNil7dKiqfprU63oFwO0AfgrgUVV9SETuBbBQVX+fcq3Uedi0TNihjYtpvlloI2Or+Ma1ZEGpdp0sz8kGEtUrsCiUYTuNcn07Ozuxf//+fPOwWqIr5L1P8qMALgbw5+T4DABXd1tLQrpJ1kqIvZMaXZsBzAawGkCHqnbFwa0HMLoxKhLyNzIZrKruU9XTAYwBMBnAiVlvICK3iMibIvJm+tmEVKdbswSq2gFgLoBzAQwRka553DEA/JriYK1ZUl+y1JodAWCvqnaIyAAAUwDcjZLhXgvgIXSj1mxoMFCO3YmaBTswOOQQ92PZCP4QWTLMpKVcDw2grC556tPaa1S6Vzmhz5M2MAs9pzR9Q3rY69ZrYAlkW+lqAzBDRHqj1CPPVNUnRGQpgIdE5N8BvINSAWVCGkpT8xKEYA/r06ge1t67Xj2s/Rt3t4fdu3dv/mktQlqJonvYLSiVqh8OYGvK6a0CdW0clfQ9RlVHBI4Xa7AHbiryZiyzBtS1ceTRly4BiQoaLImKZhnstCbdNw/UtXF0W9+m+LCE5IUuAYmKQg1WRC4TkeVJ0PfUIu+dBRGZLiKbRWRx2bGhIjJbRFYmv4+odo2iEJGxIjJXRJYmgfW3J8dbTt+6bgJIsh03/AdAb5TCEo8D0BfAQgATi7p/Rh0vBDAJwOKyY78FMDV5PRXA3c3WM9GlDcCk5PVgACsATGxFfQEIgEHJ6z4A5gE4B8BMADckx+8F8JPUaxWo9LkAnimT7wRwZ7MfZkDPccZglwNoKzOS5c3WsYLej6MUmNTS+gIYCOBtAGejtGhwSMg+Kv0U6RKMBvBhmRxL0PcoVW1PXm8EMKqZyoQQkXEAzkCp52pJfeu1CYCDrm6gpa6gpaZVRGQQgEcA3KGqO8vfayV9tYZNAOUUabAbAIwtkysGfbcYm0SkDQCS35ubrM8Bkk2hjwB4QFW7Siq2rL5Avk0A5RRpsG8AGJ+MDPsCuAHArALvn5dZKAWoA90IVG80yW7m+wAsU9V7yt5qOX1FZISIDEled20CWIa/bQIAsupasMN9BUqj2dUAftXsAUBAvwcBtAPYi5JPdTOAYQDmAFgJ4DkAQ5utZ6LrBSh93S8CsCD5uaIV9QVwGkpB/osALAbw6+T4cQDmA1gF4GEA/dKuxZUuEhUcdJGooMGSqKDBkqigwZKooMGSqKDBkqigwZKooMGSqKDBkqigwZKoqMlgW33LC+l55I4lSLIZrkAp8mY9StFYN6rq0vqpR4hLLYXlJgNYpaprAEBEHgJwFYCKBisiqf8d9ShKZv8Je2KAT9pnDj3HVn4OtliLViiOXIvBhra8nJ3WKJQ6spy0pLuhlJc2RefevXtT26Sl18xThSWLkWQxmiwVYdKeS6iN/cz10C0L3a1wUy09asNLd4rILQBuafR9yMFBLQabacuLqk5DkpJGRDTtvzhLYmGL7V3yXCPtmkC+Wq15voZtmyz1s/K0yUM9rpGWGLraPWqZJYh1ywuJmNw9rKp2ishtAJ5BKUnGdFVdUjfNCAnQcjUO0r4uQlgnvh4uQYhmjcxD1y3KPakHaeVYLfv37684S8CVLhIVhfewacWRiU+WWlj2myn2Z8selvQIaLAkKmiwJCoavtJVjog4S7NZKu8RoG9fP8/voEGDHNk+y08++cRrk2cGptVgD0uiggZLooIGS6KiUB+WZKNfv36OfPbZftTmxIkTHdn6p88++6zX5v33369duQaRdX6ePSyJChosiQoaLIkKGiyJikIHXWUpxAHEt1GuEYSewUknneTIP/rRj7xzLrjgAkfesmWLI+/c6RSUAeqPjOcAACAASURBVACsW7fOkWN81uxhSVTQYElU0GBJVBS+cFDuN8XoQ9WbkA971llnOfK3vvUt75zDDjvMke3CwdFHH10H7YqDCwekR0KDJVFBgyVRUbgPW+5r0YcFBg8e7B37h3/4B0c+/PDDU69jA7ZjCXSpdiwEe1gSFTRYEhU0WBIVNFgSFdxxUDB2cHHooYd653R0dDjyp59+6p1jd9IOGDDAkYcNG5ZXxYYTGmxnHYCzhyVRQYMlUUGDJVFRuA9b7sOFJot7QnaScmw+3KFDhzrylVde6bU59thjq14jhF1cGDlypHdOnpyyRUEflvRIaLAkKlINVkSmi8hmEVlcdmyoiMwWkZXJ7yMaqyYhJbL4sH8E8F8A7i87NhXAHFW9K6kxOxXAL7LcMG0TYk/DFr0bPXq0I0+ZMsVrYzO/hEjLwN2oskeNom4+rKq+BGCbOXwVgBnJ6xkAru6OcoTkJa8PO0pV25PXGwGMqpM+hFSl5mktVdVqRY9ZupPUk7w97CYRaQOA5PfmSieq6jRVPUtVz6p0DiFZydvDzgLwfQB3Jb8fz9rwYNs1a4NSvvGNbziyHYQBfsXzUKE8u5hgdxgsXLjQa9MTnneWaa0HAbwGYIKIrBeRm1Ey1CkishLApYlMSMNJ7WFV9cYKb11SZ10ISYUrXSQqGMBdR+xkPuAHWk+aNMmRQxP89jqh6+7atcuR33vvPUdesWJFdWXrRJayotZ3riXAiT0siQoaLIkKGiyJiqYGcNdrXjAtiKao+cdQic0RI0Y48vHHH+/IW7du9drYOdbQ5/vwww8d+dVXX3XkDRs2VFe2geTxUZm9kPRIaLAkKmiwJCposCQqmrpwUK+yR80K6rAT5DaNO+DvgB0yZIgjh55B//79Hbmzs9M7Z/ny5Y68cuVKR/78888DGtefop89e1gSFTRYEhU0WBIVTS17FDs228rll1/unXPbbbc5svVpQxP8Rxzh7prfsWOHd867777ryDaAOxT03RNgD0uiggZLooIGS6KiRwS/FIWdH508ebIj33TTTV6bk08+2ZHtvGsou/bevXsdefXq1d45a9eudeSPP/44oHHPgz0siQoaLIkKGiyJChosiQoOuioQ2j1wzjnnOPL111/vyKeddprXxk7g20FWqOzR7t27HXnNmjXeOdu3b3fk0M7a7mJTgwK+/s1O6c8elkQFDZZEBQ2WREXLlT1qll87cOBARw4tAnznO99xZLtwYBcWAGD9+vWObP3Ro48+2mtj/cTQc7I7a22a+dCCRJ5nm5aavmjYw5KooMGSqKDBkqigwZKoOCjSbYYGLWPHjnXkSy5x8zN/+9vf9trYhYE9e/Y4cijF5axZsxzZDsLsjgTAHwB2dHR459iFA7tLNs8AK7Q7txG11Gq5JntYEhVZahyMFZG5IrJURJaIyO3JcZbvJIWTpYftBPAzVZ0I4BwAt4rIRPytfOd4AHMSmZCGkqUoRzuA9uT1JyKyDMBolMp3fi05bQaAF5Ch3mwRwS92Ut3ubgWA6667zpFtzdfBgwd7bZYsWeLI8+bNc2S7CwDwM7IMHTrUkW1ZJMDfAfvss89651h/2aaQz0Po71GPv1EWn7Uh6TZFZByAMwDMA8t3kiaQeZZARAYBeATAHaq60/xHVCzfydKdpJ5k6mFFpA9KxvqAqj6aHM5UvpOlO0k9Se1hpdSV3gdgmareU/ZW7vKdZdf2juXxmex1bBDK+eef77X58Y9/7Mh2DvK1117z2jz11FOOvHTpUkceNGiQ1+akk05y5GuuucaRrU8LAA8//LAjv/XWW945mzZtcuRWDoa3hP7uWedms7gE5wP4HoB3RWRBcuyXKBnqzKSU5zoA11VoT0jdyDJL8AqASubP8p2kULjSRaKCBkuiovDgl/KI9XoNFNIWCuxABwBGjx7tyM8//7wjz58/32tjA1cstgYXAPzgBz9w5FNPPdWRQzsDnnnmmdT7NjvyvxZqGXSxhyVRQYMlUUGDJVHRVB+2UXzyySeOHPITbRr2devWOXJIzwkTJlSVzzzzTK/NCSec4Mg2SOVPf/qT18YGtoQCq2Mm9GyzZq5hD0uiggZLooIGS6IiuuyFofk66xPZ7H8ffPCB18Zm6rMB3VdffbXXxmZXsdcIfZ729nZHtnPCocyEX3zxhXcsZuxzqSXoiT0siQoaLIkKGiyJChosiYroBl1Z2tiJ9pdfftk7x9aFnTRpkiPbgBrA38lg72N31QLAH/7wB0detWqVI/fUmrDVqCXoiT0siQoaLIkKGiyJCilyt6WIaHmQQ6MCYWwgxVFHHeWdc8EFFziyLWm0c+dOr42tAWsXBax/Cvg7azdvDu6GP+ixYxtVDUZ0s4clUUGDJVFBgyVRUbgPW0T2QhtcEcoQaDOuDB8+PPW6Nuu1zYwdChRv5XlW+5yamT2GPizpkdBgSVTQYElU0GBJVDR14aBRKcrz0EoDkEZhP6OVWymbDAddpEdAgyVRQYMlUdFyAdwHgy/ZXUJZUexzyfKc7LO1122mD5s1KIo9LImKLKU7+4vIfBFZmJTu/E1y/FgRmSciq0TkTyLSt/HqkoOdLD3sbgAXq+qXAZwO4DIROQfA3QB+p6rHA9gO4ObGqUlIiSxFORRAV1RHn+RHAVwM4Kbk+AwA/wrg92nXK/ej6lX2KCayZukrJ0u2myyk+b1ZsmDn8ZXrSdbCcr2TkkebAcwGsBpAh6p2bRtdj1L9WUIaSiaDVdV9qno6gDEAJgM4MesNROQWEXlTRN7MqSMhB+jW95OqdgCYC+BcAENEpMulGANgQ4U2LN1J6kaWWYIRIjIkeT0AwBQAy1Ay3GuT03KV7iSku6QGv4jIaSgNqnqjZOAzVfXfROQ4AA8BGArgHQD/n6rurnylUvBLKKNKNbJMkOcZPNhzDjnEHX+G7mMHOlYOtbHXzTJZb4+FnpnNOpMW2BLC6tK3rz8zaXWxO4dD90n7G4dS4Jc/u3379lUMfskyS7AIwBmB42tQ8mcJKQyudJGooMGSqCg6gHsLSqXqhwPYWtiNa4O6No5K+h6jqiNCDQo12AM3FXkzlmku6to48uhLl4BEBQ2WREWzDHZak+6bB+raOLqtb1N8WELyQpeAREWhBisil4nI8mSXwtQi750FEZkuIptFZHHZsaEiMltEVia/j2imjl2IyFgRmSsiS5OdILcnx1tO37ruWkkyxTX8B6VYhNUAjgPQF8BCABOLun9GHS8EMAnA4rJjvwUwNXk9FcDdzdYz0aUNwKTk9WAAKwBMbEV9AQiAQcnrPgDmATgHwEwANyTH7wXwk9RrFaj0uQCeKZPvBHBnsx9mQM9xxmCXA2grM5Llzdaxgt6PoxRJ19L6AhgI4G0AZ6O0aHBIyD4q/RTpEowG8GGZHMsuhVGq2lXMYCOAUc1UJoSIjEMpQGkeWlTfeu1a4aCrG2ipK2ipaRURGQTgEQB3qKpTSaSV9NUadq2UU6TBbgAwtkyuuEuhxdgkIm0AkPxumTIwItIHJWN9QFUfTQ63rL5Avl0r5RRpsG8AGJ+MDPsCuAHArALvn5dZKO2oAFpoZ4WUIqfvA7BMVe8pe6vl9K3rrpWCHe4rUBrNrgbwq2YPAAL6PQigHcBelHyqmwEMAzAHwEoAzwEY2mw9E10vQOnrfhGABcnPFa2oL4DTUNqVsgjAYgC/To4fB2A+gFUAHgbQL+1aXOkiUcFBF4kKGiyJChosiQoaLIkKGiyJChosiQoaLIkKGiyJChosiQoaLImKmgy21be8kJ5H7lgCEemNUiDLFJQCRd4AcKOqLq2feoS41FJYbjKAVVpKuwkReQjAVQAqGqyI9OhIm3oVtSCViyPXYrChLS9npzUqT/AbSuab9gct6g8eMj6bADitsiDg67tv375ut8lSbSdPBcksCZktWRInp10n7dmGEh530fDSnSJyC4BbGn0fcnBQi8Fm2vKiqtOQpKQRES3/7wv9J7bKV2ZIj7RU7lna2HNC3zJZ0srn6cVsmzzPOs81srhKWeuO1TJLEOuWFxIxuXtYVe0UkdsAPINSkozpqrqkbpoREqDoDNxOFZk8X3XNxH61WZcgS4lNK2cZ3LWSS5CH7la42b9/f8VZAq50kagovIct7z3yFPhtJTjvmo+055bskGUPS+KHBkuiggZLoqJwH7awm5GooQ9LegQ0WBIVNFgSFTRYEhU0WBIVNFgSFTRYEhU0WBIVDd8iQ6qTJYAmtO8rbT9Zlr1iWXY/WPLsA0vTA3A/T7VrsoclUUGDJVFBgyVRUbgPm9VXiZGQP9q3r1ugeuDAgY4c8hvtsZEjR3rnHH744Y48YMAAR7b5DwA3JwQADBo0yJFXrlzptfn000+9Y+WEcgjs2rXLkffs2ePIoc9c/uxCunfBHpZEBQ2WRAUNlkRF4T5sT/JbrX86ePBg75zx48c78kUXXeTII0aM8NpY//TMM8/0zhk2bJgj9+/f35FDfuDevXsd2fqW9vMAwIYNG6rKL774otfm+eefd+QPPvjAkb/44guvTbldVJsPZg9LooIGS6KCBkuiggZLooLBLxUILQLYQdXZZ7v5m6+88kqvzSWXXOLIRx99tCPv3r3ba2Mn+Pv16+edY4+Fgl0sdiC2ceNGRw4Nuux17UJBqE1asuW0XGEMfiE9BhosiQoaLImKwn3YWPLDhhYBbrjhhqryKaec4rWxASbWPw35yvZYKMDE+pb2uqE2W7ZsceT//u//duSFCxd6beyxrVu3OrJdjADSA8HTgl+qwR6WRAUNlkRFqsGKyHQR2Swii8uODRWR2SKyMvl9RGPVJKREavZCEbkQwKcA7lfVU5JjvwWwTVXvSmrMHqGqv0i7Wa9evbTc1woFaDQrK7edT/y7v/s775wf/OAHjvzlL3/ZkW1wNuAHemzbts2RV69e7bXZsWNH6nVtULf1aUPXffXVVx356aefduSPP/7Ya2MDuKsVfasnubMXqupLALaZw1cBmJG8ngHg6pq0IyQjeX3YUaranrzeCGBUnfQhpCo1T2upqlZLVMzSnaSe5O1hN4lIGwAkvzdXOlFVp6nqWap6Vta5NkIqkbeHnQXg+wDuSn4/nqWRqjpOezMXCew/jw1KOe+887w2Y8eOdWRbWM4OqADg9ddfryp/8sknXhs7+AktYthdsn369HHkJUv8opRr16515PXr1ztyUQOqWsgyrfUggNcATBCR9SJyM0qGOkVEVgK4NJEJaTipPayq3ljhrUsqHCekYXCli0RFj9w1ayfRQ/e0fuG3vvUtR7bB2YC/U9X6n+vWrfPavPzyy45sJ/RtlhTAX2ywvicAdHR0OLINBLeLD6F7tUqgUXdgD0uiggZLooIGS6KiR2QvtHOqNpDFzpcCwGmnnebI11xzjSOfeOKJXhs712nnLUNBKqeffroj20wwmzf7ay4LFixw5NCcqp3ztX5vaE61lX1WZuAmPRIaLIkKGiyJChosiYroBl2hiC+7UGADQ+yEPwDceuutjjxu3DhHDmU0sdhB2PDhw71zbHpNe127kxUAVq1alXpvuzPD7t5o1s6NEPZvFvobZrUF9rAkKmiwJCposCQqmpq9sBZfptp1rE977LHHem3sYoINSgn5sEOGDHHkoUOHOnLIV7afx/qaNj084AePh4Jqtm/fXvU+scGFA9IjocGSqKDBkqgo3IetdX4w5N/YQA8bGBIqzWPL9/zjP/6jI48ZM8ZrY33YPPOLNtD6r3/9q9dmzZo1jpxWPrPSvVuFevrX7GFJVNBgSVTQYElU0GBJVKSm26zrzUS0ETsOAvepKgN+2aBjjjnGkW25IgD47ne/68h2N4Gt9xrCfuZNmzZ559jduCtWrPDOmTdvniPPnz/fkd9//32vTUyZXnKn2ySklaDBkqigwZKo6JE+bEZdHNkGY9tMhYCf4fD444935FDwi80gM3r0aEe2ixFANl/Y6v/BBx848htvvOG1efTRRx3ZZlLcs2dP6n2Lgj4s6RHQYElU0GBJVNBgSVQUPugq3w3QSjs7LbZ2a+iY3Z1rFyMAP+VRW1ubI4cGWEceeaQjn3DCCd45EydOdORRo9xCPnZHAgAsX77ckX/605868kcffeS1aRYcdJEeQZYaB2NFZK6ILBWRJSJye3Kc5TtJ4WTpYTsB/ExVJwI4B8CtIjIRwFQAc1R1PIA5iUxIQ8lSlKMdQHvy+hMRWQZgNErlO7+WnDYDwAsAUuvNxrK7MxQYYo/ZFJchbDpN67OG/HjrK4cyylx9tVst9brrrnPk0E5h62Nb3zgUiBOqB9xMuuXDisg4AGcAmAeW7yRNIPOeLhEZBOARAHeo6k6zxFqxfCdLd5J6kqmHFZE+KBnrA6ratSCdqXxneenOeihMDm5Se1gpdaX3AVimqveUvZWrfGerBr9Y6qWb9VE///zzbl8jVBrpsccec2Q7D2uDbAA/y8xJJ53kyK+88kq3dasXWe0ii0twPoDvAXhXRLqS7/8SJUOdmZTyXAfgugrtCakbWWYJXgFQqTti+U5SKFzpIlFBgyVR0SNrzWYhreZWiGbpHrqvXVyw6UFtylHAHwDaFEj2mQD+wkGWZ5A2oA29X36s2mIFe1gSFTRYEhU0WBIVPdKHtf5bKBjbpmW35Yfa29thsRlZrN/bqNq5NjU9AHzjG99w5AsvvNCRQ7txOzo6qt63XoEuac+hltSg7GFJVNBgSVTQYElUNLXsUVEceuih3rEpU6Y48qBBgxz5qaee8tosW7bMkT/++GNHDmVOsfOjVg75c7aM6OWXX+6d853vfMeRx48f751jsRkNn3nmGUcuKvNLyMctL0NVbXMqe1gSFTRYEhU0WBIVNFgSFYUPupqx4yA0sLFR/Ndcc40jf/WrX/Xa2Ppftj6t3SEL+IMsO6AK7UCw54RqhtnUnvYzrlq1ymszY8YMR7YLIUXBhQNy0ECDJVFBgyVR0SODX+w9Qn7iW2+95ch2Ij606/Soo45yZDtZH9rdagNvbJB0lucRCkpZsmSJI9sySC+99JLX5tVXX3XkLJlriqL8OVR7JuxhSVTQYElU0GBJVDS17FGIRugT2pBnM2FbH/bkk0/22owcOdKRBw4c6Mg2Izfgfx4bRB0KqrbB4+vWrfPOsYEsWeaE7bxrszZVhv4edhMiM3CTHgENlkQFDZZEBQ2WREVTyx6F7t2sgBi7M9UOygC/HJEdZIV2NtjsKp999pkjh8oTbd261ZHtzgbA3x3QaqndqxEadJXvOOjs7MT+/fs56CLxQ4MlUUGDJVFRqA/bq1cvLQ/+yOJ32R2UjdI3S1CxvbdtU49rZGlT6VirYj9jKBNPuV+7Z88e+rCkZ5CldGd/EZkvIguT0p2/SY4fKyLzRGSViPxJRPqmXYuQWsnSw+4GcLGqfhnA6QAuE5FzANwN4HeqejyA7QBubpyahJTIUpRDAXRNJvZJfhTAxQBuSo7PAPCvAH6fdr1yXyUtEzOQzc+15+Qpa5/HJ7Rt6nGNVic0h9rdc+zGTMD9u+/du7fytVPvXrpY76Tk0WYAswGsBtChql35JtejVH+WkIaSyWBVdZ+qng5gDIDJAE7MegMRuUVE3hSRN2PrTUjr0a1ZAlXtADAXwLkAhohIl0sxBsCGCm0OlO6sZT86IUC2WYIRIjIkeT0AwBQAy1Ay3GuT0zKX7iSkFrLsmm0DMENEeqNk4DNV9QkRWQrgIRH5dwDvoFSPNpVytyAtCCIkh7BOej0GYVnIsghgP2O93KK064Ter7UcERAeMKVRz2dQ+EpX+QfOYrBZ9KPBZnu/lQ22/D67du3Cvn37uNJF4ocGS6Ki6ADuLSiVqh8OYGvK6a0CdW0clfQ9RlVHhBoUarAHblqakz2r8BvngLo2jjz60iUgUUGDJVHRLIOd1qT75oG6No5u69sUH5aQvNAlIFFRqMGKyGUisjzZpTC1yHtnQUSmi8hmEVlcdmyoiMwWkZXJ7yOaqWMXIjJWROaKyNJkJ8jtyfGW07euu1ZUtZAfAL1RiqM9DkBfAAsBTCzq/hl1vBDAJACLy479FsDU5PVUAHc3W89ElzYAk5LXgwGsADCxFfUFIAAGJa/7AJgH4BwAMwHckBy/F8BPUq9VoNLnAnimTL4TwJ3NfpgBPccZg10OoK3MSJY3W8cKej+OUiRdS+sLYCCAtwGcjdKiwSEh+6j0U6RLMBrAh2VyLLsURqlqV8LWjQBGNVOZECIyDsAZKPVcLalvvXatcNDVDbTUFbTUtIqIDALwCIA7VHVn+XutpK/WsGulnCINdgOAsWVyxV0KLcYmEWkDgOS3n9q6SYhIH5SM9QFVfTQ53LL6Avl2rZRTpMG+AWB8MjLsC+AGALMKvH9eZqG0owJooZ0VUgogvQ/AMlW9p+ytltO3rrtWCna4r0BpNLsawK+aPQAI6PcggHYAe1HyqW4GMAzAHAArATwHYGiz9Ux0vQClr/tFABYkP1e0or4ATkNpV8oiAIsB/Do5fhyA+QBWAXgYQL+0a3Gli0QFB10kKmiwJCposCQqaLAkKmiwJCposCQqaLAkKmiwJCposCQqaLAkKmoy2Fbf8kJ6HrljCZL0mytQirxZj1I01o2qurRKGy3PUhe6d1qGvUbFPmTJ3W/v3cw4DKtvozI0FoW1C1UNGkKW/LCVmAxglaquSW74EICrAFQzWKeoWOgh2z9EliId1nCyZPq25/Tr1y+1TWdnpyPnSeuZxeitbqEcuVbfL774IlWXPM8pTbfQfdKuG+ocyo/Z5+ycl6ZgFWLd8kIippYeNhMicguAWxp9H3JwUIvBZtryoqrTkKSkEREt/woJfR3ar9k8X0FZvpptm927d6deI4/PWg8/N6TLnj17qp6T5b5ZzsnzbC3WpQm5X+V/90a5BLFueSERk7uHVdVOEbkNwDMoJcmYrqpL6qYZIQFq8mFV9UkAT9ZJF0JS4UoXiYqGzxJ0l3pMgOcZcLTSxHsW/e3gtFGLGPUYaFpdQ3PpWeeE2cOSqKDBkqigwZKoKNSHtbEEtuRmXnpaMhC71l7+zCqdYxc+WumZWF1Cf/cswUcAe1gSGTRYEhU0WBIVhc/DpgW/HGyEfLdJkyY58vHHH++d097e7sivv/66I1uftpUI/d2z2gV7WBIVNFgSFTRYEhU0WBIVhQ66VDUY+HAwM3DgQO/Ydddd58jnnnuud84LL7zgyEuWuKHIrTzoCsHgF9IjocGSqKDBkqhoagA3Fw6APn36eMcuuugiRz7qqKO8c1555RVHtrtoY6N8Z221cQ57WBIVNFgSFTRYEhVNDX4hYX/t888/d+Rt27Z558ybN69qm1YmNOeaNbCfPSyJChosiQoaLIkKGiyJipbL/HKwEUotaXchdHR0eOfs2LHDkWMKKkpLs8odB6THQIMlUUGDJVFRuA+bVvboYGPkyJHeMftc3nvvPe8c68PW41lmCaJuVAr88oBz+rCkx0CDJVGRarAiMl1ENovI4rJjQ0VktoisTH4f0Vg1CSmRxYf9I4D/AnB/2bGpAOao6l1JjdmpAH5Rf/V6HnaO9Uc/+pF3zvDhwx35s88+884JHauVkO9oSxblKa9UT1J7WFV9CYANF7oKwIzk9QwAV9dZL0KC5PVhR6lqV3KnjQBG1UkfQqpS87SWqqqIVPxeYOlOUk/y9rCbRKQNAJLfmyudqKrTVPUsVT0r570IOUDeHnYWgO8DuCv5/XjdNOph2Ml4m/79kksu8drs2rXLkVesWOGdYxcOGkVaUE1oscEeswOzWgZqWaa1HgTwGoAJIrJeRG5GyVCniMhKAJcmMiENJ7WHVdUbK7zldw2ENBiudJGoYAB3wVgfNpQOfu3atY78wQcfeOcU5cOmkcUfzZqZMAvsYUlU0GBJVNBgSVQwgLvB2GCXQYMGOfKQIUO8Ntu3b3fk9evXe+d88cUXddCuMaTNu9bi07KHJVFBgyVRQYMlUUGDJVHR1EFXTyP02QYMGODIJ5xwQup1Fi9e7Mh2EAYcHAPWEOxhSVTQYElU0GBJVBTuw8aUZa+7hHzYww47zJFvvfVWR16zZo3X5sknn3TkVgl0qRcNDeAmpJWgwZKooMGSqGAAdx2xc64AMGbMGEe2mw5ffPFFr83bb7/tyDGVNGo07GFJVNBgSVTQYElU0GBJVBQ+6CqPwO9pdWdDE+Jp6SltOksAOOmkkxx50aJF3jnV6rH2ZNjDkqigwZKooMGSqGiqDxsKFknbcdnKgcv9+/f3jtmFgz59+jjyRRdd5LVpb2935FB6+CVLljjyweLTsoclUUGDJVFBgyVRQYMlUVH4oCttsSAt3XiWgVpRWF369evnnTNixAhHtoOuvn37em06OztT792Izxx6to2o08UdB+SgIUuNg7EiMldElorIEhG5PTnO8p2kcLL0sJ0AfqaqEwGcA+BWEZmIv5XvHA9gTiIT0lCyFOVoB9CevP5ERJYBGI1S+c6vJafNAPACullvNuTLtPLCgMX6fCNHjvTOOfHEE6teY+vWrd4xu2t23bp13jmN2H1sU4MC6WOIUJu0a9Sie7d8WBEZB+AMAPPA8p2kCWSeJRCRQQAeAXCHqu40iYkrlu9k6U5STzL1sCLSByVjfUBVH00OZyrfydKdpJ6k9rBS6krvA7BMVe8peytX+c5yfyYmfzWEzery1a9+1Tvn8ssvd2QbILNgwQKvzfz58x05lPmlqHnY7s6bh46lzeUC2T9PFpfgfADfA/CuiHQ93V+iZKgzk1Ke6wBcl+mOhNRAllmCVwBUSurK8p2kULjSRaKCBkuigqmKuoGtsTV58mRH/vu//3uvjd0Ba3nvvfe8Y59++qkjN2p3sR0cZRkMWTnUxi4m2HPSygZUG4CxhyVRQYMlUUGDJVFRuA8by2KBDbQGgFNOOcWRr7/+ekeeMGGC18amyrQ7ssAVmAAAIABJREFUYkMp44uiUTuSa11soA9Legw0WBIVNFgSFZyHrUAoq+Ahh7iPy/qnK1as8NrYlPD33HOPI3d0dHhtDpYsLuVkzWrJHpZEBQ2WRAUNlkQFDZZEhRQ5kV9p31crEhp02cwuNhhm6NChXhu7W2DTpk2OHPvO4XpRvlDT2dmJ/fv3ByNk2MOSqKDBkqigwZKoKNyHzRrk0GzSgowBP1A5y67TnlbqKQ+h51Tuw+7du5c+LOkZ0GBJVNBgSVQw+KUCWfzrRmQQ7InkyXhYCfawJCposCQqaLAkKmiwJCo46CINJ0u2mGrnl8MelkQFDZZEBQ2WREXL+bBppTtjJ0tQTeyfOctntGT9zOxhSVRkKd3ZX0Tmi8jCpHTnb5Ljx4rIPBFZJSJ/EhG/yi8hdSZLD7sbwMWq+mUApwO4TETOAXA3gN+p6vEAtgO4uXFqElIiS1EOBdCVErpP8qMALgZwU3J8BoB/BfD7tOvl8W/S2reyz2f1tVkRQ6XmY/o8oUCWvn3dL1v7GUNBQ1ntImthud5JyaPNAGYDWA2gQ1W7NFmPUv1ZQhpKJoNV1X2qejqAMQAmA6he8bcMEblFRN4UkTdz6kjIAbo1S6CqHQDmAjgXwBAR6XIpxgDYUKENS3eSupFllmCEiAxJXg8AMAXAMpQM99rktMylOwmphSwLB20AZohIb5QMfKaqPiEiSwE8JCL/DuAdlOrRdouQo20zrlgHPcugK0sqdHudPIPBLG3s57EpO0ODriy65VlgSWuT5Rp20Giz4QB+PV17XZumFHADYqoFx2SZJVgE4IzA8TUo+bOEFAZXukhU0GBJVBSd+WULSqXqhwPYWtiNa4O6No5K+h6jqiNCDQo12AM3FXkzlmku6to48uhLl4BEBQ2WREWzDHZak+6bB+raOLqtb1N8WELyQpeAREWhBisil4nI8mSXwtQi750FEZkuIptFZHHZsaEiMltEVia/j2imjl2IyFgRmSsiS5OdILcnx1tO37ruWlHVQn4A9EYpjvY4AH0BLAQwsaj7Z9TxQgCTACwuO/ZbAFOT11MB3N1sPRNd2gBMSl4PBrACwMRW1BeAABiUvO4DYB6AcwDMBHBDcvxeAD9JvVaBSp8L4Jky+U4Adzb7YQb0HGcMdjmAtjIjWd5sHSvo/ThKkXQtrS+AgQDeBnA2SosGh4Tso9JPkS7BaAAflsmx7FIYpartyeuNAEY1U5kQIjIOpQCleWhRfeu1a4WDrm6gpa6gpaZVRGQQgEcA3KGqO8vfayV9tYZdK+UUabAbAIwtkyvuUmgxNolIGwAkvzc3WZ8DiEgflIz1AVV9NDncsvoC+XatlFOkwb4BYHwyMuwL4AYAswq8f15mobSjAmihnRVSisa+D8AyVb2n7K2W07euu1YKdrivQGk0uxrAr5o9AAjo9yCAdgB7UfKpbgYwDMAcACsBPAdgaLP1THS9AKWv+0UAFiQ/V7SivgBOQ2lXyiIAiwH8Ojl+HID5AFYBeBhAv7RrcaWLRAUHXSQqaLAkKmiwJCposCQqaLAkKmiwJCposCQqaLAkKmiwJCpqMthW30FAeh65l2aTbIYrUApkWI9ScMuNqrq0fuoR4lJLna7JAFZpKYshROQhAFcBqGiwIqLlKR8Zx5CNPHUd6lUPLO06jfobqmrwxrUYbGgHwdnVGoiIkx81VJzBPoB6PJBGFfLIYhRpOVmzXMPmlAXS8+baPK6An4vWylny9dpzQrlc04ofp1FTfthaEZFbANzS6PuQg4NaDDbTDgJVnYYkw0evXr2a4gPU62srreRPnt4mpJvt1fJ8dYfahL7R0tpY/UNljtKuU89yrLXMEsS6g4BETO4eVlU7ReQ2AM+glHNguqouqZtmhAQodMdBr169tBmDrnqRxyXIo791CUJfw2lf1fYaALBnz55u62ava+Usrkd3XYJkO0xwNMqVLhIVDZ8lqEboP61VetRQrxaaKirH9mB5yTItZHsx2yb07ZVnuiltAFVL3dhq96kEe1gSFTRYEhU0WBIVRZc9iiaWIFSSMm20u3fvXq9NrcuUrUaWWQJLnr8zZwlIj4AGS6KCBkuionAftrCbdZM8oYI9zT9tJejDkh4BDZZEBQ2WRAUNlkRF4cEvrbpw0KgJ8DzR9nYPV2hAaPdjtdKzbCTsYUlU0GBJVNBgSVQ0NYC7pxHyNQcOHOjINuA55HuOGuUWL7TXAIDt27c7ckdHhyPv3r27urJNpJbkHOxhSVTQYElU0GBJVBTuw/ak+ULri4W2Vqdtxx4yZIjX5sQT3brBX/nKV7xzVq1a5chvvfWWI3/wwQdem3ptkmwm7GFJVNBgSVTQYElU0GBJVHDhoBvYoJSTTz7Zkc877zyvzTnnnOPIxx13nCNPmjTJa2MzzIQyztjBnF1IePHFF7029957ryPPmTOn6jUbRbPSbRJSODRYEhU0WBIV9GET7IT+kUce6Z0zZcoUR77++usd+eyz/ZokgwYNcuQsiw02ONsGtoT0tZlqJk+e7LUZOXKkIy9fvtyRP/zwQ1habaGHPSyJChosiQoaLImKVB9WRKYD+CaAzap6SnJsKIA/ARgH4H0A16nq9krXaDRptQf69+/vtTnssMMc+dRTT3XkSy65xGtzwQUXOPLEiRNT77Nz505HtkErK1as8Nq89957jrxx40bvnMGDBzvyaaed5shnnHFGapuvfe1rjvzggw96bUIZGZtJlh72jwAuM8emApijquMBzElkQhpOqsGq6ksAtpnDVwGYkbyeAeDqOutFSJC8PuwoVW1PXm8EMKrayYTUi5rnYVVVq2UlZK1ZUk/yGuwmEWlT1XYRaQOwudKJ5bVm65EyPrTjsm/fvo5sd52GBlA26MRO8IcGLcOGDXPk1atXO/KiRYu8NnYy/o033nDk0M4AG8jyxRdfpOpin4sNzAGAY4891pGvuOIKR3788ce9Np988okjNzvFaF6XYBaA7yevvw/A/6SENIBUgxWRBwG8BmCCiKwXkZsB3AVgioisBHBpIhPScFJdAlW9scJb/vcsIQ0muuyFIR/WBjiPGTPGkX/4wx96baw/9/HHHzvy2rVrvTbz5s1z5Oeff96RFy5c6LXZsmWLI+/YscORsxSItj464PvpNrBl+PDhXhu7sDF06NDU+2QpAF0kXJolUUGDJVFBgyVR0SMyv9hrWr/L+nuAHwiybt06R/7DH/7gtbE+rPVPG+XfhbLD2A2PNmD7qKOO8tpY/3nDhg2OnCXjYZ6M4t0tR8/shaTHQIMlUUGDJVFBgyVREd2u2dDAxg4W7KS/jfIH/EHX/fff78jPPfec1+bzzz/PrGct2J20oUCciy66yJHtjolt22wIM/DYY4858quvvurIoc9nd/A2iqyDcfawJCposCQqaLAkKnrEwoENILH+2/z58702EyZMcOSPPvrIkZuZ8cTu6LW7dQHg/PPPd2Sb+cX6pwDw//7f/3PkrVu3OjKzFxJSZ2iwJCposCQqopuHzYIt7/Pss89655x00kmO3NbWVlUGfD/Xzv/mCQQJBU3/9Kc/deQrr7zSO8f6rE888YQjh4J3Nm+uuFe0odRzPMAelkQFDZZEBQ2WRAUNlkSFFDlBXo/ML3mwWV0A4KabbnLkyy+/3JFD2VbsrlgbTGJ33gJ+qaRTTjnFkc866yyvzT/90z85cqjska0t+/vf/96RZ8+e7bXJsqOgVVDV4DYF9rAkKmiwJCposCQqeuTCgSUUmGyztthdpmeeeabX5pprrnFkG0Rtsw4Cvg9rs62E/Gsb/BIKQH/00Ucd2e7ojclf7Q7sYUlU0GBJVNBgSVTQYElUHBSDrlAkfXt7uyO/+OKLjmx31QJ+yiC7a2HgwIFeGxtVZdMo2XRHALBmzRpHfuaZZ7xz3nnnHUe2aYjqRZ7URI2EPSyJChosiYosNQ7GishcEVkqIktE5Pbk+FARmS0iK5PfRzReXXKwk8WH7QTwM1V9W0QGA3hLRGYD+EeUynfeJSJTUSrf+YvGqVpfdu3a5cgLFixw5Cy+mk3LbksRAf7Cgc2kYssiAcDTTz/tyCEf9v3336963Sxk2f1gr2vHA0X7tFlKd7ar6tvJ608ALAMwGizfSZpAt3xYERkH4AwA88DynaQJZJ7WEpFBAB4BcIeq7jRxrRXLd7J0J6knmQxWRPqgZKwPqGpX1EWm8p22dGf5PGRofrQon8je285j2hKbAHDooYc68vHHH+/IoTTtFhuI89prr3nn/OUvf3FkOy8buk6WrC3WZ7VzxPbzAUBHR4cjN+rvkzWwP8ssgQC4D8AyVb2n7C2W7ySFk6WHPR/A9wC8KyJdQ+lfolSuc2ZSynMdgOsaoyIhfyNL6c5XAFQqA8LynaRQuNJFoqKptWZbCTtosQsLgF/XatOmTaltbOS/HWTde++9qffZu3dvQOPuYwczdmfDp59+6rWpRwpO+ze3AUCWUP3dA21r1oaQAqHBkqigwZKoKNyHLfdPmh0MXA0btAIAI0eOdGQb7BLyzayfazOyfPDBB16bolK328WSRu20tX/nkI+adWzDHpZEBQ2WRAUNlkTFQbEJMQ+hYOaxY8c68vjx4x25f//+XhubBdEGYxflr4ZopewwdQt+IaSVoMGSqKDBkqigwZKoKHzQ1bt37wOvQxPIrbKYEBoMffbZZ1XPsdH5APDXv/7VkUOZXkh22MOSqKDBkqigwZKoKNSHFRGnhE8oWCQt00hRhO5r/U9bezaUfcVmSQylryfZxy7sYUlU0GBJVNBgSVQU6sP26tXLCSrZs2ePd471ZdLkRhHSbfny5Y5sM7ScfvrpXpu3337bkattsCPpsIclUUGDJVFBgyVRQYMlUSFFBpv06tVLy3ejhiba03ZPNjNCvzxwBwBGjXJzOE+cONFrs3TpUke2u2ibmXK0lbBBUaoaNAT2sCQqaLAkKmiwJCoK9WFFRMt9lZD/Zv3ELFlDmoXNDjNgwADvnDSf235ewA8Ub6XPnCVDS5pNha5RHghFH5b0GGiwJCqyFOXoLyLzRWRhUrrzN8nxY0VknoisEpE/iYifeYKQOpPqwyZVZA5V1U+T8kevALgdwE8BPKqqD4nIvQAWqurvU67llD0K3dv6N1nKnzcrQMYSCki3PqrNeBjyT7dt25Z6TiNI8y1D1OtZl9+ns7Mzvw+rJbpyifdJfhTAxQD+nBxn6U5SCJl8WBHpnZQ82gxgNoDVADpUtWupaj1K9WcJaSiZDFZV96nq6QDGAJgM4MSsNxCRW0TkTRF5M6eOhBygW7MEqtoBYC6AcwEMEZGuicgxADZUaDNNVc9S1bNq0pQQZNhxICIjAOxV1Q4RGQBgCoC7UTLcawE8hJylO0NOftqgKzQISBt05anDmmVwl+V9q69NvxnaRWuvE3pOtU7OA/5zCaXJt8dsCaYsf0M78EwbRFZbnMiyRaYNwAwR6Y1SjzxTVZ8QkaUAHhKRfwfwDkr1aAlpKFlKdy4CcEbg+BqU/FlCCoMrXSQqig5+2YJS5e/hALYWduPaoK6No5K+x6jqiFCDQg32wE1F3oxl1oC6No48+tIlIFFBgyVR0SyDndak++aBujaObuvbFB+WkLzQJSBRUajBishlIrI8CfqeWuS9syAi00Vks4gsLjs2VERmi8jK5PcRzdSxCxEZKyJzRWRpElh/e3K85fSt6yYAVS3kB0BvlMISjwPQF8BCABOLun9GHS8EMAnA4rJjvwUwNXk9FcDdzdYz0aUNwKTk9WAAKwBMbEV9AQiAQcnrPgDmATgHwEwANyTH7wXwk9RrFaj0uQCeKZPvBHBnsx9mQM9xxmCXA2grM5Llzdaxgt6PoxSY1NL6AhgI4G0AZ6O0aHBIyD4q/RTpEowG8GGZHEvQ9yhV7SpUsBHAqGonNwMRGYdSvMc8tKi+9doEwEFXN9BSV9BS0yoiMgjAIwDuUNWd5e+1kr5awyaAcoo02A0Ayuu3Vwz6bjE2iUgbACS/NzdZnwMkm0IfAfCAqj6aHG5ZfYF8mwDKKdJg3wAwPhkZ9gVwA4BZBd4/L7NQClAHcgaqN4JkN/N9AJap6j1lb7WcviIyQkSGJK+7NgEsw982AQBZdS3Y4b4CpdHsagC/avYAIKDfgwDaAexFyae6GcAwAHMArATwHIChzdYz0fUClL7uFwFYkPxc0Yr6AjgNpSD/RQAWA/h1cvw4APMBrALwMIB+adfiSheJCg66SFTQYElU0GBJVNBgSVTQYElU0GBJVNBgSVTQYElU0GBJVNBgSVTUZLCtvuWF9DxyxxIk2QxXoBR5sx6laKwbVXVp1YaE1ECWdJuVmAxglZayGEJEHgJwFYCKBisiWp77M/TPkqcoRxqxBfhk+cz1eC55dLHU677WLrRCUY5aDDa05eXsNKXKE+SGPqxNumsT6mapfm3PCbWpR1XwtH+u0H2srqE2WT6zfU42SXCez5dFF3tOqCJ72mcM3ac86bFNmuzoU/GdOiEitwC4pdH3IQcHtRhspi0vqjoNSUoaEdHy//xQD2t7CvvflidlfFEuQahubFrv0revvxU/Sw+7Z88eRw71dN0l9JzSrpvlW9I+lyz1aitRyyxBrFteSMTk7mFVtVNEbgPwDEpJMqar6pK6aUZIgJp8WFV9EsCTddKFkFS40kWiouGzBJZyhzvLFJWlqELBWbCDicGDB3vnHHbYYY585JFHOvIvfvELr83HH3/syHPnzvXOeemllxz5o48+cuR6Pac8A9a0qbxaCi6zhyVRQYMlUUGDJVFRuA/bk7C+Vmjh4JhjjnHkyy67zJGvuOIKr83mzZurygAwb968qrq0EmlL592BPSyJChosiQoaLImKwn3Ycn+mlf2uLFhfLDT3aYNHJk92C6CHgl+sL2znWAFg+/btVXVpZdICZjgPS3oMNFgSFTRYEhU0WBIVXDioI3YXAADs3r3bkceOHeudY7ELBa+//rp3jh10xU7WATh7WBIVNFgSFTRYEhX0YWvA7v4MBXC3tbU5cr9+/Rw55Pe+9dZbjrxt2zbvnJgWCuoJe1gSFTRYEhU0WBIVhfuwrbSJsFbsBsPTTz/dO+fnP/+5I48ZM8aR33vvPa/N7373O0f+8MMPvXNiJpT5JS1JYBfsYUlU0GBJVNBgSVTQYElUcOGgG9jBwtFHH+3IZ5/t53M+7rjjHPnzzz935Ouvv95rs3jx4rwqRkGWjOKVYA9LooIGS6KCBkuioqnZC7ME7WbxbZqVEn7gwIGOfMopp3htbLDLli1bHDkU2FJUhZhWImswD3tYEhU0WBIVqQYrItNFZLOILC47NlREZovIyuT3EY1Vk5ASWXzYPwL4LwD3lx2bCmCOqt6V1JidCsBPJZ1CWiZmoHkljEIMGDDAkUePHu3INlMh4PuwCxYscOTQZsKDwWfNS6rFqOpLAOzI4CoAM5LXMwBcXWe9CAmS14cdpartyeuNAEbVSR9CqlLztJaqqohU/A5j6U5ST/L2sJtEpA0Akt9+iugEVZ2mqmep6lk570XIAfL2sLMAfB/AXcnvx7M2TEu3mWUgVgShBYthw4Y58mmnnebIw4cP99rYQZXN4hLaNUsqk2Va60EArwGYICLrReRmlAx1ioisBHBpIhPScFJ7WFW9scJbl9RZF0JSaY3vX0Iy0nIB3K0yaZ6lhJHdJTto0CCvzbJlyxz55ZdfduRW+byxwB6WRAUNlkQFDZZERcsHcFdrX8t10ujfv7937Pjjj3fkk08+2ZFDc8hr16515A0bNqTe55BD3D/Lrl27vHNsBp0sge72HBs0HUNGRPawJCposCQqaLAkKmiwJCpabuEgjUZNtNsBic3YAvjBLnbXbGj3QEdHhyOPGDHCkUO1Zm2QzY4dO7xz7L2s/nbgBqTXsI2hlBJ7WBIVNFgSFTRYEhWF+7CtGuxhJ/3PPPNM75xLL73Uka0/Gprgv+yyyxz5q1/9qiPbskiA73+G/Ny0hYNQYLhdxPi3f/s3R37qqadS79Ns2MOSqKDBkqigwZKoaLngl7Qgjkb5wH369HHkUDC2LXPU2dnpyHv37vXa2HKexx57bNX7Atk+Y1qgyqGHHuodO/zwwx35P//zPx05lEH8rrvc7Xq7d+925JCP28hxCntYEhU0WBIVNFgSFTRYEhUtF/zSrKh3Ozk/ceJE7xwbPGKDUjZv9jM22QATG1Rjg2MAP438pk2bvHPswOaII9wUvaHUn6NGuTn7bJsf/vCHXhtbpun+++935I0bN3ptGrnYwB6WRAUNlkQFDZZERVMXDrK8X1TK+CwLBzt37nTkpUuXOvKzzz7rtVm0aFHV69prAv6CxBdffOGdY4/Z644dO9Zr85WvfMWRr732WkceN26c1+aE/7+9sw+2qyrv/+cB80oiIRBCTKIxGJAoCBQRiiLFMrW0FouOBWbUX8sMM7adQusfDTqjP2d0RvrC7492RoYKNe0wRhQ6ifaFBhqbYdIGEUgMCXkBgSTkFQgkSMjb+v1xdsJZz1737p1zz9nnrJvvZ+bOPc++e+39nHOfu++z1npezjknkv1GSMqH7SV6woqskMGKrJDBiqyQwYqsGLhJl1+c94vQTWXNTpkypXSOj1R65plnIvnhhx8ujfEbB35C5WXobKLp9X/xxRdL5/hoMx9d9vLLL5fGPProo5HsJ1lNZyToCSuyQgYrsqJOU47ZZrbMzNaa2dNmdmtxXP1mRePU8WEPAV8OITxhZpOBn5vZUuD/0EG/2Sp/rMqH7RU+6Ca1WO91r+OP+kzabpUY9fgMg4suuqh0js/69T75d7/73dIY78Pu3bu3UpdeUqfX7LYQwhPF673AOmAm6jcr+sBx+bBmNge4CFiJ+s2KPlB7WcvMJgEPALeFEF53yYRD9ptVr1nRTWoZrJmNoWWs94UQHiwO7zCzGSGEbcP1mw0h3A3cXVwntPtwdcq/+4osTQV47969u3Ts/PPPj2RfHWblypWlMVXrsKky8/5z8dUMAWbNmhXJn/hE3OfPV5iBcmvRJ554IpLvvffe0pim1l3rthKos0pgwD3AuhDCnW0/OtpvFo6z36wQnVLnCXsF8HngF2b2VHHsK7T6y95f9J59Afhcb1QU4m3q9Jp9FBhqXUX9ZkWjaKdLZMXAldvsV++offv2RfLzzz9fOsfr4idhX/jCF0pjfGatz0BIfR4+m/Wmm24qnfM7v/M7kewzDFKlP/0mwF133RXJmzdvLo3pBak+vu2fw4gmXUIMEjJYkRUyWJEV1mQJ96F2w9rxC+lNZc16fv3Xf7107M///M8j+corr4zkVKshX6Z98eJ4uTq1cXD22WdH8sc+9rHSOT7YZcuWLZGc2gS45557Ijnl5/YC/x5T/XXbS9wfOnSIEEJyZUpPWJEVMliRFTJYkRXyYYcgVcr92muvjWRfOeXqq68ujfEVWbz+vjogwLPPPhvJPoAGYMWKFZH80EMPRfKmTZtKY1IB5k3g110nTJhQOqc9YF4+rBg1yGBFVshgRVbIYEVW9HXSVSfjIHGNymO9mqj5CZQPUvGlKaFcit5nnaYmXT6qP1XS0pfp9Fm+/ezp638ffkMltcHSvnFw+PBhTbrE6EAGK7JCBiuyonEftt2/6cSHrZNl2q+KhynfLLUB0U5KN19VsOl+riOlqlJN6nfY/n6OHDkiH1aMDmSwIitksCIrGvdh2/2XXt17kP07kfZh25EPK0YNMliRFTJYkRUyWJEVjVd+aSc1OfKLzt5Br1M+3ZOqHtNURRlRJvXZV03Ejp3XbWWE6CUyWJEVMliRFX31YevgAz9SPqz3f3yWZh3/yPtV/cow7SX+s/OfU1O+fur30X5suHvqCSuyQgYrsqJOU47xZvaYma0qWnd+ozj+XjNbaWabzOwHZja26lpCjJTK4Jeii8wpIYR9RfujR4Fbgb8AHgwhLDKzu4BVIYTvVFwrtPtNKV+lkyTEqnNS1/TVR3ygdSo50AdWd4NO1pWhs0B3H2DuEyRTv49utB6t0gNifQ8ePMiRI0c6C34JLY7WUx9TfAXgauBHxXG17hSNUMuHNbOTi5ZHO4GlwLPAnhDC0an0Flr9Z4XoKbUMNoRwOIRwITALuBR4f90bmNktZva4mT3eoY5CHOO4VglCCHuAZcDlwBQzO+qMzAK2DjHm7hDCJSGES0akqRDU2Dgws2nAwRDCHjObAFwD3EHLcD8LLOI4Wne2O/Z1NgG8k18n07bOGF+2vL3yCKRb81QF4tTZbKjqpZu6d0oXv6HiJ0x1Mm3r6FLV67dOAFNVQNPxUGenawaw0MxOpvVEvj+E8BMzWwssMrNvAk/S6kcrRE+p07pzNXBR4vhztPxZIRpDO10iK5rOmt1Fq/P3GcDuxm48MqRr7xhK3/eEEKalBjRqsMduavZ4LqsG0rV3dKKvXAKRFTJYkRX9Mti7+3TfTpCuveO49e2LDytEp8glEFnRqMGa2SfNbH0R9L2gyXvXwczuNbOdZram7dhUM1tqZhuL76cNd42mMLPZZrbMzNYWgfW3FscHTt+uJgGEEBr5Ak6mFZY4FxgLrALmN3X/mjpeCVwMrGk79lfAguL1AuCOfutZ6DIDuLh4PRnYAMwfRH0BAyYVr8cAK4HLgPuBG4rjdwFfqrxWg0pfDjzUJt8O3N7vDzOh5xxnsOuBGW1Gsr7fOg6h92JagUkDrS8wEXgC+AitTYN3pOxjqK8mXYKZwOY2OZeg7+khhG3F6+3A9H4qk8LM5tCK91jJgOrbrSQATbqOg9B6FAzUsoqZTQIeAG4LIUTd5gZJ3zCCJIB2mjTYrcDsNnnIoO8BY4eZzQAovu/ssz7HKJJCHwDuCyE8WBweWH2hsySAdpo02J8B84qZ4VjgBmBJg/fvlCW0AtThOALVe02RzXwPsC6EcGfbjwZOXzObZmZTitdHkwDmgsPQAAAgAElEQVTW8XYSANTVtWGH+1pas9lnga/2ewKQ0O/7wDbgIC2f6mbgdOARYCPwMDC133oWun6U1r/71cBTxde1g6gvcAGtIP/VwBrga8XxucBjwCbgh8C4qmtpp0tkhSZdIitksCIrZLAiK2SwIitksCIrZLAiK2SwIitksCIrZLAiK2SwIitGZLCDnvIiRh8dxxIU1Qw30Iq82UIrGuvGEMLa7qknRMxIGstdCmwKrSqGmNki4DpgSIM1M0XadECdxh05BTGl3k/7sSNHjhBCSL7pkRhsKuXlI1WD2ovzporuDjIjKcQ7FClD8wWMq37B0Nln6e9dx+g7+ePxY3zHHn8s1cHnKD1v3WlmtwC39Po+4sRgJAZbK+UlhHA3RUkaMwu96F3aFFW6d9JzK/VU66Qse9VTDar/Q6Tu08lTuIqUbu3/IYa7x0j+x+Wa8iIypuMnbAjhkJn9KfAQrSIZ94YQnu6aZkIkaLoCd2j/d5DTzLYO3XIJqjrppO7ViUvgx3TSSrUOXpdx48YNe87+/fs7b90pxCDR+BN2pM2RRedU/Qdo6rOvevofPnx4yHVYPWFFVshgRVbIYEVW9Hyny9Puv9TpGyu6x6B8tnU2S4ZCT1iRFTJYkRUyWJEVjfuw7f5LU4EwKV/5He+I3/opp5wy7M8B3nzzzUh+6623IjkV4jcofuOgU/dz0hNWZIUMVmSFDFZkhQxWZEXjk65eRO37MT6MLjWBuvDCCyP5vPPOi+TJkyeXxvhJ1gsvvBDJv/zlL0tjtm3bFslvvPFGJCsAqEXdsFM9YUVWyGBFVshgRVb0deOgk5/XSf3w8tix5SbRf/RHfxTJv/u7vxvJ06ZNK405dOhQJG/atCmSly9fXhrz05/+NJJXr14dyTt27CiN8RsUqQ0J7/vmnI18POgJK7JCBiuyQgYrsqLxJMQeXTeSvc961llnlcasWLEikidMmDCsDGU/cf/+/ZGcqgnl/emJEydGsvdXAR555JFI/t73vlc6Z9WqVZH88ssvR/IgreX630/VWvtwxeD0hBVZIYMVWSGDFVkhgxVZ0fjGQS+oKgk5ffr00pipU6cOOyY1GXruuecieePGjZE8adKk0hi/AXHuuedGcirI5qqrrorkp556qnTOq6++GsmvvPJKJA/SpMuT2uSoG/SkJ6zIChmsyAoZrMiKUeHDenz90euuu650jl/Q98HZTz75ZGnMd7/73Uj2wS5+IwFgxowZkfyZz3wmkn/v936vNGbu3LmRfPHFF5fOeeKJJyLZv59BCoap408ra1aMSmSwIisqDdbM7jWznWa2pu3YVDNbamYbi++n9VZNIVrU8WG/B/w98E9txxYAj4QQvl30mF0A/GWdG/aix4Ffw/ON2XzgdereO3fujOT/+I//KI3xfq0fkwq09uu5P/rRjyLZr8sCnHZa/PefCqrx1x3kddduUvmEDSEsB15xh68DFhavFwKf7rJeQiTp1IedHkI4mr+8HShvJQnRA0a8rBVCCMPFuap1p+gmnT5hd5jZDIDi+86hTgwh3B1CuCSEcEmH9xLiGJ0+YZcAXwS+XXxf3DWNOqAq4yC1oO+DRf7lX/4lkn3UP5SzZFOTOY/fkNiyZUskb968Gc+8efMi+aWXXiqds3v37kjWpKvAzL4P/A9wrpltMbObaRnqNWa2EfjNQhai51Q+YUMINw7xo090WRchKtFOl8iKURH84v03v9C+du3a0phly5ZF8uLFsRvu/VWo57NW6eYrKY4fP740xvvXL774Yukc75fLhxViAJHBiqyQwYqsGBU+rOfAgQOR7IOdAbZu3RrJTz/99LDX6BQfiHPGGWdE8uzZs0tj/L3PPPPM0jn+Ort27Ypkv/47WtATVmSFDFZkhQxWZIUMVmTFqJh0+UVzP2nxEywoB5SksgW6gc9mPfXUUyM5lRHrg3dS1WH27NkTyfv27Yvk7du3l8b4lks5bjboCSuyQgYrskIGK7Ji4Noe9YKmqqDUqcA3c+bMSE61V/KVa3wWLcCcOXMi+eqrr45kn50LsHTp0kj2QTY5oCesyAoZrMgKGazIilGxDjsopPxzfywV7OLxa8JjxowpnTNr1qxI9r7whz/84dKYSy6JE5e//vWvR3KqwsygoSesyAoZrMgKGazIChmsyIrGe822B4PUmaTkjp8wnX/++ZH8G7/xG6UxPrP2vPPOK53za7/2a5H8rne9q1IXn2n713/915F81113VY5pCvWaFaMCGazIChmsyIpGfdiTTjoptPtndSqp5O7T+qzZKVOmRHIqONtvHJxyyimlc3w7Ur8h4TcWAC699NJI9v7p3/zN35TGrFq1aljdeoV8WDEqkMGKrJDBiqyQwYqsGLiNA09Ok65UxoE/5rNo62ye1Mlk8FkK733ve0vn3HJL3BvF9wjbsGFDacztt98eyT6iq1e/H026xKigTo+D2Wa2zMzWmtnTZnZrcVztO0Xj1HnCHgK+HEKYD1wG/ImZzeft9p3zgEcKWYieUqcpxzZgW/F6r5mtA2bSat95VXHaQuCn1Og32+7z5OSfpvCBLZMmTSqdU5Wx6yu2QGe+fZ0sBe/n+gze1BhfhabfWQnH5cOa2RzgImAlat8p+kDtnC4zmwQ8ANwWQnjddeUesn2nWneKblLrCWtmY2gZ630hhAeLw7Xad6p1p+gmlU9Yaz1K7wHWhRDubPtRR+073ZP5eHRtlNTa58SJEyPZr3XOnz+/NMYHu3g/MdUi1Fdb9PcFmDBhQiS/733vi2RfCQbgyiuvjGQfMNNv/7QOdVyCK4DPA78ws6eKY1+hZaj3F608XwA+1xsVhXibOqsEjwJDbbWofadoFO10iayQwYqsaLxU0aBmzfpJVqoMpp+0XHvttZF8wQUXlMb46/iM2Ouvv7405sc//nEkp8ptzpgxI5LnzZsXyWeffXZpjO/35d9zqrR+t/qVdQs9YUVWyGBFVshgRVb0tdxmanG+Kng5NcYHRftM1YMHD1bq4hf0fYYpwB//8R9Hsm9ZlMqA9bp5zjrrrNIx7yunruE/p6pgGCj3n3311VcjefHi8t5Pnczm46UqIH24eYyesCIrZLAiK2SwIisa92HbA5rrtCOqsy7rr+Pl1DW8H+XP2bZtG57NmzdHsl/7TFVoqbpPyp/zPngKfx3flnPv3r2lMT7J0FcvXL58eWmMX4ftxjp5nd/HUOgJK7JCBiuyQgYrskIGK7Kir+U2U4vbVfqknPNUtmc7nQRw+CAVgFNPPTWSfYCJ30iA8sbAiy++GMmpkuxz586N5NTGh1/037NnTySnsnF37NgRyWvWrIlkv7EAzQUj+UwUVX4RowIZrMgKGazIioH3Yb2c8i29D+t91k7KnNdZyPa6pLJb/WaC91lTmye+QovPkAV48803I9m/x5Q/6u9dJyioKeTDilGJDFZkhQxWZEXjFbjbAzvqJCHWCRapCjAZ5AozJyJ1Arjlw4pRgQxWZIUMVmSFDFZkReMZB+0ToDoZB8ONH+pY3eh10QxVrZ/8OcNl6uoJK7JCBiuyQgYrsqKvPmyvqFMtpmqzoRP/WrTwWb/eZ62aYwz3cz1hRVbIYEVW1Ok1O97MHjOzVUWv2W8Ux99rZivNbJOZ/cDMxlZdS4iRUhn8UrQ9OiWEsK/o1/UocCvwF8CDIYRFZnYXsCqE8J2Ka0XBLyk/sZMkxCqfNXVNH3zdSbvMOmO8LlVVarpFr4KE6qxx+3affkyqsk37vffv38/hw4c7C34JLY6mYI4pvgJwNfCj4vhC4NNV1xJipNTthHhy0aNrJ7AUeBbYE0I4uiWxhVbDZCF6Si2DDSEcDiFcCMwCLgXeX/cGZnaLmT1uZo93qKMQxziuVYIQwh5gGXA5MMXMjjqCs4ByCxLUa1Z0lzq9ZqcBB0MIe8xsAnANcActw/0ssIjj6DXbTlU59bpUBVeksmb9OVVl56E8KfFBGqkJlJ/c+TF1ModTmcJVGx2pCZTPLq56P6nr1tmU8e/JT8JS1A1YqrPTNQNYaGYn03oi3x9C+ImZrQUWmdk3gSdpNVAWoqfU6TW7Grgocfw5Wv6sEI2hnS6RFU1nze6i1ar+DGB3YzceGdK1dwyl73tCCOXeqTRssMduavZ4LqsG0rV3dKKvXAKRFTJYkRX9Mti7+3TfTpCuveO49e2LDytEp8glEFnRqMGa2SfNbH0R9L2gyXvXwczuNbOdZram7dhUM1tqZhuL76f1U8ejmNlsM1tmZmuLwPpbi+MDp29XkwCKSnE9/wJOphWWOBcYC6wC5jd1/5o6XglcDKxpO/ZXwILi9QLgjn7rWegyA7i4eD0Z2ADMH0R9AQMmFa/HACuBy4D7gRuK43cBX6q8VoNKXw481CbfDtze7w8zoeccZ7DrgRltRrK+3zoOofdiWoFJA60vMBF4AvgIrU2Dd6TsY6ivJl2CmUB7d+Fcgr6nhxCOdkreDkzvpzIpzGwOrXiPlQyovt1KAtCk6zgIrUfBQC2rmNkk4AHgthDC6+0/GyR9wwiSANpp0mC3ArPb5CGDvgeMHWY2A6D4vrPP+hyjSAp9ALgvhPBgcXhg9YXOkgDaadJgfwbMK2aGY4EbgCUN3r9TltAKUIcOA9V7QZHNfA+wLoRwZ9uPBk5fM5tmZlOK10eTANbxdhIA1NW1YYf7Wlqz2WeBr/Z7ApDQ7/vANuAgLZ/qZuB04BFgI/AwMLXfeha6fpTWv/vVwFPF17WDqC9wAa0g/9XAGuBrxfG5wGPAJuCHwLiqa2mnS2SFJl0iK2SwIitksCIrZLAiK2SwIitksCIrZLAiK2SwIitksCIrZLAiK0ZksIOe8iJGHx3HEhTVDDfQirzZQisa68YQwtruqSdEzEgay10KbAqtKoaY2SLgOmBIgzWzMNLGxU0F69TR80TUpVe0v8ciMiv5pkdisKmUl49UKdVenLeqqzOUfxEHDx4sjelGJxZ/31QRYa+v16VbRlOn64rXpU5x5So60T/1x+SvU+f9tB87cODAkPfreetOM7sFuKXX9xEnBiMx2FopLyGEuylK0px00kmRS5D666zqY9Wrf33+uqny6VVjekWqrLw/1q/euJ18BiNpFTCSVYJcU15ExnT8hA0hHDKzPwUeolUk494QwtNd00yIBI2myJx00kmhvZNJ6l9DlUtQp+tKN+jnzLxOpxZPv1yCOnj9fTcbf86BAwc4cuRIZ607hRgker5K4Gl/KqWWL/xTq1/ri/1c1xyUz6Bb1JnQ+nXYodATVmSFDFZkhQxWZEXTfbpCXV9FnFjUjSXQE1ZkhQxWZIUMVmRFX9dhhThKXbvQE1ZkhQxWZIUMVmSFDFZkReOTrtGED49Mhc35cMg6mQwnIgp+EaMSGazIChmsyAr5sCNg/Pjxkfzud7+7dI73WZ977rlIHuTUliaRDytGJTJYkRUyWJEVjfuwOQdw+3TlqVOnRvKHP/zh0pgPfOADkfy3f/u3kbxr164uadcb6qw1V43xpH7v7b58qn7asWtX3l2IAUIGK7JCBiuyQgYrskIbByPAF+adM2dO6Zzrr78+kv3GwT/8wz+UxvRrMjpu3LjSsenTp0fyWWedFcmpjY/XX389kvfu3RvJr732Wqcq6gkr8kIGK7JCBiuyoq8bBykGeTOhqmHIqaeeWhrjj5199tmRnFpkT9XA7QV1GpFs3749krdujbsCdKv5h4JfxKhEBiuyotJgzexeM9tpZmvajk01s6VmtrH4flpv1RSiRR0f9nvA3wP/1HZsAfBICOHbRY/ZBcBfdl+9wWLChAmR7P3Rc889t/Iay5cvj+RBqvT95ptvVo7pVcB51yq/hBCWA6+4w9cBC4vXC4FPH49yQnRKpz7s9BDCtuL1dmD6cCcL0S1GvKwVQghmNuTzXK07RTfp9Am7w8xmABTfdw51Ygjh7hDCJSGESzq8lxDH6PQJuwT4IvDt4vviugNzyRJNdZz2k6xPfepTkfzBD36wNOall16K5GeeeSaSB+nzGCRdhqLOstb3gf8BzjWzLWZ2My1DvcbMNgK/WchC9JzKJ2wI4cYhfvSJLusiRCXa6RJZoQDuAh8I4gOVAa644opI/uhHPxrJqWzPpUuXRrIPXq7T+DhFVSDOIAcRjQQ9YUVWyGBFVshgRVacsD6s9wF9oLVfYwX4zGc+E8lnnHFGJD/99NOlMf/+7/8+rB4+oAbK1VVSAd0HDhyIZF8lUT6sEAOADFZkhQxWZIUMVmTFCTvp8hObK6+8MpJvuumm0ph58+ZFsq/ismTJktKYZ599NpLf+c53RvKHPvSh0piZM2dG8quvvlo6Z/Xq1ZHcjWzWHNATVmSFDFZkhQxWZMWo9GH9pkAqGNu3KPqt3/qtSD7ttHLm+rZt2yJ5xYoVkbx+/frSmMmTJ0fyNddcE8l/+Id/WBrjNwpefPHF0jn/+I//GMkvv/xyJL/xxhulMaNhM0FPWJEVMliRFTJYkRXWpF8zXDr4CK8byb4i4OzZs0tjvvCFL0TyF7/4xUj2vieUfUtfWfpXv/pVaYxv7+mrdKfaCPnrbNq0qXSO959/8pOfRPLmzZtLY7yfu3NnnOzcVNXEOoQQkpHtesKKrJDBiqyQwYqskMGKrBgVky6/MeADTD7/+c+XxvjsgUsuiSsppYJH/ATJ37dOBqwfk7qPz77t5Hf01ltvlY6tXbs2kv2mRWrjo19o0iVGBTJYkRUyWJEV2QW/pPxEn3nqS7f7gBMoB0573zLVAsgvrO/ZsyeSd+3aVRqzf//+0rF2fOA1lDckfEA3pDc2qnjhhRci+bLLLovkV17xhdbLwePe5246UFxPWJEVMliRFTJYkRUyWJEVfe0128mCeKo367hx4yL5zDPPjGQfIZW6t49cSk1A/KRl48aNkZwqVeTv4ydhu3fvLo3xGwcTJ04snTN27NhInjp1aiSfc845pTHz58+P5KuuuiqSU5/Tz3/+80j+xS9+Ecl+4gll/f1k1ZdZ8qjXrBg11OlxMNvMlpnZWjN72sxuLY6rfadonDpP2EPAl0MI84HLgD8xs/m83b5zHvBIIQvRU+o05dgGbCte7zWzdcBMWu07rypOWwj8lBr9ZjstkX6UlA/rF6+3b98eyf/1X/9VeR3fZ3XDhg2lMf66PovWR/RDeeG9qkxmilRWgi8PeuGFF0byxz72sdKYSy+9NJL9Z+A3LKDsC0+fHje99NVvoPxZ+s8tlQ1RdwPiuHxYM5sDXASsRO07RR+ovUpgZpOAB4DbQgivu9n+kO071bpTdJNaT1gzG0PLWO8LITxYHK7VvlOtO0U3qXzCWutReg+wLoRwZ9uPOmrfebw+rF+TS/k63mfyftU999xTGrNv375I9r6mX9sFmDJlSiT7gJlU2yO/Bumvm6pK49/jpEmTSue85z3vieSrr746kn1AOpTXc70/nVp79v6nDzTy7UyhnCnsKzh63x9iX3647N06LsEVwOeBX5jZU8Wxr9Ay1PuLVp4vAJ+rcS0hRkSdVYJHgaEei2rfKRpFO10iK2SwIiv6mnHQSfBLatLlA0p8xmhqMlGliw8ugfKiuZdTEyg/yfzgBz8YyakySj7bITXp8tfxJe9TATN+ovlv//Zvkfytb32rNCa1mdBOahLt+5f595PSrb0803CbCHrCiqyQwYqskMGKrGi88stIA7ibIuVnnX766cPKqTLz3s+9/vrrIzkVpFKnoowPmvFyKsDEl5n/53/+50iuyvCti9c3lYE8HIcOHeLIkSOq/CLyRwYrskIGK7JiVFQvHGR8kLT357yPC/Dxj388kn3LUCj7yzt27Ijk559/vjTm4YcfHnZMU6R88vbP6fDhw6peKEYHMliRFTJYkRUyWJEVmnT1mKoMi1TAjJ+Ypa5RlcngMwMAXnvttUhOlZXvF+2TriNHjmjSJUYHMliRFTJYkRUKfhmlpCrkeJou9z4c8mHFqEQGK7JCBiuyovEkRPmtzTBI/qmnKllTSYhi1CCDFVkhgxVZIYMVWZFdr1mRH3VKrNadjOsJK7JCBiuyQgYrsiK71p1V10zJnVwjtXid+6aHX7CvU46/E6p+H6nfj3xYMSqRwYqsqNNrdryZPWZmq4pes98ojr/XzFaa2SYz+4GZlSsAC9FlKgO4i7ZHp4QQ9hX9uh4FbgX+AngwhLDIzO4CVoUQvlNxreADdY9b4Q7809R79AHOVf4dlPWt43d5ff2YTv3iqs8h9fOqKoJVbeHrUlV9MfWe24+NKIA7tDhaa3xM8RWAq4EfFccXAp+uupYQI6VuJ8STix5dO4GlwLPAnhDC0aKkW2g1TE6NvcXMHjezx7uhsDixqWWwIYTDIYQLgVnApcD7695ArTtFNzmuVYIQwh5gGXA5MMXMjjpFs4CtXdZNiBJ1es1OAw6GEPaY2QTgGuAOWob7WWARx9Frtp1UZmedbE9PJ5O3qglIatLiWyH5c1K9Zqsmc6kx/v1Mnjy5dE5VdZhUv1Z/zN879dlXTQrr/A697MvbQ/3JdJ2drhnAQjM7mdYT+f4Qwk/MbC2wyMy+CTxJq4GyED2lTq/Z1cBFiePP0fJnhWgM7XSJrGi68ssuWq3qzwB2N3bjkSFde8dQ+r4nhDAtNaBRgz12U7PHc1nmkq69oxN95RKIrJDBiqzol8He3af7doJ07R3HrW9ffFghOkUugciKRg3WzD5pZuuLoO8FTd67DmZ2r5ntNLM1bcemmtlSM9tYfC+37O4DZjbbzJaZ2doisP7W4vjA6dvVJIAQQiNfwMm0whLnAmOBVcD8pu5fU8crgYuBNW3H/gpYULxeANzRbz0LXWYAFxevJwMbgPmDqC9gwKTi9RhgJXAZcD9wQ3H8LuBLlddqUOnLgYfa5NuB2/v9YSb0nOMMdj0wo81I1vdbxyH0XkwrMGmg9QUmAk8AH6G1afCOlH0M9dWkSzAT2NwmDxn0PWBMDyFsK15vB8rdjPuMmc2hFe+xkgHVdyRJAO1o0nUchNajYKCWVcxsEvAAcFsI4fX2nw2SvmEESQDtNGmwW4HZbXIuQd87zGwGQPF9Z5/1OUaRFPoAcF8I4cHi8MDqCyNPAmjSYH8GzCtmhmOBG4AlDd6/U5bQClCHDgPVe0GRzXwPsC6EcGfbjwZOXzObZmZTitdHkwDW8XYSANTVtWGH+1pas9lnga/2ewKQ0O/7wDbgIC2f6mbgdOARYCPwMDC133oWun6U1r/71cBTxde1g6gvcAGtIP/VwBrga8XxucBjwCbgh8C4qmtpp0tkhSZdIitksCIrZLAiK2SwIitksCIrZLAiK2SwIitksCIrZLAiK2SwIitGZLCDnvIiRh8dxxIU1Qw30Iq82UIrGuvGEMLa7qknRMxIGstdCmwKrSqGmNki4DpgSIM1s9CLxnLdwNcwTek2SPrmTFUt2CIyK3nSSAw2lfLykeEGmBnjxo07JqeK+XqjqGMknXRq8QY6fvz4SK5TENgXHq7T4a8To09dtxvdaTr5bOsUnK7SzRd59qTs4ig9b91pZrcAt/T6PuLEYCQGWyvlJYRwN0VJGjML7X89nfzbTT1t/F996ulYdR//V526Rie6dYNuPS27ce86n21Vb9mqPr7DvZeRrBLkmvIiMqbjJ2wI4ZCZ/SnwEK0iGfeGEJ7ummZCJGi6Andod7ibcglS1/TX8V1ZOnEJ6nRh6dbnXacdZhW9+t1XuQRVn9Phw4eHXCXQTpfIisafsO1/XZ1MJro16RL9YyTrsHrCiqyQwYqskMGKrOj5TtfxUuXXpn4unzUvRjJv0hNWZIUMVmSFDFZkReM+bN0gByFS6AkrskIGK7JCBiuyQgYrsmLgNg7EiUnd5FQ9YUVWyGBFVshgRVbIhx0l+CD2VJC0z1YdpI2burroCSuyQgYrskIGK7Kir8EvonO8j+prg/m0dYB9+/ZF8iD9LrQOK0YlMliRFTJYkRUyWJEV2jjIgFQtqunTp0fyzJkzI9lPwgA2bdoUydu3b++Cds2iJ6zIChmsyAoZrMiKxn3YQeki4xtDDFJgiPdZL7zwwtI511xzTSR/6EMfiuS33nqrNMb7rN/61rci2W8sNImCX8SoRAYrsqLSYM3sXjPbaWZr2o5NNbOlZrax+H5ab9UUokUdH/Z7wN8D/9R2bAHwSAjh20WP2QXAX9a5YRO+oQ8MSTUye+c73xnJ7Q3vUj8H2L9/fyS//vrrw94XYMyYMZHsfcspU6aUxlxwwQWRfNNNN5XOmT9/fiRPnjw5klPv+ZlnnhlWtxyofMKGEJYDr7jD1wELi9cLgU93WS8hknTqw04PIWwrXm8Hpg93shDdYsTLWiGEYGZD/p9X607RTTp9wu4wsxkAxfedQ50YQrg7hHBJCOGSDu8lxDE6fcIuAb4IfLv4vrjuwF5sHFQ1MktNQGbMmBHJ5513XiRffvnlpTEvvPBCJPsJVGqiVtWw7uyzzy6N8bqkNg7Gjh1bOtbO3r17S8eq9M+BOsta3wf+BzjXzLaY2c20DPUaM9sI/GYhC9FzKp+wIYQbh/jRJ7qsixCVaKdLZMWoCODupGnxqaeeGskHDhyI5JR/N3Xq1EieNWtWJPsFf4DTTz89kidMmBDJKf/a+7mptk5+E8MH7/hNDSgHv+TYLkpPWJEVMliRFTJYkRWjwoetIuUn+mDlLVu2RPL69etLY84555xIPvPMMyPZ+6dQ9oVfeSUOy9izZ09pzBtvvBHJ3l+FchLiGWecEcl11rhTvv2gk5/G4oRGBiuyQgYrskIGK7JiVE66/ITDT2IA1q5dG8l+4T2FDx5ZsWJFJJ977rmlMT745fnnn4/kiRMnVt530qRJpWPnn39+JF9//fWR/O53v7s0xmc3+OumJneDVJIT9IQVmSGDFVkhgxVZcUKUjE/d89ChQ8OOSS2q+00ALz/22GOlMd439t9guqQAAAhuSURBVHIq09b7vb4yIZTfk9cl5ZO/613vimTv5/7qV78qjfHHevX7U8l4MSqRwYqskMGKrBiV67C9oirZMRUQXeXzpXxYfyxVHebjH/94JF9xxRWRnFq79QmP06ZNi+StW7eWxnz961+P5F/+8peRXDUXqIt8WDEqkcGKrJDBiqyQwYqsOGFLxvuJjdelTjBMN+6bqhbjJ1B/8Ad/UDrnqquuiuRTTjml8t4+28FPzObMmVMa4yd8dbIUOvm91s1+0BNWZIUMVmSFDFZkxajYOPBZsT54JOVTHTx4sKc6HcXr5kvTf/azny2NufHGuJzZ3LlzS+ecdlrcVsKXf0+9Z6+LD2z3Qe0A27Zti2T/uXVrHqK2R2JUIoMVWSGDFVkhgxVZkV3GQWqB2U9k/IL4q6++2nU9UqT6Xvny774k55/92Z+VxvgyRKnMWv85+MnQm2++WRqzefPmSF68OK70/7Of/aw0ZteuXZHcqw0VTbrEqKROj4PZZrbMzNaa2dNmdmtxXO07RePUecIeAr4cQpgPXAb8iZnN5+32nfOARwpZiJ5SpynHNmBb8Xqvma0DZtJq33lVcdpC4KfU7Dc7EvymAJT7rPrIeu+7Qbncps8WSG0seD/L39f7q1AOUvnt3/7tSJ43b15pjPdPU5kMviT8hg0bInndunWlMY8//ngk/+d//mck79xZbreWqgbTC3riw5rZHOAiYCVq3yn6QO1VAjObBDwA3BZCeN2FCQ7ZvlOtO0U3qfWENbMxtIz1vhDCg8XhWu071bpTdJPKJ6y1HqX3AOtCCHe2/ajj9p0jIbUO67M/P/WpT0Xya6+9VhrjK6X4lkB+/RHK66Ef+MAHIjnV7tOf46uvpNZuvT/nA68Bli9fHsmLFi2K5P/93/8tjfF+uw9+6dUaax3qBvbXcQmuAD4P/MLMniqOfYWWod5ftPJ8Afhcp8oKUZc6qwSPAuXk+RZq3ykaRTtdIitksCIrsss4SDnkY8eOjeT3ve99kTx//vzSGB9g4ic2qRI8PsrfZ6qmyg75iY5fiPeTPSgH6yxdurR0zo9//ONI9psCTS34d0Lqc6qLnrAiK2SwIitksCIrRoUP6/01v1GQagHkg7xPP/3049bFB8j4UpQA//qv/xrJzzzzTCQfOHCgNGbTpk2RvGrVqtI53jcepPZE3kf12bqpzZ/2TYvhSnjqCSuyQgYrskIGK7LCmvR9hgpBPM5rlI75JETfQvPv/u7vSmPOOeecSPZrualAcb8+umTJkkh+6KGHSmP++7//O5L37t1bOidn6rRt8gE+48ePL41pnw+88cYbHD58OLlYqyesyAoZrMgKGazIChmsyIrGJ10jLRmfcvK9U+/LnP/+7/9+acxZZ50VyX5x22fEAjz55JORvGLFikh+6aWXSmN8BRb/nusEggzSpkAn+PeY2jho//wPHjzIkSNHNOkS+SODFVkhgxVZ0bgP2+6/dCtL0/tIfhPAZ9VC2Wf1ARcpH3bPnj2RvHv37mGvIerj5zYhBPmwIn9ksCIrZLAiK/rqw6bohl/rfdrUWmcn7zv39dBBRj6sGJXIYEVWyGBFVshgRVY0njXbPulKTWKqgkHqTHz8OZosDT51g6L0hBVZIYMVWSGDFVnRqA9rZpU+aqqEejupAJNebDaMRr93UN5jygbag5Hkw4pRQ53WnePN7DEzW1W07vxGcfy9ZrbSzDaZ2Q/MbGzVtYQYKXWesG8BV4cQPgRcCHzSzC4D7gD+XwjhfcCrwM29U1OIFnWacgTgaKm8McVXAK4GbiqOLwT+L/CdqutVBb/4qiFe9u2KoFwBsBvJjT7AO0WqpabH6+Lff5Othrrhs9ZJmqw6pyoJccTVC83s5KLl0U5gKfAssCeEcPTKW2j1nxWip9Qy2BDC4RDChcAs4FLg/XVvYGa3mNnjZvb4aJx5i2Y5rlWCEMIeYBlwOTDFzI7+v54FbB1izLHWnSNpxiAE1FslmGZmU4rXE4BrgHW0DPezxWmNte4UJzZ1Ng5mAAvN7GRaBn5/COEnZrYWWGRm3wSepNWPtpL2SUadJ66flNQJmPFOfZ3JkZ/cpSZdVbqkJlBel25Vu+nFBCr1nr3+nUwa/Wdb9Tsczi7qrBKsBi5KHH+Olj8rRGNop0tkhQxWZEXTWbO7aLWqPwPYXXH6oCBde8dQ+r4nhFAu10PDBnvspq012Usav3EHSNfe0Ym+cglEVshgRVb0y2Dv7tN9O0G69o7j1rcvPqwQnSKXQGRFowZrZp80s/VFlsKCJu9dBzO718x2mtmatmNTzWypmW0svp/WTx2PYmazzWyZma0tMkFuLY4PnL5dzVopKsX1/As4mVYc7VxgLLAKmN/U/WvqeCVwMbCm7dhfAQuK1wuAO/qtZ6HLDODi4vVkYAMwfxD1BQyYVLweA6wELgPuB24ojt8FfKnyWg0qfTnwUJt8O3B7vz/MhJ5znMGuB2a0Gcn6fus4hN6LaUXSDbS+wETgCeAjtDYN3pGyj6G+mnQJZgKb2+RcshSmhxC2Fa+3A9P7qUwKM5tDK0BpJQOqb7eyVjTpOg5C61EwUMsqZjYJeAC4LYTwevvPBknfMIKslXaaNNitwOw2ecgshQFjh5nNACi+7+yzPscwszG0jPW+EMKDxeGB1Rc6y1ppp0mD/Rkwr5gZjgVuAJY0eP9OWUIrowIGKLPCWlHO9wDrQgh3tv1o4PTtatZKww73tbRms88CX+33BCCh3/eBbcBBWj7VzcDpwCPARuBhYGq/9Sx0/Sitf/ergaeKr2sHUV/gAlpZKauBNcDXiuNzgceATcAPgXFV19JOl8gKTbpEVshgRVbIYEVWyGBFVshgRVbIYEVWyGBFVshgRVb8f/z6O/cqDuC8AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 576x2160 with 10 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "_, axes = plt.subplots(10, 1, figsize=(8, 30))\n",
+    "for i in range(10):\n",
+    "    axes[i].imshow(fake_imgs[i][0].numpy(), cmap='gray')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
@zachbellay I created a notebook that implements DCGAN. It builds upon [this example](https://github.com/pytorch/examples/tree/master/dcgan). The notebook can be inspected [here](https://github.com/skorch-dev/skorch/blob/feature/dcgan-notebook/notebooks/dcgan.ipynb).

I have made some slight adjustments to better fit skorch but overall found that I had to change surprisingly little.

However, I would strongly assume that other GANs need many more adjustments, e.g. using different optimizers for generator and discriminator, or not training them in lockstep. For such cases, it's probably best to use pure pytorch.