### PR TITLE
[RFC] Feature facilitate customization of net

### DIFF
--- a/notebooks/dcgan.ipynb
+++ b/notebooks/dcgan.ipynb
@@ -1,0 +1,627 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DCGan with skorch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Code is adapted from [pytorch examples](https://github.com/pytorch/examples/tree/master/dcgan)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "%pylab inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.parallel\n",
+    "import torch.optim as optim\n",
+    "import torch.utils.data\n",
+    "import torchvision.datasets as dset\n",
+    "import torchvision.transforms as transforms\n",
+    "import torchvision.utils as vutils"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from skorch import NeuralNet\n",
+    "from skorch.utils import to_tensor\n",
+    "from skorch.callbacks import PassthroughScoring"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "torch.manual_seed(0)\n",
+    "device = torch.device(\"cuda:0\") if torch.cuda.is_available() else 'cpu'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nz = 100  # size of the latent z vector\n",
+    "ngf = 32  # units of generator\n",
+    "ndf = 32  # units of discriminator\n",
+    "nc = 1  # number of channels\n",
+    "batch_size = 64\n",
+    "lr = 0.0002\n",
+    "beta1 = 0.5  # for adam\n",
+    "max_epochs = 5\n",
+    "ngpu = 1\n",
+    "img_size = 32  # 32 is easier than 28 to work with\n",
+    "workers = 2  # for dataloader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = './mnist'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = dset.MNIST(\n",
+    "    root=path,\n",
+    "    download=True,\n",
+    "    transform=transforms.Compose([\n",
+    "        transforms.Resize(img_size),\n",
+    "        transforms.ToTensor(),\n",
+    "        transforms.Normalize((0.5,), (0.5,)),\n",
+    "    ]),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# custom weights initialization called on generator and discriminator\n",
+    "def weights_init(m):\n",
+    "    classname = m.__class__.__name__\n",
+    "    if classname.find('Conv') != -1:\n",
+    "        m.weight.data.normal_(0.0, 0.02)\n",
+    "    elif classname.find('BatchNorm') != -1:\n",
+    "        m.weight.data.normal_(1.0, 0.02)\n",
+    "        m.bias.data.fill_(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Generator(nn.Module):\n",
+    "    def __init__(self, nz, ngf, ngpu):\n",
+    "        super().__init__()\n",
+    "        self.nz = nz\n",
+    "        self.ngf = ngf\n",
+    "        self.ngpu = ngpu\n",
+    "\n",
+    "        self.main = nn.Sequential(\n",
+    "            # input is Z, going into a convolution\n",
+    "            nn.ConvTranspose2d(     nz, ngf * 4, 4, 1, 0, bias=False),\n",
+    "            nn.BatchNorm2d(ngf * 4),\n",
+    "            nn.ReLU(True),\n",
+    "            # state size. (ngf*4) x 4 x 4\n",
+    "            nn.ConvTranspose2d(ngf * 4, ngf * 2, 4, 2, 1, bias=False),\n",
+    "            nn.BatchNorm2d(ngf * 2),\n",
+    "            nn.ReLU(True),\n",
+    "            # state size. (ngf*2) x 8 x 8\n",
+    "            nn.ConvTranspose2d(ngf * 2, ngf, 4, 2, 1, bias=False),\n",
+    "            nn.BatchNorm2d(ngf),\n",
+    "            nn.ReLU(True),\n",
+    "            # state size. (ngf) x 16 x 16\n",
+    "            nn.ConvTranspose2d(ngf,     nc, 4, 2, 1, bias=False),\n",
+    "            nn.Tanh(),\n",
+    "            # state size. (nc) x 32 x 32\n",
+    "        )\n",
+    "\n",
+    "    def forward(self, input):\n",
+    "        if input.is_cuda and self.ngpu > 1:\n",
+    "            output = nn.parallel.data_parallel(self.main, input, range(self.ngpu))\n",
+    "        else:\n",
+    "            output = self.main(input)\n",
+    "        return output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Discriminator(nn.Module):\n",
+    "    def __init__(self, nc, ndf, ngpu):\n",
+    "        super().__init__()\n",
+    "        self.nc = nc\n",
+    "        self.ndf = ndf\n",
+    "        self.ngpu = ngpu\n",
+    "\n",
+    "        self.main = nn.Sequential(\n",
+    "            # state size. (ndf) x 32 x 32\n",
+    "            nn.Conv2d(nc, ndf, 4, 2, 1, bias=False),\n",
+    "            nn.LeakyReLU(0.2, inplace=True),\n",
+    "            # state size. (ndf) x 16 x 16\n",
+    "            nn.Conv2d(ndf, ndf * 2, 4, 2, 1, bias=False),\n",
+    "            nn.BatchNorm2d(ndf * 2),\n",
+    "            nn.LeakyReLU(0.2, inplace=True),\n",
+    "            # state size. (ndf*2) x 8 x 8\n",
+    "            nn.Conv2d(ndf * 2, ndf * 4, 4, 2, 1, bias=False),\n",
+    "            nn.BatchNorm2d(ndf * 4),\n",
+    "            nn.LeakyReLU(0.2, inplace=True),\n",
+    "            # state size. (ndf*4) x 4 x 4\n",
+    "            nn.Conv2d(ndf * 4, 1, 4, 1, 0, bias=False),\n",
+    "            nn.Sigmoid()\n",
+    "        )\n",
+    "\n",
+    "    def forward(self, input):\n",
+    "        if input.is_cuda and self.ngpu > 1:\n",
+    "            output = nn.parallel.data_parallel(self.main, input, range(self.ngpu))\n",
+    "        else:\n",
+    "            output = self.main(input)\n",
+    "\n",
+    "        return output.view(-1, 1).squeeze(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Dcgan(nn.Module):\n",
+    "    def __init__(self, nc, nz, ndf, ngf, ngpu):\n",
+    "        super().__init__()\n",
+    "        \n",
+    "        self.nc = nc\n",
+    "        self.nz = nz\n",
+    "        self.ndf = ndf\n",
+    "        self.ngf = ngf\n",
+    "        self.ngpu = ngpu\n",
+    "\n",
+    "        self.discriminator = Discriminator(\n",
+    "            nc=self.nc,\n",
+    "            ndf=self.ndf,\n",
+    "            ngpu=self.ngpu,\n",
+    "        )\n",
+    "        self.discriminator.apply(weights_init)\n",
+    "        self.generator = Generator(\n",
+    "            nz=self.nz,\n",
+    "            ngf=self.ngf,\n",
+    "            ngpu=self.ngpu,\n",
+    "        )\n",
+    "        self.discriminator.apply(weights_init)\n",
+    "        \n",
+    "    def forward(self, X, y=None):\n",
+    "        # general forward method just returns fake images\n",
+    "        return self.generator(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class DcganNet(NeuralNet):\n",
+    "    def __init__(self, *args, optimizer_gen, optimizer_dis, **kwargs):\n",
+    "        self.optimizer_gen = optimizer_gen\n",
+    "        self.optimizer_dis = optimizer_dis\n",
+    "        super().__init__(*args, **kwargs)\n",
+    "\n",
+    "    def initialize_optimizer(self, *_, **__):\n",
+    "        args, kwargs = self.get_params_for_optimizer(\n",
+    "            'optimizer_gen', self.module_.generator.named_parameters())\n",
+    "        self.optimizer_gen_ = self.optimizer_gen(*args, **kwargs)\n",
+    "\n",
+    "        args, kwargs = self.get_params_for_optimizer(\n",
+    "            'optimizer_dis', self.module_.discriminator.named_parameters())\n",
+    "        self.optimizer_dis_ = self.optimizer_dis(*args, **kwargs)\n",
+    "\n",
+    "        return self\n",
+    "    \n",
+    "    def validation_step(self, Xi, yi, **fit_params):\n",
+    "        raise NotImplementedError\n",
+    "    \n",
+    "    def train_step(self, Xi, yi=None, **fit_params):\n",
+    "        Xi = to_tensor(Xi, device=self.device)\n",
+    "        discriminator = self.module_.discriminator\n",
+    "        generator = self.module_.generator\n",
+    "        label_real = torch.ones((len(Xi),),device=self.device)\n",
+    "        label_fake = torch.zeros((len(Xi),),device=self.device)\n",
+    "\n",
+    "        # (1) Update discriminator: maximize log(D(x)) + log(1 - D(G(z)))\n",
+    "        discriminator.zero_grad()\n",
+    "        output_real = discriminator(Xi)\n",
+    "        loss_real = self.criterion_(output_real, label_real)\n",
+    "        loss_real.backward()\n",
+    "\n",
+    "        noise = torch.randn(Xi.shape[0], self.module_.nz, 1, 1, device=self.device)\n",
+    "        fake = generator(noise)\n",
+    "        output_fake = discriminator(fake.detach())\n",
+    "        loss_fake = self.criterion_(output_fake, label_fake)\n",
+    "        loss_fake.backward()\n",
+    "        \n",
+    "        self.optimizer_dis_.step()\n",
+    "        \n",
+    "        # (2) Update generator: maximize log(D(G(z)))\n",
+    "        generator.zero_grad()\n",
+    "        output_fake = discriminator(fake)\n",
+    "        loss_gen = self.criterion_(output_fake, label_real)\n",
+    "        loss_gen.backward()\n",
+    "        self.optimizer_gen_.step()\n",
+    "        \n",
+    "        loss_dis = loss_real + loss_fake\n",
+    "        \n",
+    "        self.history.record_batch('loss_dis', loss_dis.item())\n",
+    "        self.history.record_batch('loss_gen', loss_gen.item())\n",
+    "        \n",
+    "        return {\n",
+    "            'y_pred': fake,\n",
+    "            'loss': loss_dis + loss_gen,\n",
+    "        }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "net = DcganNet(\n",
+    "    Dcgan,\n",
+    "    module__nz=nz,\n",
+    "    module__ndf=ndf,\n",
+    "    module__ngf=ngf,\n",
+    "    module__nc=nc,\n",
+    "    module__ngpu=ngpu,\n",
+    "    \n",
+    "    criterion=nn.BCELoss,\n",
+    "\n",
+    "    optimizer_gen=optim.Adam,\n",
+    "    optimizer_gen__lr=0.0002,\n",
+    "    optimizer_gen__betas=(beta1, 0.999),\n",
+    "\n",
+    "    optimizer_dis=optim.Adam,\n",
+    "    optimizer_dis__lr=0.00002,\n",
+    "    optimizer_dis__betas=(beta1, 0.999),\n",
+    "\n",
+    "    batch_size=batch_size,\n",
+    "    max_epochs=max_epochs,\n",
+    "\n",
+    "    train_split=False,  # not implemented\n",
+    "    iterator_train__shuffle=True,\n",
+    "    iterator_train__num_workers=workers,\n",
+    "    iterator_valid__num_workers=workers,\n",
+    "\n",
+    "    callbacks=[\n",
+    "        PassthroughScoring('loss_dis', on_train=True),\n",
+    "        PassthroughScoring('loss_gen', on_train=True),\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train net"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<class '__main__.DcganNet'>[uninitialized](\n",
+       "  module=<class '__main__.Dcgan'>,\n",
+       "  module_=Dcgan(\n",
+       "    (discriminator): Discriminator(\n",
+       "      (main): Sequential(\n",
+       "        (0): Conv2d(1, 32, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (1): LeakyReLU(negative_slope=0.2, inplace=True)\n",
+       "        (2): Conv2d(32, 64, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (3): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "        (4): LeakyReLU(negative_slope=0.2, inplace=True)\n",
+       "        (5): Conv2d(64, 128, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (6): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "        (7): LeakyReLU(negative_slope=0.2, inplace=True)\n",
+       "        (8): Conv2d(128, 1, kernel_size=(4, 4), stride=(1, 1), bias=False)\n",
+       "        (9): Sigmoid()\n",
+       "      )\n",
+       "    )\n",
+       "    (generator): Generator(\n",
+       "      (main): Sequential(\n",
+       "        (0): ConvTranspose2d(100, 128, kernel_size=(4, 4), stride=(1, 1), bias=False)\n",
+       "        (1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "        (2): ReLU(inplace=True)\n",
+       "        (3): ConvTranspose2d(128, 64, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (4): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "        (5): ReLU(inplace=True)\n",
+       "        (6): ConvTranspose2d(64, 32, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (7): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "        (8): ReLU(inplace=True)\n",
+       "        (9): ConvTranspose2d(32, 1, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (10): Tanh()\n",
+       "      )\n",
+       "    )\n",
+       "  ),\n",
+       "  module__nc=1,\n",
+       "  module__ndf=32,\n",
+       "  module__ngf=32,\n",
+       "  module__ngpu=1,\n",
+       "  module__nz=100,\n",
+       ")"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "net.set_params(optimizer_gen__lr=0.0003, optimizer_dis__lr=0.0004)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  epoch    loss_dis    loss_gen    train_loss       dur\n",
+      "-------  ----------  ----------  ------------  --------\n",
+      "      1      \u001b[36m0.4713\u001b[0m      \u001b[32m3.2007\u001b[0m        \u001b[35m3.6720\u001b[0m  288.9744\n",
+      "      2      0.4876      \u001b[32m2.8905\u001b[0m        \u001b[35m3.3781\u001b[0m  363.5930\n",
+      "      3      \u001b[36m0.3492\u001b[0m      3.6009        3.9501  300.6626\n",
+      "      4      \u001b[36m0.3198\u001b[0m      3.7600        4.0798  297.8958\n",
+      "      5      \u001b[36m0.1154\u001b[0m      5.0819        5.1972  293.7685\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<class '__main__.DcganNet'>[initialized](\n",
+       "  module_=Dcgan(\n",
+       "    (discriminator): Discriminator(\n",
+       "      (main): Sequential(\n",
+       "        (0): Conv2d(1, 32, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (1): LeakyReLU(negative_slope=0.2, inplace=True)\n",
+       "        (2): Conv2d(32, 64, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (3): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "        (4): LeakyReLU(negative_slope=0.2, inplace=True)\n",
+       "        (5): Conv2d(64, 128, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (6): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "        (7): LeakyReLU(negative_slope=0.2, inplace=True)\n",
+       "        (8): Conv2d(128, 1, kernel_size=(4, 4), stride=(1, 1), bias=False)\n",
+       "        (9): Sigmoid()\n",
+       "      )\n",
+       "    )\n",
+       "    (generator): Generator(\n",
+       "      (main): Sequential(\n",
+       "        (0): ConvTranspose2d(100, 128, kernel_size=(4, 4), stride=(1, 1), bias=False)\n",
+       "        (1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "        (2): ReLU(inplace=True)\n",
+       "        (3): ConvTranspose2d(128, 64, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (4): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "        (5): ReLU(inplace=True)\n",
+       "        (6): ConvTranspose2d(64, 32, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (7): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "        (8): ReLU(inplace=True)\n",
+       "        (9): ConvTranspose2d(32, 1, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1), bias=False)\n",
+       "        (10): Tanh()\n",
+       "      )\n",
+       "    )\n",
+       "  ),\n",
+       ")"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#net.fit(torch.utils.data.Subset(dataset, torch.arange(0, 500)))\n",
+    "net.fit(dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7efd1c0d2710>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nO3deXxU9b3/8dc3k8lCyAJJBBQQcAOBJEjYalnktrghSMUqqIi2UPVq6e1VH251qd5brffXqt2odUOLCIIi1t2LFBSuNtCALCKCUIMsSYAEzD75/v44k31CJpKZOUnez8djHjmZOXPOJyfMO1++53u+x1hrERER94qKdAEiInJ8CmoREZdTUIuIuJyCWkTE5RTUIiIuFx2Kjaalpdl+/fqFYtMiIh3S+vXrC6y16YFeC0lQ9+vXj5ycnFBsWkSkQzLG7GnuNXV9iIi4nIJaRMTlFNQiIi4Xkj7qQCorK8nLy6OsrCxcu5QIiYuLo3fv3ni93kiXItIhhC2o8/LySExMpF+/fhhjwrVbCTNrLYWFheTl5dG/f/9IlyPSIYSt66OsrIzU1FSFdAdnjCE1NVX/cxJpQ2Hto1ZIdw76PYu0LZ1MFBFpC//6P/jwsZBsOqigNsbsNsZ8aozJNca02ytZunbtGtb9fP3110yfPv2Et7dixQoefvjhVr3noosu4siRI99qf8uXL2fr1q3f6r0inU5VBbx/Pzx7Iax/Diq+afNdtOZk4nnW2oI2r6ADO/nkk1m6dOkJbaOqqoopU6YwZcqUVr3vzTff/Nb7XL58OZMnT+bss88O+j1VVVVER4ft3LSIOxzYCq/MhQOfwrBr4IJfQUxCm++mU3Z9WGu57bbbGDJkCEOHDmXx4sUA7Nu3j3HjxpGVlcWQIUNYs2YNPp+P2bNn167729/+tsn2vvzyS8aMGcPQoUO55557ap/fvXs3Q4YMAWDLli2MHDmSrKwsMjIy2LFjBwDPP/88GRkZZGZmcs011wAwe/ZsbrjhBkaNGsXtt9/Oc889x80331z72o033sjo0aMZMGAAq1at4vrrr2fQoEHMnj27dt/9+vWjoKCA3bt3M2jQIObMmcPgwYOZNGkSpaWlAPzlL39hxIgRZGZmctlll1FSUsLatWtZsWIFt912G1lZWezcuZPc3FxGjx5NRkYG06ZN4/DhwwBMmDCBn/3sZ2RnZ/P444+38W9JxMWqffDRE/DkeDi2H2a8BFN/D7GJIdldsE0gC7xrjLHAn621T57ITh94fQtbvy4+kU00cfbJSdx3yeCg1n3llVfIzc1l48aNFBQUMGLECMaNG8eLL77I+eefz913343P56OkpITc3Fz27t3L5s2bAQJ2J8ybN48bb7yRWbNm8Yc//CHgPufPn8+8efO46qqrqKiowOfzsWXLFh566CHWrl1LWloahw4dql0/Ly+PtWvX4vF4eO655xps6/Dhw6xbt44VK1YwZcoUPvroI5566ilGjBhBbm4uWVlZDdbfsWMHixYt4i9/+Qs//OEPWbZsGVdffTU/+MEPmDNnDgD33HMPTz/9NLfccgtTpkxh8uTJtd02GRkZ/O53v2P8+PHce++9PPDAAzz2mNMXV1FRoXldpHM5vAeW3wh7PoKBk+GSxyEhLaS7DLZF/V1r7TnAhcC/G2PGNV7BGDPXGJNjjMnJz89v0yLb2ocffsiMGTPweDz06NGD8ePH849//IMRI0bw7LPPcv/99/Ppp5+SmJjIgAED2LVrF7fccgtvv/02SUlJTbb30UcfMWPGDIDaVnFjY8aM4b//+7955JFH2LNnD/Hx8axcuZLLL7+ctDTnl9y9e/fa9S+//HI8Hk/AbV1yySUYYxg6dCg9evRg6NChREVFMXjwYHbv3t1k/f79+9eG9/Dhw2vX2bx5M2PHjmXo0KEsXLiQLVu2NHlvUVERR44cYfz48QBce+21rF69uvb1K664ImCNIh2OtfDPv8KfzoV9m+DSP8EVfw15SEOQLWpr7V7/14PGmFeBkcDqRus8CTwJkJ2dfdw75gbb8g23cePGsXr1at544w1mz57Nz3/+c2bNmsXGjRt55513mD9/PkuWLOGZZ55p8t6WhqTNnDmTUaNG8cYbb3DRRRfx5z//+bjrJyQ0388VGxsLQFRUVO1yzfdVVVXNrg/g8Xhquz5mz57N8uXLyczM5LnnnmPVqlXHram1dYp0GMfy4fV5sP0NOPW7cOkfodupYdt9iy1qY0yCMSaxZhmYBGwOdWGhNHbsWBYvXozP5yM/P5/Vq1czcuRI9uzZQ48ePZgzZw4//vGP2bBhAwUFBVRXV3PZZZfx0EMPsWHDhibbO/fcc3nppZcAWLhwYcB97tq1iwEDBvDTn/6UqVOnsmnTJiZOnMjLL79MYWEhQIOuj3A4evQovXr1orKyskHdiYmJHD16FIDk5GS6devGmjVrAHjhhRdqW9cincJnb8KfxsAX78Ok/4JrXw9rSENwLeoewKv+FmM08KK19u2QVhVi06ZNY926dWRmZmKM4de//jU9e/ZkwYIFPProo3i9Xrp27crzzz/P3r17ue6666iurgbgV7/6VZPtPf7448ycOZNHHnmEqVOnBtznkiVLeOGFF/B6vfTs2ZO77rqL7t27c/fddzN+/Hg8Hg/Dhg1r0h8dSg8++CCjRo0iPT2dUaNG1YbzlVdeyZw5c3jiiSdYunQpCxYs4IYbbqCkpIQBAwbw7LPPhq1GkYgpK4Z37nS6O3oOhVkroEfwI6HakrH2uL0U30p2drZtfIJp27ZtDBo0qM33Je6k37e0a3vWwqs/gaI8+O5/wPg7IDompLs0xqy31mYHek0DX0VEalSVw8qHYO3vnO6N696GvqMiXZWCWkQEgP2fwis/gYNbYPh1MOkhiA3P1cwtUVCLSOdW7YO1T8DK/4Iu3WHmy3DmpEhX1YCCWkQ6r0NfOhev/GsdDJoCkx+DhNRIV9WEglpEOh9rYcPz8M5dYKJg2p8h4wpw6RS9CmoR6VyOHYQVP4XP34L+42DqHyGlT6SrOq5ONSlTuKY5jaTc3NwTmjlPpEPb9jr8cTTs+gAueBiuec31IQ2dLKg7ikCXidf4NkF9vO2JdAhlRfDqjbD4akjuDXP/DqNvhKj2EYHto8o21tbTnO7cuZPRo0fXTnNav+X+6KOPMmLECDIyMrjvvvsAjjv16M6dO7ngggsYPnw4Y8eO5bPPPgOaTn36ySefMGbMGIYNG8Z3vvMdtm/fTkVFBffeey+LFy8mKyuLxYsXc+jQIS699FIyMjIYPXo0mzZtAuD+++/nmmuu4dxzz212IimRDuHLNc5ESptegnG3wY/eh5MGRrqqVolMH/VbdzhjFttSz6FwYXB3QQnFNKfz5s1jxowZzJ8/v/b5d999lx07dvDJJ59grWXKlCmsXr2avn37Njv16Ny5c5k/fz5nnHEGH3/8MTfddBMrV64EGk59WlxczJo1a4iOjub999/nrrvuYtmyZfzyl78kJyeH3//+9wDccsstDBs2jOXLl7Ny5UpmzZpFbm4uAFu3buXDDz8kPj7+hA69iCtVlsHKB2HdH6B7f7j+XegzItJVfSud8mTi8aY5vf7666msrOTSSy8lKyurwTSnF198MZMmNR1fuW7dOpYvXw44s+TdeuutgBPU7777LsOGDQPg2LFj7Nixg759+wacevTYsWOsXbuWyy+/vHbb5eXltcv1pz4tKiri2muvZceOHRhjqKysbPZnXbZsGQATJ06ksLCQ4mJnLvApU6YopKVj2rfRuXglfxtk/wgmPRiSO6+ES2SCOsiWb7idyDSngVhrufPOO/nJT37S4Pndu3cHnHq0urqalJSU2hZvY/WnFP3FL37Beeedx6uvvsru3buZMGFCq39eTVEqHY6vCj56DFY9DF1S4aplcMb3Il3VCeuUfdRtPc3p6NGja1utNdOdApx//vk888wzHDt2DIC9e/dy8ODBZutKSkqif//+vPzyy4AT9Bs3bgy4blFREaeccgpAgxn36k9RWvOz1kxhumrVKtLS0gLe/ECk3Svc6dxgduWDMGgy3LSuQ4Q0dNKgnjZtWu19CidOnFg7zemqVavIzMxk2LBhLF68mHnz5rF3714mTJhAVlYWV199dcBpTh977DF+85vfkJGRwRdffEFycjIAkyZNYubMmbX3U5w+fXqDEA1k4cKFPP3002RmZjJ48GBee+21gOvdfvvt3HnnnQwbNqzBqI3zzjuPrVu31p5MvP/++1m/fj0ZGRnccccdLFiw4ASOnIgLWQs5z8D8sVCwHX7wFEx/1rkcvIPQNKdtoKSkhPj4eIwxvPTSSyxatKjZgO0sOvLvW1zk6H5YcQvseBcGTHAuXkk+JdJVfSua5jTE1q9fz80334y1lpSUlKD7sEXkBGxZDn/7D6gsgQt/DSPmtJtx0a2loG4DY8eObbYvWUTaWOkReOt22LQYTh4G056E9DMjXVVIhTWorbUt3gRW2r9QdKeJALDr77D8Jji6z7nryrhbweONdFUhF7agjouLo7CwkNTUVIV1B2atpbCwkLi4uEiXIh1JZSm8/wB8/CdIPR1+9B70Hh7pqsImbEHdu3dv8vLyyM/PD9cuJULi4uLo3bt3pMuQjuLrfzoXrxRsh5Fz4XsPQEyXSFcVVmELaq/XS//+/cO1OxFp73xV8OFv4O+PQMJJcM2rcNrESFcVETqZKCLuU/CFcxfwvTkwZDpc/D8Q3y3SVUWMglpE3MNa+MdT8N694ImB6c/AkMsiXVXEKahFxB2K98Fr/w47/xdO+zeY+ntIOjnSVbmCglpEIm/zMvjbz6GqHC76HxjxY9fevzASFNQiEjmlh+GNW2HzUjhluHPxStrpka7KdRTUIhIZOz9wLl755iCcdzd89+fgUSQFoqMiIuFVUQLv3w+f/BnSzoQrF8Ip50S6KldTUItI+Oxd71y8UrgDRt0I37sPvLrLUEsU1CISer5KWP0/sPpRSOwJs15zpiWVoCioRSS0CnbAK3Ph6w2QcYUzJWl8SqSraleCDmpjjAfIAfZaayeHriQR6RCqq+suXvHGweULYPClka6qXWpNi3oesA3QDfdE5PiK9sJrN8GuVXD6952LVxJ7Rrqqdiuo2yEYY3oDFwNPhbYcEWn3Pl0KfxoDX30Ck38LV72skD5BwbaoHwNuBxKbW8EYMxeYC9C3b98Tr0xE2peSQ/DGf8KWV6D3SJg2H1JPi3RVHUKLLWpjzGTgoLV2/fHWs9Y+aa3NttZmp6ent1mBItIO7Hgf/jgGtq2Aib+A695SSLehYFrU5wJTjDEXAXFAkjHmr9baq0Nbmoi4XsU38O4vIOdpSB8IVy2BXpmRrqrDaTGorbV3AncCGGMmALcqpEWEvBxn2N2hXTDmZqcl7dUt2EJB46hFpHV8lfD3X8Oa/+dMQ3rt69B/bKSr6tBaFdTW2lXAqpBUIiLud/AzeHUu7NsImTPhwochLjnSVXV4alGLSMuqq+Hj+c5kSrFd4Yq/wqBLIl1Vp6GgFpHjO/KVc/HKl6vhzAvgkicgsUekq+pUFNQiEpi1sGkJvHkbVFc5AX3OLN15JQIU1CKdTVUFlBTANwV1XwMtHzsAh3dDn9HOxSvd+0e68k5LQS3S3tUGb74/ZAv9gZvvf76w4XJ5UeDtGA90SYWENOfryefA6Juc+xdGecL7M0kDCmoRt6kqb761G+i58uLA26kN3nRISIVeWf7ltLpATkiHLmnOclwKRAU1/Y+EmYJaJNRqgrd+q7ZJC7je8vGCNyGtLlhPHla3XP/5hHQniBW8HYaCWqS1KsuC6+OtWa44Gng7UdF1Ld4uqc59A2tbuKn+r/VawAreTktBLVI/eBuEbKAWcGELwZtWF6ynDG/U0m20HJeiERQSFAW1dA7H8mHzUjiwuWkgVxwL/J7a4PX38aacWrfcoJvB3wJW8EqIKKil46oqh8/fhtwXYcd7YH3QtWdd2HbvXxey9U+q1Z5cS1bwiisoqKVjsRb2boCNLzp3Gik7Aom94Ds3O3NTnDQw0hWKtJqCWjqG4q9h40uwcREUfA7RcTBwMmTNgAHnaRywtGsKamm/Kkrgszec1vOuVWCroe8Y51LnwZdqVjfpMBTU0r5YC/9a5/Q7b1nujMBI7gtjb4XMK3X7J+mQFNTSPhzeXde1cXg3eBOcVnPmDDj1XI0vlg5NQS3uVX4Utr4GuYtgz4eAce4kMv4OZy7k2K6RrlAkLBTU4i7VPmfe442LYNvrUFkC3U+DifdAxpWQ0ifSFYqEnYJa3KFgh9PvvGkxFO+F2GTIuAKyZkLvERrPLJ2agloip/QwbH7FaT3n/QNMFJz2bzDpQTjrYt3RWsRPQS3h5auCnf/rtJ63vwW+cjjpbPj+g5DxQ0jsGekKRVxHQS3hsX+z03LetAS+OehMWpR9nTNqo1emujZEjkNBLaHzTQF8+rLTet6/CaK8cOb5Tr/z6d+H6JhIVyjSLiiopW1VVTgTIW1cBDvedW6K2isLLvw1DJnuTIAkIq2ioJYTZy18/U8nnD9dCqWHnFnqRt/ktJ5PGhTpCkXaNXcF9YpbIL47pA+E9LMg7Uxd1OBmxfuc4XQbF0H+Z+CJhYEXQ9ZVMGACeNz1z0ukvXLPJ8lXBXnrnZnPqivrnk/u4wR2+kBI939NOxO6dI9crZ1ZZakzEVLui7DrA2cipD6jYPJjMHgaxKdEukKRDsc9Qe2JhpvWgq/Smcsh/zP/43Pn6561UFVat37CSU6rO/0sSPN/TR8IXU/SCIK2Zi189bF/IqRXnZuvJveBsf/pjNrQREgiIeWeoK7h8ULaGc5j0CV1z1dXQ9G/6oK7YDvkb4dNL0N5Ud16ccl1re6aLpT0syCptybuaa0j/6qbCOnQLmcipLOnOnM8n/pdHU+RMHFfUDcnKgq69XMeZ06qe95aOLq/LrhrHtvfgn++ULeet4s/vOu3wgc621Nfap3yY85ESBsXwe41znP9xsK422DQFJ0zEImA9p9QxkBSL+cxYELD174pbBjgBdth94fOCbAanhhIPb1RF8pZznPRseH8SSKnutoJ5Y2LnJCuLIHuA+C8eyDzCkjpG+kKRTq1FoPaGBMHrAZi/esvtdbeF+rC2kRCKiR8B079TsPny4qdSYAKttf1g3+d60xEj3XWMVHQrX/Tk5gdaSRK4c66iZCKvoLYJOcy7syZ0Gek+vpFXCKYFnU5MNFae8wY4wU+NMa8Za39vxDXFjpxSdB7uPOor7IUCr+o14XymTMKZcc7zoUbNZL7ND2JmX4mxHcL78/xbZQegS2vOHM8533inwhpInzvfmdonTc+0hWKSCMtBrW11gLH/N96/Q8byqIixhsPPYc6j/p8lXDoy4YnMfO3w+6PGo5E6dqj6UnMtLMiPxLFV+UMpct90Rla5yuH9EHw/V/C0B863UYi4lpB9VEbYzzAeuB04A/W2o8DrDMXmAvQt28H69P0eP3dH2c2fL52JEqjfvBNi50hbDXiUpqexEw/M/QjUQ5sdW78umkJHDvgXEw0fLYzaqNXlro2RNoJ4zSYg1zZmBTgVeAWa+3m5tbLzs62OTk5bVBeO2UtHN3XMLxrlksK6tbzJjjDEOu3wNMHQsqp334kyjeFsHkp5C6EfRshKhrOON8J5zPO10RIIi5ljFlvrc0O9Fqr0sBae8QY8wFwAdBsUHd6xkDSyc7jtPMavlY7EqXexTy718Cml+rW8cRA6hkNT2KmD3QuLAk0EqWqwpkAaeMi+Pwd58rOXplwwSMwdDokpIX25xWRkApm1Ec6UOkP6Xjg+8AjIa+so2ppJEr9fvCv/9loJIoHuvevO4mZdoYzWmXzUigpdPrIR9/gjNrocXbYfzQRCY1gWtS9gAX+fuooYIm19m+hLasTOt5IlIIdzuiT/M/qulBqRqJ4YmHgRU44nzZRF++IdEDBjPrYBAwLQy0SiDceemU4j/pq5kRJSNdESCIdnJpf7VXNnCgi0uFpVh0REZdTUIuIuJyCWkTE5RTUIiIup6AWEXE5BbWIiMspqEVEXE5BLSLicgpqERGXU1CLiLicglpExOUU1CIiLqegFhFxOQW1iIjLKahFRFxOQS0i4nIKahERl1NQi4i4nIJaRMTlFNQiIi6noBYRcTkFtYiIyymoRURcTkEtIuJyCmoREZdTUIuIuJyCWkTE5RTUIiIup6AWEXE5BbWIiMu1GNTGmD7GmA+MMVuNMVuMMfPCUZiIiDiig1inCvhPa+0GY0wisN4Y8561dmuIaxMREYJoUVtr91lrN/iXjwLbgFNCXZiIiDha1UdtjOkHDAM+DvDaXGNMjjEmJz8/v22qExGR4IPaGNMVWAb8zFpb3Ph1a+2T1tpsa212enp6W9YoItKpBRXUxhgvTkgvtNa+EtqSRESkvmBGfRjgaWCbtfY3oS9JRETqC6ZFfS5wDTDRGJPrf1wU4rpERMSvxeF51toPAROGWkREJABdmSgi4nIKahERl1NQi4i4nIJaRMTlFNQiIi6noBYRcTkFtYiIyymoRURcTkEtIuJyCmoREZdTUIuIuJyCWkTE5RTUIiIup6AWEXE5BbWIiMspqEVEXE5BLSLicgpqERGXU1CLiLicglpExOUU1CIiLqegFhFxOQW1iIjLKahFRFxOQS0i4nIKahERl1NQi4i4nIJaRMTlFNQiIi6noBYRcTkFtYiIy7UY1MaYZ4wxB40xm8NRkIiINBRMi/o54IIQ1yEiIs1oMaittauBQ2GoRUREAmizPmpjzFxjTI4xJic/P7+tNisi0um1WVBba5+01mZba7PT09PbarMiIp2eRn2IiLicglpExOWCGZ63CFgHnGWMyTPG/Cj0ZYmISI3ollaw1s4IRyEiIhKYuj5ERFxOQS0i4nIKahERl1NQi4i4nIJaRMTlFNQiIi6noBYRcTkFtYiIyymoRURcTkEtIuJyCmoREZdTUIuIuJyCWkTE5VqcPS+crLVYC9XWUl37tW7ZVtc952u8bnWjdf3LPv/zTbZb3XAftg3W9dXst7p+Hc7ztetWN1rXNlq3yXYtvmqarFuznXivh5QELynxMXTr4iWli5eULjGkdPHSzf81NtoT6V+tiJwAVwX1oHvfpqyyOtJlhE2UgShjiDIG41/2RNUt17xujMET1XTdKAMlFT6OlFRS4Wv+uMV7PXTr4iW5S6Mwj3fCPLleqHfr4iU53ln2evQfLhE3cFVQ33ze6fiq/QFWL7A8jcLJec15vi7MAgVd3fpRJ7Cup95zxjR83Vm/3rq1rxtMVDP1+783xrTJcbPWUlrpBPbhkgqKSio5XFLJkdIKjpRUcqSkwvm+xPl++/6jFJVWcqSkkqpq2+x2u8ZG+0O9Jshrwr350E+K9+KJapufS0Qc7grqiWdEuoR2yRhDl5housREc3JKfNDvs9ZyrLzKH+ZOyB8prQv0utB3gj7vcKnzXGkltpl8NwaS4hoHeF13TEq8l24JMU1a9Elx0W32h0uko3FVUEt4GWNIjPOSGOelT/fg31ddbSkuay7cKymqacGXOq/vKjjGkZJKjpZVNbtNT5QhOd5bF+b1u2TivaQk1AV7/VZ+lxiPAl46PAW1tFpUlPG3kGPoR0LQ76vyVVNU6g/z0goOf1PZpAVf8/3+4jI+23+UwyUVlFT4mt2m12MC9LfXb8HH+Ltq6oLdE2WIjoryfzV4PP6v/uej2rBbSqQtKKglbKI9UaR2jSW1a2yr3lde5aOopoX+TYAWfG3oV/DVoRI+zXNCv7zq25+Yrgtu56vziKp73lP/9agm6zuvR+Ex1L3e4A9CgPd56p73mMb7CPCeZmrwNK6l5o9Sk+01/GPlMQ1f1x8r91BQi+vFRns4KcnDSUlxrXpfWaXP6V//pu7EammFD1+1para4quurrfc+Gu189UX+Pnq473PZymvrKaq2td0e/Uete/zNa3DDTxRhoQYDz2T4+iZHE/PpFh6JvmXk2PpmRRPz+Q4unXxKtRDTEEtHVac10Ov5Hh6JQd/gtUNaq4BqKr/h8TnXDtQ//uqgH9onD8U9Z9vuE6A9/iqA/7RqTkXsb+ozOmK2ldM/rHyJieSY6KjnABPivOHehw9kuLoVe9remKshnueAAW1iMs4Q0/BE+W+C5UqfdXkHy1nf3GZE+BFZRwoLmOfP8xzvzrC/i1lVDTqdjIG0rrG1oZ3bajXBLp/OSFWkRSIjoqIBM3rieLklPjjDgO11nKkpJJ9jUL8QFEZ+4rL+FdhCZ98eYii0som702Mi24Q4jUt9J5Jda3z7gkxna6rRUEtIm3KGEO3hBi6JcRw9slJza5XWuFjf3EZ+4pKOVBcxv6icvYXlTqt9eJyPj+QT/7Rchp32cd4ouiRHNsgvHv4Q71m+aTEOGKiO05Xi4JaRCIiPsZD/7QE+qc1P8SzyldN/rHyJl0sB4qc5c17i3hv64EmI3yMgdSE2HonPeudCK3XUu/aTrpa2keVItIpRXuiWjwhbK2lqLTS3zqvC/EDxU6o5x0uIWfPIY6UNO1q6Rob3bCbJcnpL++VVHdSNDUhhqgIT4ugoBaRds2YuguwBvZsvqulrNJXO4KlwVf/8kdfFHDwaDm+Rn0tXo/hpMSGJz17NRrZ0iMptF0tCmoR6RTivB76pSXQ7zhdLb5qS8GxcqeLpV53ywF/X/rWr4tZue0gpZVNr5ZN6xrDgLSuLLlhTJvXrqAWEfHzRJnaFjJ9Aq9jraW4tMp/0rPMOQFaVM7+4tJmJys7UUEFtTHmAuBxwAM8Za19ODTliIi4mzGGZP/8MWf1TAzLPlvsVDHGeIA/ABcCZwMzjDFnh7owERFxBNP7PRL4wlq7y1pbAbwETA1tWSIiUiOYoD4F+Kre93n+50REJAzabDyJMWauMSbHGJOTn5/fVpsVEen0ggnqvTQ8/9nb/1wD1tonrbXZ1trs9PT0tqpPRKTTCyao/wGcYYzpb4yJAa4EVoS2LBERqdHi8DxrbZUx5mbgHZzhec9Ya7eEvDIREQGCHEdtrX0TeDPEtYiISADGhuBSGmNMPrDnW749DShow3LaiupqHb4IuWMAAAQkSURBVNXVOqqrdTpiXadaawOe4AtJUJ8IY0yOtTY70nU0prpaR3W1jupqnc5WV8eZWVtEpINSUIuIuJwbg/rJSBfQDNXVOqqrdVRX63SqulzXRy0iIg25sUUtIiL1KKhFRFwuYkFtjLnAGLPdGPOFMeaOAK/HGmMW+1//2BjTzyV1zTbG5Btjcv2PH4ehpmeMMQeNMZubed0YY57w17zJGHNOqGsKsq4Jxpiiesfq3jDV1ccY84ExZqsxZosxZl6AdcJ+zIKsK+zHzBgTZ4z5xBiz0V/XAwHWCfvnMci6wv55rLdvjzHmn8aYvwV4rW2Pl7U27A+cS9F3AgOAGGAjcHajdW4C5vuXrwQWu6Su2cDvw3y8xgHnAJubef0i4C3AAKOBj11S1wTgbxH499ULOMe/nAh8HuD3GPZjFmRdYT9m/mPQ1b/sBT4GRjdaJxKfx2DqCvvnsd6+fw68GOj31dbHK1It6mBuRjAVWOBfXgr8mzEm1Pdsd+VNEqy1q4FDx1llKvC8dfwfkGKM6eWCuiLCWrvPWrvBv3wU2EbTOdTDfsyCrCvs/MfgmP9br//ReJRB2D+PQdYVEcaY3sDFwFPNrNKmxytSQR3MzQhq17HWVgFFQKoL6gK4zP/f5aXGmGZugRlWbr65wxj/f13fMsYMDvfO/f/lHIbTGqsvosfsOHVBBI6Z/7/xucBB4D1rbbPHK4yfx2Dqgsh8Hh8Dbgeqm3m9TY+XTia23utAP2ttBvAedX81pakNOPMXZAK/A5aHc+fGmK7AMuBn1tricO77eFqoKyLHzFrrs9Zm4cw3P9IYMyQc+21JEHWF/fNojJkMHLTWrg/1vmpEKqiDuRlB7TrGmGggGSiMdF3W2kJrbbn/26eA4SGuKRhB3dwh3Ky1xTX/dbXODIxeY0xaOPZtjPHihOFCa+0rAVaJyDFrqa5IHjP/Po8AHwAXNHopEp/HFuuK0OfxXGCKMWY3TvfoRGPMXxut06bHK1JBHczNCFYA1/qXpwMrrb9nPpJ1NerHnILTzxhpK4BZ/pEMo4Eia+2+SBdljOlZ0y9njBmJ8+8t5B9u/z6fBrZZa3/TzGphP2bB1BWJY2aMSTfGpPiX44HvA581Wi3sn8dg6orE59Fae6e1tre1th9ORqy01l7daLU2PV5BzUfd1mwzNyMwxvwSyLHWrsD5B/2CMeYLnBNWV7qkrp8aY6YAVf66Zoe6LmPMIpzRAGnGmDzgPpwTK1hr5+PMFX4R8AVQAlwX6pqCrGs6cKMxpgooBa4Mwx9bcFo81wCf+vs3Ae4C+tarLRLHLJi6InHMegELjDEenD8MS6y1f4v05zHIusL+eWxOKI+XLiEXEXE5nUwUEXE5BbWIiMspqEVEXE5BLSLicgpqERGXU1CLiLicglpExOX+P4OPf6tGQHAfAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(net.history[:, 'loss_dis'], label='loss discriminator')\n",
+    "plt.plot(net.history[:, 'loss_gen'], label='loss generator')\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "noise = torch.randn(10, nz, 1, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fakes = net.predict(noise)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAKwAAAaACAYAAAD1j7evAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAgAElEQVR4nOy9abAdxXn//30kC9C+ICRdJGFJSCwyi8BiEZuJQQlgDMRgbHBc2MEhcUKCK05i2ckv5fzLlWC/sKtSLsfBBbFis9pgIICNQYABWwjEIqF9YZOEhPYNkNDS/xdnrjz9neec7jv3nDm35edTpbrnmTs93TPn0dynu59FnHMwjFTo1e4BGEZXMIU1ksIU1kgKU1gjKUxhjaQwhTWSolsKKyIXichSEVkhIjOaNSjDqIeUXYcVkd4AlgGYDmA1gBcAXOOcW9S84RmGz4e60fZ0ACucc68BgIjcBeByAHUVVkSciByQtf8s+d/HEmqj/X7//v0N25T5j6z1w8dirsvnaNcNXSdmLGWIuR8+VuZZOufUwXZHYUcDWJWTVwM4o1EDEcGHPvT7LrUb6dWrsZWi/T5/TY3evXsXju3evduTWYE1heZj/OX16dOn0OaQQw7x5A8++MCT9+3bF+xHu2c+h5+l9kx4fHxdTaH37t3ryX379vVkfo4AsGfPHk/me9bI993oZdIdhY1CRG4AcEOr+zH+MOiOwq4BMDYnj8mOeTjnbgFwC1AzCfJvAu3NF/pTzf/j6x3Lc+ihhxaOlTEj+Bi/obSx8xuIxxq639hzeGzamzt0zzFve35bxpgrMSZBrLnSnVWCFwBMEpHxInIIgM8CeLAb1zOMIKXfsM65vSJyI4BHAfQGcJtzbmHTRmYYCt2yYZ1zjwB4pEljMYwgttNlJEXLVwmYvAGuTZaasT7KBvz777/f5Tah5TXtnJhJS5nxx7ThCaw2ieHx8vKTNn6GxxIzuQvJgL8Mx+PKY29YIylMYY2kMIU1kqJyGzZv02kbB80IioxZuGZ7jseibTbwddjWitlXj6GMDRu6H+06Jff4uz0W7Rp5G7bRRpC9YY2kMIU1ksIU1kiKym3YmPXNPDFOEWV8Q9n9rn///p6suQqybcVrkDE2bJn7ibEbY+xp7luzc5sxlpCrpvYMBg0adOBzI3dEe8MaSWEKaySFKayRFKawRlKUjpot1ZmIy092ysRNlUG7R94YYFlrwxMbnoRpbXhiE9OmTKBf6BpAcaIZM6EKndMs/eGNg3pBiPaGNZLCFNZIClNYIykq3TgQEc+m0xauGznvAs2z5w477DBPZttSc/ouY7/x5gJvnGgbKa1yUuF7jMlLUMYBvQz5vhvNW+wNaySFKayRFKawRlJU7vySp0xAXkwWlJh+3n333YbXLdNPDDF5s1pFMxLItcqGzV+3UR/2hjWSwhTWSApTWCMpTGGNpKh84yDvya9FR2qe/jHXzROz8N4Mp5oy8GZJTMrRZkXjhvrRxhLK2lImK42WbHns2N9nbl21alXh953YG9ZIClNYIylMYY2kqNSGdc55zi0xthkvrGv2T8jpu0zK9WbB4x86dKgnH3744YU2W7du9eSdO3cWzmHnnGbcY4xDfTMccbR+du3a1fD3ndgb1kgKU1gjKYIKKyK3ich6EVmQOzZMRB4TkeXZz6GNrmEYzSIYhCgi5wHYCeB/nXMnZMe+A2Czc+7mrMbsUOfc10Kd9erVy+XXWbW+Qw7Pda7b5d9z0OF7773nyaFSSkCxaFxHR0fhnOOOO86TzzjjjIYyAPzmN7/x5F/84heFc3itkssrxQRExtj6MVm5mVCGGc2WHjhw4IHP27Ztw969e8sFITrnngawmQ5fDmBm9nkmgCtC1zGMZlDWhh3pnFubfV4HYGSTxmMYDen2spZzzolIXbvCSncazaTsG/YdEekAgOzn+nonOuducc5Ndc5Nbdf+vXHwUPYN+yCA6wDcnP18IKaRc84z4rWJQRnP/1CK8hiHGo6i7devX+GcUaNGeTJPqC677LJCmxNPPNGTx40b1+WxvPPOO4VzfvnLX3ryli1bPFl7bpxSlJ8/R2EAzanJy5s9WjrN/Pi7FXEgIncCmA3gWBFZLSLXo6ao00VkOYALM9kwWk7wDeucu6bOry5o8lgMI4jtdBlJUXnUbN6+aVYEZshhW7Ozjj76aE+eOnWqJ5999tmFNmyPTpgwwZO1Uklsr7355pue/NZbbxXaPPfcc57ct2/fwjlsC4eyJGrX4c0S3nwAwhsH2qZMKKNMyC62qFnjoMEU1kgKU1gjKSrPwJ23tbS1wmaMh9f9xowZUzjnP/7jPzz5/PPP92ReCwWKa7Pcj7aOuXr1ak+eNWuWJ2/atKnQZseOHZ7M9jYADBgwoGHfodJC2lhmz55daLN27VpP5jXtvON1vWOhsveA/73v37/fMnAbBwemsEZSmMIaSWEKayRFW1PGa4vOoZTx9a6bhydD7KQCABdc4O8sDxs2zJNDkZ0AsH6976R2xx13FNosXLjQkydOnOjJJ5xwQqENT+7Y6QYoTn44+uGII44otOGJ5OTJkz2ZnWMA4JFHHvFkjuDVHFl4s4E3MbRnG5t21N6wRlKYwhpJYQprJEWlNmyvXr286EjNsYKznsTANizbgCeddFKhzeDBgz2ZnUe0DQy213iB/6ijjiq04UV/dqDRbE12iPnRj35UOGf8+PGefPzxx3uyFsHLz+ntt9/25JdeeqnQZvNmP/6UbVjNyaZV6fYBe8MaiWEKaySFKayRFJXbsPn1Qm3tbdu2bZ4c44ydt4sB4OKLL/bkr32tmJSG+2Z7WrPDQhlM2CEFKDq33HXXXZ6srWOyzao5yIwc6aeCuPrqqz1ZW3sePny4J7/88suevHLlykIbttPZZi3jrBRy+rbshcZBgymskRSmsEZSmMIaSVF5yvj85EbzVg8Z8VrKeI4gZccWrZzPihUrPHnZsmWerE0MOMXlo48+6skLFiwAw/ezceNGT9bSwYdS4APFCFfO/KJdl++JNw54wgvEpR3tKjEZf+phb1gjKUxhjaQwhTWSoq2lO9npGAg7v2iZCEeMGOHJxx57rCezrQYAX/3qVz15+fLlnqwt6HOpIY5U1eww3tSIWXhnW1PL/HLOOed48uWXX+7Jmq3PGWXuv/9+T46ZU3Q1i0tsm/wx2zgwDhpMYY2kMIU1ksIU1kiKyjcO8pOOZhnsRx55pCfzhOPXv/51oc28efM8mdOyN8trnidZHA2h3Q9PIqdPn14456qrrvJknmjOnz+/0GbmzJmezBNcbQJYpi4FP39OQ8qTVyC+Hpi9YY2kMIU1kiKmKMdYEXlSRBaJyEIRuSk7bvVmjcqJqTXbAaDDOfeSiAwE8CJqpTq/gC7Wmz300ENd3t7UHCvYlmQbihfigWI6zSlTpnjyiy++WGjD3vW8aF7Gk15zsuFF/4suusiT2QkHAM4999yGbYBiBhmObr3tttsKbR566CFP3rBhgydrdmQoI0vMxkdMTVseR+l0m865tc65l7LPOwAsBjAaVm/WaANdsmFFZByAUwDMgdWbNdpA9LKWiAwAcC+ArzjntlM1mLr1ZvO1ZrU/mYbRFaJSxotIHwAPAXjUOffd7NhSAOc759Zmdu5TzrljG12nd+/eLp9BT8tUyHYt20Oa8ws70XAmQi3qlB2gY5xSQo4gWrlPtqevu+66YD9nnXWWJw8ZMqRwDke8/uQnP/HkZ599ttCG7VzNwYfhl0yMc3lIp0Lrvd1KGS+1K90KYHGnsmZ01psFulBv1jC6Q4xJcDaAzwN4VUReyY59A7X6svdktWffBHB1nfaG0TRias0+C6De/pzVmzUqxXa6jKSo3Pklb3BrtVlDkx9tohZa3NY2G0499VRPZkeQJUuWBMfGExJOgQkAf/Znf+bJ7LSi1QPje163bl3hnF/+8pee/MQTT3iyFgEbcjDRohR4UsXXKDM51dqE6rd1Ym9YIylMYY2kMIU1kqJSGxbw7cBQzVFN1haq+TrsyPKxj32s0Oav/uqvPJkX/T/zmc8U2rCzCNvGkyZNKrThjQNGW7xnx5z77ruvcA7bsJz5JcYBnW1wrkULFNNtlnEKimmTn4c0chq3N6yRFKawRlKYwhpJ0dZ12LLXYHhtkO25p556qtCG10e5TNBHPvKRQhvODsMljS699NJCm9GjR3syZ4vh0p4A8N///d+evHTp0sI5XDY0xmZl25DXr7V1WHY24vlCpPNUQxnw1+QbZUy0N6yRFKawRlKYwhpJYQprJEXlGwfdnXSFUjUCxUnY9u3bC204qpSjFGbPnl1ow5MBztAyatSoQhuetLDX/+23315ow1G+WqaUULSANoHiyAW+Hy3VKffTjI0DzVkpH039xhtv1L2WvWGNpDCFNZLCFNZIispt2FYQsqs0e483EzjyVlu85lqybJ/OnTu30GbNmjWe/MILL3jyr371q0Ibzfma0WzUPJqd2L9//4aytkFRxmblOQU76k+dOrXQJn/sjjvuqHtte8MaSWEKaySFKayRFFGZX5rWmYjLOw3HlHDsaskcjZh7ZHuU7TsAGD58uCez07eWionXhHkdVgswZAcTzR7VSiHl0e6Zx8v3+Oabb0ZdJ09Mhm7uR2uT/97ff/997Nu3r1zmF8PoSZjCGklhCmskhSmskRSVbhz06tXLy3SieclrkbR8jRCxJXTy8ORCm0Dt3LnTkzdu3OjJ2tj5OtyP9gxiUoyy4w1H8GqOLJx2lJ2CtGfL44uZwPI9azVsGS1VqYa9YY2kMIU1ksIU1kiKyjcO8k4bmv3G9lrIBtSOsS2p9cOL1zFZUNiJhm2zmH6YGHubHXOAYtZDvmetXx5/6FkDRbuW7fgYGzwmojd/jx988AH2799vGwdG+pjCGkkRU5TjMBF5XkTmZaU7/y07Pl5E5ojIChG5W0SKf7cMo8nElO4UAP2dczuz8kfPArgJwN8DuM85d5eI/BDAPOfcfzW6Vq9evZy2ppiH7ahQgCFQtJFi7ELuh21C7RpcKqkZ2VYaZTnpynXLZGCJyfzC58SsqYac4UOZvnfv3l3ehnU1Oi3tPtk/B+DjAH6eHbfSnUYlRNmwItI7K3m0HsBjAFYC2Oqc6/yvsxq1+rOG0VKiFNY5t885NwXAGACnAzgutgMRuUFE5orI3CqX0IyDky6tEjjntgJ4EsA0AENEpNMYGQNgTZ02tzjnpjrnpsY4+xpGI4LOLyJyBIA9zrmtItIXwHQA30ZNca8CcBciS3eKiBdBqU1a2JOeJzraZIgnBixr/1HY8I+ZXJRxBAldoyzN+GsVmuAC4dq/2v2wIw6nP9WiOfKbGo2y2sR4a3UAmCkivVF7I9/jnHtIRBYBuEtEvgXgZdTq0RpGS4kp3TkfwCnK8ddQs2cNozJsp8tIiqqdXzagVvl7OICNgdN7CjbW1lFvvB92zh2hNahUYQ90WlviKuar6YHYWFtHmfGaSWAkhSmskRTtUthb2tRvGWysraPL422LDWsYZTGTwEiKShVWRC4SkaWZ0/eMKvuOQURuE5H1IrIgd2yYiDwmIsuzn0PbOcZORGSsiDwpIosyx/qbsuM9brxNDQLoLKfZ6n8AeqPmljgBwCEA5gGYXFX/kWM8D8CpABbkjn0HwIzs8wwA3273OLOxdAA4Nfs8EMAyAJN74ngBCIAB2ec+AOYAOBPAPQA+mx3/IYAvB69V4aCnAXg0J38dwNfb/TCVcY4jhV0KoCOnJEvbPcY6434ANcekHj1eAP0AvATgDNQ2DT6k6Ue9f1WaBKMBrMrJqTh9j3TOrc0+rwMwsp2D0RCRcaj5e8xBDx1vs4IAbNLVBVztVdCjllVEZACAewF8xTnnJcvqSeN13QgCyFOlwq4BMDYn13X67mG8IyIdAJD9XB84vzKyoNB7AdzunLsvO9xjxwuUCwLIU6XCvgBgUjYzPATAZwE8WGH/ZXkQNQd1INJRvQqyaOZbASx2zn0396seN14ROUJEhmSfO4MAFuP3QQBA7FgrNrgvQW02uxLAP7d7AqCM704AawHsQc2muh7A4QBmAVgO4HEAw9o9zmys56D2534+gFeyf5f0xPECOAk1J//5ABYA+Nfs+AQAzwNYAeBnAA4NXct2uoyksEmXkRSmsEZSmMIaSWEKaySFKayRFKawRlKYwhpJYQprJIUprJEUprBGUnRLYXt6yItx8FHalyDLZrgMNc+b1ah5Y13jnFvUvOEZhk93iiOfDmCFq2UxhIjcBeByAHUVVkQq8bRpRuLkP0SnoJjn1qrnku8788xSB9MdhdVCXs7oysA0QglzY6p5c7LiMtVetOou3Dd/edq9hc4pU3lcu24ZeCxadRdOeswJpsuMQ6u4mK8uxH3kaXn5eRG5AcANre7H+MOgOwobFfLinLsFWUoaEXH5/9Xa2zL0Ror5Hx1T+yr01tX64Tapmx4xfyFCf1XKoD37fK3cRn10Z5Ug1ZAXI2FKv2Gdc3tF5EYAj6KWJOM259zCpo3MMBQqLz+f/xMTYxKUGV/Mn+oyJkGZfkL0pNUIrcw9T8Tee++9bvcTMj327dtXd5XAdrqMpGj5KgGTf6PETI74f6P2vzP0pivztoxpEzNpKTOWGEKFjrV+Qn+98hOfTkITzar/Qtgb1kgKU1gjKUxhjaRoqw0bs5XJaG0OO+wwT+atPW1FgK/D24XNqgkb6le735gt0+HDh3vyhAkTPFnb8n355Zc9udEWaDOJuefY521vWCMpTGGNpDCFNZKichs2Txl3PG03ZteuXZ5cxkmlGeuJMfZozFjYnj7iiGLZ1auuusqTP/OZz3jywoXFXfJ///d/9+Q333wzOBZ+lq1wa+RjrXJ+MYzKMYU1ksIU1kgKU1gjKSqfdOUnFGUM+BgHDSamn2ZsFJSZ3GljY6egnTt3Fs7hjQHeSPjIRz5SaHPyySd78ltvvRUcSysmWd151vaGNZLCFNZIClNYIykqt2Hz9oy2CRDKS8CbBEDYztJCcfhY//79PXnbtm0NrwnE2axlHJ5jbL53333Xk9944w1PHjFiRKHNSSed5MkPP/ywJ2sOM1U5aHOITN3zqhiMYTQLU1gjKUxhjaRoq/PLBx98UDjGtiRTxgYMXRMo58xcJgixjE37/vvvF44tWbLEk5cuXerJzzzzTKHNr371K09mO75snq8QZZ5TPewNaySFKayRFKawRlKYwhpJ0dbcWhr8ey35bQh2Hunbt2/hnNAkS3OyKQPfz6GHHhocB09K+vXrVzjn1FNPbdhm2bJlhTY8yeVNGN6MAMpFMTP8HWobRvl+du3ahf3791tuLSN9TGGNpDCFNZKi0o0DEfHsGc3+CUW8ajYt22Zsd2l2Itu5McU+Qmj3w/bnkUce6cnsRA0Ux69tfGzZsqWhvH379kIbzXZs1K9GzPcRuq62YTRw4MCGv+/E3rBGUpjCGkkRVFgRuU1E1ovIgtyxYSLymIgsz34Obe0wDaNGjA37YwDfB/C/uWMzAMxyzt2c1ZidAeBroQtlFe4OyDHBaJy5T7NvQg4lWqbvVqw/azbskCFDPJltWu0ZsM163nnnFc7hNdPNmzd7ckxwI8sx2c35ujGZIXl+oGVjzBeWa7S2G3zDOueeBrCZDl8OYGb2eSaAK0LXMYxmUNaGHemcW5t9XgdgZJPGYxgN6faylnPONSp6bKU7jWZS9g37joh0AED2c329E51ztzjnpjrnppbsyzAOUPYN+yCA6wDcnP18ILZh3tCPWaxnJxTNKYWN+LwBD+ie9HysGZMwbWF+4sSJnnzaaad58saNGwttxowZ48lTpkwpnMPj5yhfLbqYJ6wxE1qmGc9JG1t+c6fRZDxmWetOALMBHCsiq0XketQUdbqILAdwYSYbRssJvmGdc9fU+dUFTR6LYQSxnS4jKXpc9kI+xs4VgwcPLrQJOSZrC9UMn1MmipadswHgggv8P0Tnn3++Jx977LGFNqtXr/bkUaNGFc5hW57tds0pJXRPZcpQxdi0bG9r/eSfnWbjdmJvWCMpTGGNpDCFNZKirZlftPU2tr1iSqSHythrZYPWr/f3OkLX0GBbjEuIAsCJJ57oycccc4wns0M3AOzYscOTX3vttcI5Tz75pCevXbvWk9kZBii39tyqMkdMbNYZe8MaSWEKaySFKayRFKawRlJUPunKG/G82A0Uy/VwyR/NWYQnBuxUoy28b9q0qeE1YuCNgqFDi5FCPMmKcczhBf7f/e53hXN+/etfezKnjC8TZVEm4iCGmGvEXtfesEZSmMIaSWEKayRFpTZsr169vEyCmp3FC96c0URLn86wI/WaNWsK5zRysIiFNwrY8RooOuY8+OCDnvzCCy8U2gwbNsyTb7/99sI5vPFRJt0725banIK/ozI2bEx0dP66jfqwN6yRFKawRlKYwhpJUakNu3//fs8G1WwVdl5mu0pzkmbna86KsmHDhi6PVYNt42nTpnnyjTfeWGjDDtqHH364J999992FNq+88oonv/fee10aZ1li1mGbsS6rOdTns91omRc7sTeskRSmsEZSmMIaSWEKayRFWyMONCM/lIJcizjgY60q5cRZXK699lpPvvDCCwtteKLGky6OqgWAhQsXerLmVPPb3/7WkxtNVDoJLeCXiRQug7bJkd/I6VbmF8PoSZjCGklhCmskReU2bN65WrM1Q3ZWGScPrWwQR6Yymt146aWXevJJJ53kyVqkKjvvPPvss5583333FdoMGjTIk7Xxd3R0eDI/N825h89pRQZH7TrsUK9lrcxvJnQrZbxh9CRMYY2kMIU1ksIU1kiKtkbNakZ+yECPSSnERnuZNpMmTSqcc8UVfnWncePGefKCBQvAfOtb3/LkV1991ZM1TyxOrTR+/PjCOVzviydqXB8MKE7EeJIYExlQBp7caRPn/HdkEQfGQUNMjYOxIvKkiCwSkYUiclN23Mp3GpUT84bdC+CrzrnJAM4E8DciMhm/L985CcCsTDaMlhJTlGMtgLXZ5x0ishjAaNTKd56fnTYTwFMI1JsVEc+5RVtAZvuFvdNj2rCNpKXB5OhbPocz0ADFxXq+xtNPP11ow1GxbDdqkaqcglMbCzv8cEpOjtwAgHXr1nlyq5yEQmgbA3knoUbll7pkw4rIOACnAJgDK99ptIHoVQIRGQDgXgBfcc5tz/8vaVS+00p3Gs0k6g0rIn1QU9bbnXOdm99R5TvzpTtjMjEbRiOCb1ipadmtABY7576b+1WXy3eKiGezaeuj7PA8YsQIT9acVjjDIdt3/PvOsTSSx44dG2zDGQQffvjhQputW7d6Mq91aunsP/3pT3vyxRdfXDjnrbfe8mTOxvj6668X2nA0MY8l5oXSjOyFWj95vdCc9DuJMQnOBvB5AK+KSGf88TdQU9R7slKebwK4OuJahtEtYlYJngVQ77+ele80KsV2uoykMIU1kqLyVEV5BwwtQpZTEYXSEAFFpw6eTGhOHSGv+OOOO67QhieEb7/9tifzBAso3iP3c8kllxTa3HCDvwqoObLwxISvq0XR8jmtmmSVQdsQUs9r8TgMo6mYwhpJYQprJEXlDtx5xxTNkXfbtm2ezDZrTMp4JsYOY9uZ07YD8NLdA8D06dM9WVvwfu655zyZo2i/8IUvFNpwlKwWjcspOWfPnu3JXHsWKD6HkFzvWFeJ6Sc/DzEHbuOgwRTWSApTWCMppEon3nouiHl4PY7XYcuUpNTgNuxI/Zd/+ZeFNtdff70ns0O35ijOa8QsDx48uNBm3rx5nvyjH/2ocM7jjz/uyVwGqV3O2TFoa64DBgw48Hnnzp3Yt2+fukhsb1gjKUxhjaQwhTWSwhTWSIrKJ10hJ4cyYTR8D+xwUiatpxYJcMopp3jy1Vf7Pusf/ehHg/3wJJIjBQDgm9/8picvWbKkcA5vJjTy0u+kGc+2GREHmtNTPovOqlWrsGvXLpt0GeljCmskhSmskRQ9fuOAnaZjMhGyI4uWcp3rz7KdpdVD5YyBo0aNCvaTXxAHihG8HBUMFLPFaE7r/BzYVo7JDMnPSXu2nIUlRl/4WfJ3eNZZZxXanH322Qc+33rrrXj77bfNhjXSxxTWSApTWCMpepwNy7bj8OHDPVlbt2THFV7n0xxM1qxZExpKAbYBuR9tfZHtuZgAyRh7NLQ+qq258vjZft64cWOhDTvZl8nSzc9fW4vPX3fHjh3Yu3ev2bBG+pjCGklhCmskhSmskRSVT7pCDhgDBw70ZI5e1Zw8eGLAkbeakc/Rt60q+RMixiFFG38oi0tMTV7eONAmjRwhEbNxw9fhsWn3k89us2nTJuzZs8cmXUb6mMIaSWEKayRF5Zlf8vaNZg+xowdHou7evbvQhp0r2H4r49zM19SuG2P/a3ZhHi65CRQX2tnWBIobKPzctOcU2mzQ7F526GHbX/sOQxsfmt2ed0hvZH/bG9ZIClNYIylias0eJiLPi8i8rNbsv2XHx4vIHBFZISJ3i0jxb6hhNJngOmxW9qi/c25nVq/rWQA3Afh7APc55+4SkR8CmOec+6/Atbx1WK1vtm94XVazzdhhhp2OYzJwd/X3QFxwHY+NbcJzzz230Gbp0qWerDnqsI3Ndro2/tDacygjC1DMvqjB1wkFiTJ79+7F/v37y63DuhqdbvJ9sn8OwMcB/Dw7PhPAFaFrGUZ3ia2E2Dur0bUewGMAVgLY6pzrnCKuRq1gsmG0lCiFdc7tc85NATAGwOkAihUr6iAiN4jIXBGZW3KMhnGALq0SOOe2AngSwDQAQ0Sk00AbA0D1iM7Xmu3WSA0DcZOuIwDscc5tFZG+AH4N4Nuo1Ze9Nzfpmu+c+0HgWsFJFxvsHE1QpoSRthAdSuMZky0mxqmDJ0faJgDDmwBaBC/fE19Xm5yGJjsx6UJjJrR8HW6jPYP8dXbv3l130hWz09UBYKaI9EbtjXyPc+4hEVkE4C4R+RaAl1EroGwYLSWm1ux8AKcox19DzZ41jMqwnS4jKap24N6AWqn64QCKIZo9Extr66g33g8754rpI1Gxwh7oVGRuKqsGNtbWUWa8ZhIYSWEKayRFuxT2ljb1WwYba0xb/KoAACAASURBVOvo8njbYsMaRlnMJDCSolKFFZGLRGRp5vQ9o8q+YxCR20RkvYgsyB0bJiKPicjy7OfQdo6xExEZKyJPisiizLH+pux4jxtvU4MAnHOV/APQGzW3xAkADgEwD8DkqvqPHON5AE4FsCB37DsAZmSfZwD4drvHmY2lA8Cp2eeBAJYBmNwTxwtAAAzIPvcBMAfAmQDuAfDZ7PgPAXw5eK0KBz0NwKM5+esAvt7uh6mMcxwp7FIAHTklWdruMdYZ9wMApvf08QLoB+AlAGegtmnwIU0/6v2r0iQYDWBVTk7F6Xukc25t9nkdgJHtHIyGiIxDzd9jDnroeJsVBGCTri7gaq+CHrWsIiIDANwL4CvOue353/Wk8bpuBAHkqVJh1wAYm5PrOn33MN4RkQ4AyH6uD5xfGVlQ6L0AbnfO3Zcd7rHjBcoFAeSpUmFfADApmxkeAuCzAB6ssP+yPIiaszqynw+0cSwHyKKZbwWw2Dn33dyvetx4ReQIERmSfe6Lmq29GDXFvSo7LW6sFRvcl6A2m10J4J/bPQFQxncngLUA9qBmU10P4HAAswAsB/A4gGHtHmc21nNQ+3M/H8Ar2b9LeuJ4AZyEmpP/fAALAPxrdnwCgOcBrADwMwCHhq5lO11GUtiky0gKU1gjKUxhjaQwhTWSwhTWSApTWCMpTGGNpDCFNZLCFNZIClNYIym6pbA9PeTFOPgo7UuQZTNchprnzWrUvLGucc4tat7wDMOnO4XlTgewwtWyGEJE7gJwOYC6Cisiwf8dnHOV/0PFFBMOXTMG7T9yMxyFmjWWqvoOUWZsoXFknlml88PWQwt5OSPUKJ+cV7tZTrrLCXO15L6haihaG35oLHMiX6BcJcRQ1e0YJYqpzB0zFn62obHFXFerMhl66XCSaoYTIOdpeelOEbkBwA2t7sf4w6A7ChsV8uKcuwVZSho2CbQU5iETQPsfz28gfuPG9MNvCq2GKreJeauF7idmbFpa9jI049ky2luZ39w8/pgU/vXozipBqiEvRsKUfsM65/aKyI0AHkUtScZtzrmFTRuZYSh0y4Z1zj0C4JEmjcUwgthOl5EULV8laIRmfIeWqMpMQLQ23HfMclOZvkMTs2YtWcXA49eWpJjQUpg2OeVz+BraPefbNFrqszeskRSmsEZSmMIaSVG5DdvdRXDNngvZuVrd1TI1bcsQso1bsb9fD352MfOD0FY519IFis9ywIABnrx27Vow+bE1evb2hjWSwhTWSApTWCMpqq416/I2UcxaZ2gdECiuBcbYnyFbMmZ9lNEcWQ477DBPZntOG+u2bds8OWa9NOZ75HuMcS/ke+JnrbVhuzbGLTPfz65du7B//37VuLc3rJEUprBGUpjCGklhCmskReUbB3kjvUxMlDbpKrM4XybYkY/169fPk48++uhCm8suu8yTJ06c6Mlvv/12oc3Pf/5zT37jjTcK5+zcudOTeWJW5p5jIg5CTkOAHg8XapOffDbSC3vDGklhCmskhSmskRSVbhz06tXL5aMjY+xRthO1RfRQVKZmM4XO0RyTDz/8cE/+xCc+4ck33nhjoc3xxx/vyewYotl7ixcv9uRf/OIXhXN++ctfevLKlSs9WduQCNm52sYHj5c3NTRCDtwhndu7d2/dRBr2hjWSwhTWSApTWCMp2ur8otmwnAGEHSk0my9kI2n9hNYK+/btWzh23HF+AeovfvGLnnzllVcW2gwZMsST+f60sfH4NQf0devWefLtt9/uyb/5zW8KbZ555hlPZjtdG0tM1hZGu04eTefy9vT+/fvNhjUODkxhjaQwhTWSwhTWSIq2Zn7RFrfZYOdJl7agH1r019owPHE76aSTCudcffXVnswbBxxdABST87LTirapwQv8WgLgoUOHevIXvvAFTx4zZkyhzYsvvujJ77//fsOx1htfiNCkNxTZ0CjCwt6wRlKYwhpJYQprJEVbbVgNtjfZ5ouJiI2JMmW76sgjj/Tkyy+/vNDmggsu8OSRI0c2vCYA7Nixw5OffvppT77//vsLbZ5//nlP/uQnP1k450/+5E88efz48Z48derUQptjjz3Wk9mmbVblnFBRlFD2wobX7vJoDKONmMIaSRFUWBG5TUTWi8iC3LFhIvKYiCzPfg5tdA3DaBYxNuyPAXwfwP/mjs0AMMs5d3NWY3YGgK+FLiQinq2i2Udsw8Zkbw6tFcY4Jp9++umefMYZxRp5Y8eO9WR2StmwYUOhzezZsz35Jz/5iSfPnTs3ON4nnniicA47k/PYOMMMUHTeeeWVVzw5xvaPgZ8tOxJp33u+TaN18+Ab1jn3NIDNdPhyADOzzzMBXBG6jmE0g7I27EjnXGeSz3UARjY62TCaRbeXtZxzrlHRYyvdaTSTsm/Yd0SkAwCyn+vrneicu8U5N9U5N7XKbNPGwUnZN+yDAK4DcHP284GYRs45b9IUk24zpu5qKNOLtijNjiq80M6TGKA4GVqyZIkn/+pXvyq0uffeez1548aNnvzee+8V2jDLly8vHHv55Zc9mbPOaM47F198sSdz5K0W2RAiJt3m4MGDPfmdd94ptHn33XcPfG4U1RCzrHUngNkAjhWR1SJyPWqKOl1ElgO4MJMNo+UE37DOuWvq/OqCOscNo2XYTpeRFJU7v8Q6OXQSk1Uw1Ie2ccAOzqeddponH3HEEYU27Mjy3HPPefLDDz9caLNs2TJPDmUQBIp2et6+64SjYvmcf/zHfyy0YbucbdoHH3yw0IZt7Jj073yMHcW1Ukl5BxntfjuxN6yRFKawRlKYwhpJ0eOCEMvYrGWucdZZZ3kyZxnU2ixcuNCTf/vb3zb8PVC0+UJlnYCiDa5lqVm/3t+rYSeb73//+4U2f/d3f+fJf/EXf+HJ2voorwFv2rTJkzUblp1o2IZlmbEM3MZBgymskRSmsEZSmMIaSVHppEtEPM9ybdKlZR/JE0rVCBQnLdomAGdK4Uwq7KQCFKMDOLpVm0yEonxjstJo8HW3bt3qybypAQAXXXSRJ5955pmefO211xba3HHHHZ7MUcwxzjv8ncZk/KmHvWGNpDCFNZLCFNZIisptWG2hvBnXzTNw4EBP5rTtAHDMMcd4MttQXHoIKDqcrF692pNj7NEY55cy8AaF5kCyZcsWT+7o6PDkE044odCGHcE50jYmijkmW4+V7jQOSkxhjaQwhTWSonLnl7x9wlntgKItGWPjsV3M9ukNNxSjzLkkKDtn//jHPy604Wx/oTVjoHU2a6gfrWwTP29+BqNHjy604bVazra4eTPnWCnarJwJpn///oU2+fE3Kg9qb1gjKUxhjaQwhTWSwhTWSIpKJ13OOc8g1xaUQ4vMWiQAG/WcaYRTvQPFCciaNWs8mZ08gLCnvDa2qiZdnH6T04cCxdTzHL2qje2hhx7y5FWrVnlyzMST0RxdtNJOatsu92YYbcQU1kgKU1gjKSp3fsnbjjH2XJmo2UMPPdSTtUwjbEexw4xGyLkl5n643xhnZu0ctsG5bNNll11WaMPZbvjZao5JvDFQ1uE81E/+O2r0ndsb1kgKU1gjKUxhjaQwhTWSoq2pijTjuszCOi9ec4pLTusDACNGjPBk9pwfNGhQoQ2nmS+TYp0nHNr98qRLe06jRo3y5PPPP9+TP/axjxXaaN5xebZv3144tnTpUk/m8cZEMTNaNER+o6ZbKeMNoycRU+NgrIg8KSKLRGShiNyUHbfynUblxLxh9wL4qnNuMoAzAfyNiEzG78t3TgIwK5MNo6XEFOVYC2Bt9nmHiCwGMBq18p3nZ6fNBPAUAvVmOWpWs3W6mlJeg+1EzTZjO4m97y+55JJCm5UrV3ryq6++6slaWkzuh++P7WIAGD58uCezMw9QLNM0ffp0T9ay3YSiObToYt50iYmA5evyM9C+97x93aiPLmmHiIwDcAqAObDynUYbiF4lEJEBAO4F8BXn3Pb8/5JG5TvzpTutEqLRXaLesCLSBzVlvd05d192OKp8Z750ZzP+3Bt/2ATfsFJ7Ld4KYLFz7ru5X3W5fKdzzlszLbOGF7J/gGKGk1mzZhXaTJkyxZM5kvO8884rtGEb73/+5388+Yknnii04TVHtq/Z8RoAJk2a5Mnjx48vnPPHf/zHnvzRj37UkzXbOLSGqq0rc/r3MuvkXY18bqQDMSbB2QA+D+BVEenMU/MN1BT1nqyU55sAro64lmF0i5hVgmcB1FN5K99pVIoZlUZSmMIaSVG580t+gqQZ1+zIwpMUzeOdF5p5o2DOnDmFNm+88YYnT5gwwZO1CASe2HC6Sm3h/dlnn/Vk9uCfOHFioc3VV/vTAe4XAEaO9Je9eXMhZoGfnzWnxAeAt99+25NbNenKb1A0ciqyN6yRFKawRlKYwhpJIa3KRKLRu3dvp6WBzMMOJGznxqQo5x01jqIFigvvP/jBDzxZGydfl+3pFStWFNqw/cw2IZdfAoq2sRb1y7Z9TJpSzlyzZMkST/7yl79caDN//nxPLpPphdHmLvnvaPfu3di/f7+6lGpvWCMpTGGNpDCFNZKi8uyFebtPs0dj1g+16+aJsXs5/fvPf/5zT9YcuDlwkZ2+uUQQABx//PGezI46Wta+mCBEhp+B5ky+adMmT/7pT3/qyZoNHnq2ZbL3aPecD/rU0tB3Ym9YIylMYY2kMIU1ksIU1kiKSjcOevXq5fKL4FrfoYXpmLTsvFGgheZwG3ZcmTx5cqHNGWec4clnn322J/MECyjeIzutaBOQmOwwHAnAz42jLgDg8ccf9+R/+Zd/8eR169YV2sRkegkRk9Zz2LBhBz5v3rwZe/bssY0DI31MYY2kMIU1kqJyGzaU4SOUJSQm0pZtVs1mYscVbqNl+uPIWrZZP/KRjxTa8GYC27Ba1Cwf27p1a+GctWvXejKXadKcsWfPnu3Jy5cv92StrFPIho3Z1ODnn7dXO8lnY1y+fDnee+89s2GN9DGFNZLCFNZIikptWBFxeVtR67sZ63wxv2f7OcYWYzuXHavZxgWK66zsGM4ONEDR5tu2bVvhHF6HZdtfC9ZkO5fPaZT5upMyNiw/Fx47X3fPnj3mwG0cHJjCGklhCmskhSmskRSVbxzkJyHaxgGPhyc62sSgynvIU2ZTIyRr1ylTHqrMhDbGsShmssoTTW6jOSPlJ2bbtm3D3r17bdJlpI8prJEUprBGUlQeNZu3ZzQbNuTsG1MqKSbNechhRnOs5vGyPR3TT5koU61NaJG/jG2stdEch0JtQs9Fa5P/zho9I3vDGkkRU7rzMBF5XkTmZaU7/y07Pl5E5ojIChG5W0SKCaAMo8nEvGF3A/i4c+5kAFMAXCQiZwL4NoDvOecmAtgC4PrWDdMwasQU5XAAOr0m+mT/HICPA7g2Oz4TwDcB/FfE9Q58DtlHQDGgMKbsUcjJQ+ubrxGz3svOL1rGQw4O5LFojuLct5aRuozDTxl4fNqzZDT7P08+y4uG5kjeSWxhud5ZyaP1AB4DsBLAVudc5+hXo1Z/1jBaSpTCOuf2OeemABgD4HQAx8V2ICI3iMhcESnGbBhGF+nSKoFzbiuAJwFMAzBERDr/XowBsKZOmwOlO7s1UsNA3CrBESIyJPvcF8B0AItRU9yrstOiSncaRneJ2TjoADBTRHqjpuD3OOceEpFFAO4SkW8BeBm1erQNERFvoqJtHHCN1JhoVp7Y8ERNW4jm62hp5RmeDMT0M3ToUE/mjCwxE0+tbiyPJeSkAhTvOWbjICZVJsMlo9577z1P1qIs8qWqGm0cxKwSzAdwinL8NdTsWcOoDNvpMpLCFNZIiqqjZjegVqp+OICNlXXcPWysraPeeD/snDtCa1Cpwh7oVGRuKstcNtbWUWa8ZhIYSWEKayRFuxT2ljb1WwYba+vo8njbYsMaRlnMJDCSolKFFZGLRGRpFqUwo8q+YxCR20RkvYgsyB0bJiKPicjy7OfQRteoChEZKyJPisiiLBLkpux4jxtvU6NWnHOV/APQGzU/2gkADgEwD8DkqvqPHON5AE4FsCB37DsAZmSfZwD4drvHmY2lA8Cp2eeBAJYBmNwTxwtAAAzIPvcBMAfAmQDuAfDZ7PgPAXw5eK0KBz0NwKM5+esAvt7uh6mMcxwp7FIAHTklWdruMdYZ9wOoedL16PEC6AfgJQBnoLZp8CFNP+r9q9IkGA1gVU5OJUphpHOus6DAOgAjG53cDkRkHGoOSnPQQ8fbrKgVm3R1AVd7FfSoZRURGQDgXgBfcc5tz/+uJ43XdSNqJU+VCrsGwNicXDdKoYfxjoh0AED2c32bx3MAEemDmrLe7py7LzvcY8cLlItayVOlwr4AYFI2MzwEwGcBPFhh/2V5ELWICqAHRVZIzbP6VgCLnXPfzf2qx423qVErFRvcl6A2m10J4J/bPQFQxncngLUA9qBmU10P4HAAswAsB/A4gGHtHmc21nNQ+3M/H8Ar2b9LeuJ4AZyEWlTKfAALAPxrdnwCgOcBrADwMwCHhq5lO11GUtiky0gKU1gjKUxhjaQwhTWSwhTWSApTWCMpTGGNpDCFNZLCFNZIClNYIym6pbA9PeTFOPgo7UuQpd9chprnzWrUvLGucc4tat7wDMOnO4XlTgewwtXSbkJE7gJwOYC6Cisiwf8doaJqzSo2EcqNqv1HboajUJn7qcpBSStaHMo726yx5fvJPLPUB9MdhdVCXs4INdISEufhBL9ctSQmATCjKQVXgAn1qx0r8+WVUdhQ1cPYvkPVH7WkzpzAeNeuXZ7MVSc1YiqA5/Wi0TVbXrpTRG4AcEOr+zH+MOiOwkaFvDjnbkGWkoZNAu1PEL9NQm8FQE+PTmMoHOO3Jf+vDl1TG5vWhvuOecPyOTFjiSE0Fu2vSmgszfo+8m0a/bXozipBqiEvRsKUfsM65/aKyI0AHkUtScZtzrmFTRuZYSh0y4Z1zj0C4JEmjcUwgthOl5EULV8lYPIGdYyRz0a9tsQTqj/FdbyA4sQgtNym9R2zdsvETKiatdbcVWKKSHPNsHfffbfQJrTcp03U8sca3b+9YY2kMIU1ksIU1kiKym3YvH1TZh9ds2H5OnxOjG3JbWLs69A4YvvuyfD4eWs25v40m5WpYuPAMCrHFNZIClNYIykqt2Hzdl6M4wSvA2rrluy4UsbVjm3WMrZnmTaa3cvPRbtuyJ+X3QK16/KzjbE133///YbXAMLukFo/eXfPRs4z9oY1ksIU1kgKU1gjKUxhjaSodNIlIt5kIGYTIGYCErpGmTYxmwDNCJCMaaOdw04oY8aM8eRzzz230IadgLZs2eLJffv2LbR56aWXPPmdd97x5N27dysj9omZzOV1wTYOjIMGU1gjKUxhjaSo3IbNLzRri86hxe333nuv0Ca0uaDZUGwDDhs2zJO3b/eKCgII5yXQbE1uE3LU0a6rOZd/+MMf9uQvfelLnnzZZZcV2vAGy4YNGzx53rx5hTZvvvmmJ2/bts2TOb+D1g+fs3PnzkKb/NymUV4Ce8MaSWEKaySFKayRFJXasM45zz7RbFg+xut8MUF7bJ9qNuzUqVM9+U//9E89ee7cuYU269at82Re19y6dWuhDd8P2418TaB4P4MGDSqcc/bZZ3vyaaed5snspAIACxYs8ORnn33Wk2fNmlVos3HjRk/moEPNhuV1VB6L9h3mv2dbhzUOGkxhjaQwhTWSwhTWSIq2Rhxoi+YxyXsZntj069ev4e+BoqMHR4NqGwfLli3zZHYeidkIYWLanHLKKYVzPve5z3kybyQ89dRThTa33HKLJz///POerEUKM6EoWo2YaIj85kijcdgb1kgKU1gjKUxhjaSo3Pklb6uUiYDVHEzY7mUHGa0ftvGeeOKJYJtQVj7NSYXbxDjm8HXYMQcABg4c6Mlr16715IcffrjQ5sUXX/RkLasjU8YZnuE2mnNL/jnYxoFx0GAKayRFUGFF5DYRWS8iC3LHhonIYyKyPPs5tLXDNIwaMTbsjwF8H8D/5o7NADDLOXdzVmN2BoCvhS4kIl7xMs2G4mOhwL/O63blGkDY+TqmEmIoe0wMmq08YMAAT+YAQ6Bo577yyisNZaD4XGICIHnNNMbuZZqZUTz4hnXOPQ1gMx2+HMDM7PNMAFc0bUSG0YCyNuxI51zntHQdgJFNGo9hNKTby1rOOdeo6HG+dGdMfLphNKKsBr0jIh0AkP1cX+9E59wtzrmpzrmp7aqOYhw8lH3DPgjgOgA3Zz8fiGm0f/9+z1kiZnG+DGUcaJgyJYw0+D8pO7to/4knTpzoyWeddVbhHN444M0SbQIYym6jOeJwREGZ1KaM9h3n9aJbGwcicieA2QCOFZHVInI9aoo6XUSWA7gwkw2j5QTfsM65a+r86oImj8UwgtgsyEiKyh248/ZlM+xVoDmp2ptRnkizAdnWZEdr3iQAgOuuu86TTzrppMI5vKA/ZMgQT+7o6Ci0efvttz05JnNNzMYNE7KVtX7yz84cuI2DBlNYIylMYY2kqDzzS94+aVaZoGbYn2VsWt65O/zwwwvnTJs2zZP//M//3JPHjh1baDNypL/TrQXtsZ131FFHefIZZ5xRaMNZXF5//XVP1hxbmrE7ydfQvsPYTSV7wxpJYQprJIUprJEUprBGUvS4qNlQivVmTLCA4iI/O3loqelDaT05hScAfPOb3/TkY4891pO1RfJVq1YFx8ITJI6sveiiiwptVq5c6ckrVqzw5GY5I8VsFITa1MPesEZSmMIaSWEKayRFj7Nhm+UQw/0yvBg/ePBgTy5TkpJtT6CYbWXJkiWefMcddxTacPkhdqABgCuu8OM+L7jA9/YcNWpUoc3w4cM9uVnzgRChjDl8jmV+MQ4aTGGNpDCFNZJCqrJjAKBPnz4u72isOTxz6SAOKIzJ/FImW0w+I432e6AYgBeT6YXvkduUcYgGig7bl156qSdfffXVhTa8nvv//t//8+Tly5cHxxKTTZKPcZYazaEm32bXrl3Yv3+/ujBrb1gjKUxhjaQwhTWSwhTWSIq2Rhxo9VC1dOJ5ykQcxKTb5I2CmPTvMROm0P3EoPXDNV95wqSVbeLySTfddJMn/8M//EOhDd9zmXSbMZPg/OS0kSOMvWGNpDCFNZLCFNZIiraW7uTFekB3Vs4Tsn+Acg40vEGhXaMV2WG0TIsxzsxcnpQdW7RoXM46M2HChIZjA8I2a5ksj9r95Z3hG5UDtTeskRSmsEZSmMIaSWEKayRFpZOuffv2YceOHQfkmFpYjGaw8yI/T+Z27typjqURzfJi4/H27dvXk7VJZjPSyk+aNKnQhp9T//79PZkjh4HiBkWZSVZokwbwvdgafTf2hjWSIqbGwVgReVJEFonIQhG5KTtu5TuNyol5w+4F8FXn3GQAZwL4GxGZjN+X75wEYFYmG0ZLiSnKsRbA2uzzDhFZDGA0auU7z89OmwngKUTUm6VrB89h+01LPclZT7g262uvvVZos23bNk8uEwkQA3vXczQrR1ho8P0BwPnnn+/J06dP92SOAgaKmwBLly71ZN6M0MbXjDJHWsRBft7RaOOnSzasiIwDcAqAObDynUYbiF4lEJEBAO4F8BXn3Pb8m69R+c586U7D6C5Rb1gR6YOast7unLsvOxxVvjNfurMZAzb+sAm+YaX2Kr0VwGLn3HdzvypVvjO/xlZmTU+zfwYNGuTJn/70pz2ZM6kAwIIFCzyZ7VzNuTzkwK05j3Aa+VNPPdWTtbVPtj+PO+64wjnnnHOOJ/O6rAY7dXOmGs1pvar6wLG2cYxJcDaAzwN4VUReyY59AzVFvScr5fkmgGJcsWE0mZhVgmcB1PtvZuU7jUqxnS4jKUxhjaSoPOIgVPeJHR/Y6Nfa88RlxIgRnnzxxRcX2lx44YWefP/993vy/PnzC23YiYYjYrUFfk6DyRMorY7suHHjPFmr/8U1annCxxsjAPDWW295Mk+6YlKMliEmhXz+O2w0DnvDGklhCmskhSmskRSVp4zP26BlHCm0KM7Vq1d7Mm8KfOpTnyq0OeGEEzz5yiuv9OT164sbd9wPL8TzBgYAdHR0eDLf8/jx4wtteAE/ZvGebX/NMZzvievgzp49u9CG69OWyX7DhDLZNM35xTDajSmskRSmsEZSVL4Om18v1GyVkL2m2T/sqDJ37lxP5qx9QNGG5XVNDtADivZmTFY+vkdeLw2tS9e7Ljuc8zPQbP2hQ/0oJrZ7tYyHoawtZZxjNCeb/DqsBSEaBw2msEZSmMIaSWEKayRFW9Ntah76ZVKss+G/du1aT37kkUcKbbhvXkTX6rvyRCwmQwsf40mYtsC/ZcsWT9YmULygz89Ni5rlvn70ox95Mj83oNzGQGhipk228xlxLN2mcdBgCmskhSmskRSVO7/k7b6YdOmhOrJAcRF906ZNnvzMM88U2ixatMiTOcX6McccU2hz5JFHevLo0aM9OZ+ZsZMNGzZ4Mjsna3bjypUrPVlz4ObxTp3qR9FrY3n66ac9ec6cOZ7cqmw3bPtzZh7Adxx69dVX61+7m2MzjEoxhTWSwhTWSApplt0SQ69evVw+S12MPcqOEprdy0GInOGQr5mNxZN5LFqWRO6Hx6Y5dbAtGVNeiddUtfVqdgzn4EYtIJJtWLafywQhamvP/Gy5JJOWET3/HX3wwQfYv3+/6lVjb1gjKUxhjaQwhTWSwhTWSIpKJ119+vRxea/3UB1ToGjAa84ioTI7MfcYU582tImhTUDKlHFitElXvjYrUJwkapNTnuw0IwI2lP4dKE4itTb5dPU7duzA3r17bdJlpI8prJEUprBGUlS+cRCKjuTSO2yraXYv23gcQaptHIScimMiYGPsz9A5bO8BxQ0KzeZjWz5m/GWc40MbLGWc1kN27/vvv499+/aZDWukT0zpzsNE5HkRmZeV7vy37Ph4EZkjIitE5G4RlaxgQQAAIABJREFUKVaXMIwmE/OG3Q3g4865kwFMAXCRiJwJ4NsAvuecmwhgC4DrWzdMw6gRU5TDAehcwOuT/XMAPg7g2uz4TADfBPBfXepccRbhY2x/anZYmbKbIaeamDVittU4e4x2HR6b9gwYzRlbs8sbjQ2IyzLD8Phi7GBuwzasViI0P7ZuByGKSO+s5NF6AI8BWAlgq3Ou86mtRq3+rGG0lCiFdc7tc85NATAGwOkAipXO6iAiN4jIXBGZW+WKhHFw0qW/Ec65rQCeBDANwBAR6Xz3jwGwpk6bA6U7q6qqZxy8xKwSHCEiQ7LPfQFMB7AYNcW9KjstunSnYXSHmKjZDgAzRaQ3agp+j3PuIRFZBOAuEfkWgJdRq0fbEI6a1UwE3gTgBfJGqRg7YUcQzbGFF+zZ0NdqwPJEh/vRJmp8HT4npqZtzGQpJrqYxxuTOpMnUPz9aM+Wy05t3rzZk4cMGVJok3fMafSXOGaVYD6AQoJV59xrqNmzhlEZttNlJIUprJEUlTq/iMgG1ErVDwewMXB6T8HG2jrqjffDzrkjtAaVKuyBTmtrslPDZ7YfG2vrKDNeMwmMpDCFNZKiXQp7S5v6LYONtXV0ebxtsWENoyxmEhhJUanCishFIrI0i1KYUWXfMYjIbSKyXkQW5I4NE5HHRGR59nNoo2tUhYiMFZEnRWRRFglyU3a8x423qVErzrlK/gHojZof7QQAhwCYB2ByVf1HjvE8AKcCWJA79h0AM7LPMwB8u93jzMbSAeDU7PNAAMsATO6J4wUgAAZkn/sAmAPgTAD3APhsdvyHAL4cvFaFg54G4NGc/HUAX2/3w1TGOY4UdimAjpySLG33GOuM+wHUPOl69HgB9APwEoAzUNs0+JCmH/X+VWkSjAawKienEqUw0jnXmUh1HYCR7RyMhoiMQ81BaQ566HibFbVik64u4Gqvgh61rCIiAwDcC+ArzjmvHHdPGq/rRtRKnioVdg2AfOmTulEKPYx3RKQDALKf69s8ngOISB/UlPV259x92eEeO16gXNRKnioV9gUAk7KZ4SEAPgvgwQr7L8uDqEVUAD0oskJqXs63AljsnPtu7lc9brxNjVqp2OC+BLXZ7EoA/9zuCYAyvjsBrAWwBzWb6noAhwOYBWA5gMcBDGv3OLOxnoPan/v5AF7J/l3SE8cL4CTUolLmA1gA4F+z4xMAPA9gBYCfATg0dC3b6TKSwiZdRlKYwhpJYQprJIUprJEUprBGUpjCGklhCmskhSmskRSmsEZSmMIaSdEthe3pIS/GwUdpX4Is/eYy1DxvVqPmjXWNc25Rgzauq0mNeXxlamPF1ICNeQ6hc1qVsLlZNWxjngsTqsEbU6O3DM45dXAx+WHrcTqAFa6WdhMicheAywE0UlgvL2tMrteYXKmcs5RlrXgb52nl3K/aF8Hn8BeuFdjgc/ietcLHrIxartrdu3c3vI72nLhIX4wCc95cPiemWDXfc6hgSCO96I5JkGrIi5Ew3XnDRiEiNwC4odX9GH8YdEdho0JenHO3IEtJ07t3b5dPW963b9/CRbU/MXm0P3UhO0pL5c5/dvga2jX5T1moDqvWT5k5Q8z4Y34f+lOtjS3muXQVrZ9Y+787JkGqIS9GwpR+wzrn9orIjQAeRS1Jxm3OuYVNG5lhKHTLhnXOPQLgkSaNxTCC2E6XkRQtXyXIw3W6tCK4XHw3xhgPbS5o/ZTZkGCaUT9Lm4Boa7MhYu6HJ1n8rGMmhHzPWj88fr4urwcD/lr5li1b6vcfHKFh9CBMYY2kMIU1kqJSG3bfvn1eTVHNBgzZUdqCONtMvOcfA49FWyAP2awxDifsb6Bdk2vCajZ4qJ8Yhxk+J2azhNHs7f79+3vypEmTPHnVqlVg8jV3G+mAvWGNpDCFNZLCFNZIikqTwfXq1cvlbTitb7Y/2caLsXvZFotZK4wh9KxiniX3q40txjc3RJl15Zh+YmxlXmfl9d6Q3bt161bs3btXvQF7wxpJYQprJIUprJEUprBGUlQ66RIRb9KlGfk8nhhni9A9aP2w4c8L+lo/7Pkf8+w4gJDbaJscMQv6rZiIxUQChJx5Yq4bE4RYL2rW3rBGUpjCGklhCmskReUO3HnHDs3+0SJE88Qk34ixmUK2ZBkHGg1OeBGzEdKKSFUg/FxiNlN4LDE2bBm7tx72hjWSwhTWSApTWCMpKrVhe/fu7Tk5aLbl1q1bPbkZmVNiMrK0ilC2lZi16KrQkuYx7MgSY183IzNkJ/aGNZLCFNZIClNYIylMYY2kqHTS1adPH4wZM+aAnI+g7YQX2jn9ZrOcPto1seGIWG3jICbioEzKeO67o6PDky+88MJCmwkTJngyR/CuW7eu0IajYpcsWeLJ27dvL7TJ37OmF53YG9ZIClNYIylMYY2kqDzzS35jQMtows4vMRGwDDtNa6np33333S5fN8ZxhTn88MM9eerUqZ6s2aK8eaKxY8cOTx40aJAnjxs3rtBmyJAhnnzcccd5Mtu0APDGG280HJs2VrZr2Wbdtm1boU0omroTe8MaSWEKayRFUGFF5DYRWS8iC3LHhonIYyKyPPs5tLXDNIwawSBEETkPwE4A/+ucOyE79h0Am51zN2c1Zoc6574W6qxPnz5u6NDf67bmrN1oDa4eAwYM8OQTTzzRk6dNm1Zos3HjRh6bJ2uOIKNGjfLk/L0AwMCBAwttOHPf+PHjPVl7BvydaDYfZwhkO11bu129erUns3161113FdqsXbvWk/m55bMOdsLjZztXm7vkncf37t2L/fv3lwtCdM49DWAzHb4cwMzs80wAV4SuYxjNoKwNO9I51/lfbx2AkU0aj2E0pNvLWs45JyJ17Yp86c6YZSDDaERZDXpHRDoAIPu5vt6JzrlbnHNTnXNTTWGN7lL2DfsggOsA3Jz9fCCm0b59+7wJhOb1HypVrkV2Tpw40ZNvuMGvxTxlypRCG15oj4kY5TSSWvkehjPK8OROewZ8zzzZA4rj5VJBy5YtK7R55BG/BuDjjz/uyeykAhSdj2IiNUJRst3JZBOzrHUngNkAjhWR1SJyPWqKOl1ElgO4MJMNo+UE37DOuWvq/OqCJo/FMIKYUWkkRaXOL0yMwwnbankH8E5uuukmT/7MZz7jydpkj21LjgZl2007hzc5VqxYUWjDzsy8CcDjAIqOK0cddVThHLaf2f782c9+Vmhz//33ezI70GjZbmLszxAx33P+HHN+MQ4aTGGNpDCFNZKiUhvWOeet48VkfGbY0QUoOqqww7DWDzuPvPbaa56s2aNLly71ZHYemT17dqENO36ws4jmZHPllVd6MtvkQHH8r776qic/99xzhTZsc7NN3iq6muHQbFjjoMEU1kgKU1gjKUxhjaSoPGV8PqJVW6hm5wp2FtGyhnzve9/z5Ntvv92TeUIFFCc7PIHiRfV6481TJn063592zvDhw4Pn8GRu/fqiAx2Pv0yK+DLEpIzPb+406tPesEZSmMIaSWEKayRFW8secdQpUHQOYZuWozYBYPNmP0aSbSYtMpXtpJhU7lXBUb6DBw8unMM2N290cGYboHiPbMdr98yOQ2XKHlnKeOMPFlNYIylMYY2kaGvZo5isgmx/ag4boZL1mgM3r3/269ev4TW1vlmOscPYYVt7BpxFUFur3bRpkye//vrrDcemwePV5hR8HV7v1e6Z13tjSqnm71HLDNOJvWGNpDCFNZLCFNZIClNYIykqTxmfdyrRFrf5WDMW8DUnD140Z/nMM88stPnoRz/qyWvWrPHk+fPnF9qwEwqXdRo7dmyhDafo1J4BT7LYKSgmowxPhrTvIzSR5PT82jG+59DYGkWd2BvWSApTWCMpTGGNpKg8aja/EB2TvbAMfA3NhmW7kBe7tcV6LmPJGVq0LIMcSfvOO+94smbDsg2opWXnVO6cqSZmE4Mjb2M2G9i+jPm+eLNE+z7yJZk2bNhQ91r2hjWSwhTWSApTWCMpTGGNpGjrpKsqtIkBj4MnAlrK9Z/+9KeezBOzt99+u9CGa2MxWl0yjibQIg7Yi41TIpXx8ucFfiCcljQm3RQ/W62f/MTSUhUZBw0xNQ7GisiTIrJIRBaKyE3ZcSvfaVROzBt2L4CvOucmAzgTwN+IyGQAMwDMcs5NAjArkw2jpcQU5VgLYG32eYeILAYwGrXynednp80E8BSAhvVmRcRzMtHsWV7Q72q68WycDa8JFDcKONPL4sWLC22WL1/e8LplFtE1e44dWbQUoxwhERNlwc+FNyRi2sREzfJ1tKjlRm0aPccu2bAiMg7AKQDmwMp3Gm0gWmFFZACAewF8xTnnvQJc7b+ZOrUTkRtEZK6IzO3WSA0DkQorIn1QU9bbnXP3ZYejynfmS3c2Y8DGHzZBG1ZqBuKtABY7576b+1Xp8p2dxKzhheQ6Yw62CZ2j2ZYxtlgItp21sbFtyWU5gWJkKV9Xs9tDz65Mm5jrlMnqWI+YjYOzAXwewKsi8kp27BuoKeo9WSnPNwFcHdWjYXSDmFWCZwHUU38r32lUiu10GUlhCmskRVvTbcakKorxcA8Z9TEL4qF08K2Cvf6BYmSD5iDDaUdjIg74WEwKoa5eQyNmEpx3kGnaxoFhtBtTWCMpTGGNpGhrrdmYFOXsLBKTCYav0aro3DLE2IDs8KyVMOLNhDL3w20GDhwYHAs7imvfRxlbOd+PZX4xDhpMYY2kMIU1kqJSGxbw7RPN7uL1UD4nlG5cO0fLyLJu3bqG/VZFPuNJJ+ycPXr06MI57NTNtmbMmirPD0aMGFE4h9fFee08JoU/o2XVyQdaWuYX46DBFNZIClNYIylMYY2kqHzjIO+1H+OgwWiOLDzB4IkA17QCwik5W7WxEBorUHR20SIduB1PoLTnxPCi/1tvvVU4JyZrC8P3GDOW/OSTawd71wpeyTB6EKawRlKYwhpJUfnGQYzDbx62zcrYvZqdyHYVL2ZX5RyjOZxomV4Ytj9jnhPf86BBgzyZM84AxWcXykyoncP3o23kTJw48cBnLQtkJ/aGNZLCFNZIClNYIykqt2GbUYozBNtqXJYTiMuU0gq4pNG5555bOIft2pjM2DHOO2zXcuCidg1+lmyz8jiA4ng5k82SJUsKbfLZIi0I0ThoMIU1ksIU1kgKU1gjKSqfdOWN+DIlczRHCjbSY9I98kSMZa4J2yyGDx/uyWeddVbhHJ4MaVGznNKeJzoxGyzsVBOTlpQ3ErSJWqhUkkb+e240AbY3rJEUprBGUpjCGklRuQ1bBWwDsU0IFO05bQG8GbANyE427IACFB2pH3/88cI5q1at8uQyUb8xzyBUwkize8uUPYrF3rBGUsSU7jxMRJ4XkXlZ6c5/y46PF5E5IrJCRO4WkUNC1zKM7hLzht0N4OPOuZMBTAFwkYicCeDbAL7nnJsIYAuA61s3TMOoEVOUwwHojIrrk/1zAD4O4Nrs+EwA3wTwX6Hr5W2eGPtHcxBmypTZ4euyU0rM2mEM3M/JJ5/syZpjDtuwnG0bKK67sm0cUxaV0drw+GPKooay9Rx22GFRfWvEFpbrnZU8Wg/gMQArAWx1znVa+qtRqz9rGC0lSmGdc/ucc1MAjAFwOoDjYjuw0p1GM+nSKoFzbiuAJwFMAzBERDpNijEA1tRpY6U7jaYRs0pwhIgMyT73BTAdwGLUFPeq7LTo0p2G0R0kNEERkZNQm1T1Rk3B73HO/X8iMgHAXQCGAXgZwJ855xqmBenVq5fLG9zaYrdWCimPZuSHDHaeUAHFSQp7xbPcLLjfo48+unAO36N2z6tXr254XU6TCYQzssREHMTAkyqeIGpRwflzdu3ahf3796v5QmNWCeYDOEU5/hpq9qxhVIbtdBlJYQprJEXQhm1qZyIbUCtVPxxAcTW8Z2JjbR31xvth59wRWoNKFfZApyJzU1nmsrG2jjLjNZPASApTWCMp2qWwt7Sp3zLYWFtHl8fbFhvWMMpiJoGRFJUqrIhcJCJLsyiFGVX2HYOI3CYi60VkQe7YMBF5TESWZz+HtnOMnYjIWBF5UkQWZZEgN2XHe9x4mxq14pyr5B9qvggrAUwAcAiAeQAmV9V/5BjPA3AqgAW5Y98BMCP7PAPAt9s9zmwsHQBOzT4PBLAMwOSeOF4AAmBA9rkPgDkAzgRwD4DPZsd/CODLwWtVOOhpAB7NyV8H8PV2P0xlnONIYZcC6MgpydJ2j7HOuB9AzZOuR48XQD8ALwE4A7VNgw9p+lHvX5UmwWgA+djkVKIURjrn1maf1wEY2c7BaIjIONQclOagh463WVErNunqAq72KuhRyyoiMgDAvQC+4pzzqmr0pPG6bkSt5KlSYdcAGJuT60Yp9DDeEZEOAMh+FjOztQkR6YOast7unLsvO9xjxwuUi1rJU6XCvgBgUjYzPATAZwE8WGH/ZXkQtYgKoAdFVkjNG/tWAIudc9/N/arHjbepUSsVG9yXoDabXQngn9s9AVDGdyeAtQD2oGZTXQ/gcACzACwH8DiAYe0eZzbWc1D7cz8fwCvZv0t64ngBnIRaVMp8AAsA/Gt2fAKA5wGsAPAzAIeGrmU7XUZS2KTLSApTWCMpTGGNpDCFNZLCFNZIClNYIylMYY2kMIU1ksIU1kiKbilsT48gMA4+Sm/Nikhv1PwCpqO27/4CgGucc4uaNzzD8OlOcarTAaxwtSyGEJG7AFwOoK7CiogjOdgJ/4eKaRMDXyeUihIo5vuPqa3A53D+/xhiakFw3zEvojLPshn9aM82/5wyR5dy6TYboEUQnBFqlC9eFvNF8BfMeVCBsOJo/XARNc5p2q9fv0KbwYMHe/LOnTs9mfOgArVcp3l27NjRcKwaWn7bUBERLWcu37P2LEPw/cTklGVZyw+bz8fLfeRpeSVEEbkBwA2t7sf4w6A7ChsVQeCcuwVZho9evXq5/J9VreQPv6X4z7BWBilUziemZD2/LbVykzw2vob2VuOyoTElNvkvgjYWfg4hEwEojpef/5AhQwpt+Nlu2bKlYb/a2Pga2v2E/vIe6K/ub8KkGkFgJEzpN6xzbq+I3AjgUdRyDtzmnFvYtJEZhkK3bFjn3CMAHmnSWAwjiO10GUlRaUxXr169XH4pRZss8bHQeml23Yay1g9PfriN1g8/q9DkQmsTsw4bU283tIaqTe5Cy33aMtfQoX5qLm6zYcOGQhtePmO5f//+hTb5Z7d582bs2bNHvUF7wxpJYQprJIUprJEULd/pyuOc8xbXNTuM7cCYBXE+hxfwtTahPfEye/4xJUJjfs9bl5o9yhsSLGvPNnRPmg2+fft25czfE7Nx8OEPf9iTV6xY0XBsjcZpb1gjKUxhjaQwhTWSourSnU5bU8zD4+E1PM1mYps15AwT069GaN3yyCOPLLQ5/vjjPXnatGmerNm9RxzhV63USsm/+uqrnrxw4cKGvweKDj4xbph9+/b15Jj5AX9nMeS/sz179tQtP29vWCMpTGGNpDCFNZLCFNZIirY6v2gLxGz4xxjwZSZdofvWJiDsoX/sscd68nnnnVdoc9VVV3kyt+FYMm1s2sbB6tWrPfl3v/udJz/00EOFNnwOx5dp98yT5JiIie4Gju7fv79uEKK9YY2kMIU1ksIU1kiKSp1fAN8m0jYReDGeNwry8eudxDh5M2xnxThwjxo1ypO/+MUvevIVV1wRbBMTEcs2uLa5MHq0XzTwwgsv9ORx48YV2vCze/HFFz1Zi/plmzXkYA+EI3rLOBYduFbplobRBkxhjaQwhTWSonIbNm87xmRx4Wwrmp3FdhTbfJrNFHKy0eA27GBy4oknBq/BmVPmzp1bOIcduDdu3Fg4Z/jw4Z48YsQIT2bbGQA+8YlPePL8+fM9WctpFVrTjskww3J3EvrZG9ZIClNYIylMYY2kMIU1kqLHZX5R2niyNoEKZUrR2vAxTmCspZ7UEvHm0TKa8PPliFFtAsJj0SJXBw4c6MkcyfClL30p2GbGDL8sxfPPP19ow+OPyTpeJrt5nr1795rzi3FwYAprJIUprJEUlW8c5InJThJj57KDBssx2WIYrV9e9OdsK9qmBjvzhJxugGJGQM1pmjdUXn/9dU/etGlToc2ECRMayi+88EKhDX9HMc4vIRtWe7b5eUerUsYbRuWYwhpJYQprJEXQhhWR2wBcCmC9c+6E7NgwAHcDGAfgDQBXO+e21LtGVwitCzdr3Zivw44fmqN4mSqAbK8dfvjhwX5i4DXho446ypOnTJkSbPPKK694srZeXSaLSxmH+liHmJg37I8BXETHZgCY5ZybBGBWJhtGywkqrHPuaQCb6fDlAGZmn2cCKMaGGEYLKGvDjnTOrc0+rwMwsknjMYyGdHsd1jnnuEp3Hqs1azSTsgr7joh0OOfWikgHgPX1TszXmhURlzfsY1K5VwVPOJo1jlDUKWdf0frWJj5jxozx5FNOOcWTR44s/tFjJ5qtW7d6cpnyShqhtKShyIZGz76sSfAggOuyz9cBeKDkdQyjSwQVVkTuBDAbwLEislpErgdwM4DpIrIcwIWZbBgtJ2gSOOeuqfOrC5o8FsMIUrnzS3ciJstes522MvfDads15xc+1tHRUTjnj/7ojzz5U5/6VPC67KDNNqtWgomvo2WqCREqkwr432GjDIm2NWskhSmskRSmsEZStDXzSxk7slk2cChbYZkMe5ptxoF/gwcP9mTN6ZszfX/yk58snHPttdd68tixYz2ZyyABwP/93/95Mq8Ba98Hj4Wd1kP2qHZdzYE75FB/4Lyoswyjh2AKaySFKayRFKawRlJUOukSETX9eR72wA8Z8PX6yaMZ9Ox9z4vmWraVUN+akwrXauU0mFwGCQCOOeYYT77oIvafB8aPH+/Ja9as8eT77ruv0GbJkiWezJG3GuyoEhPFHIpSiIm0rYe9YY2kMIU1ksIU1kiKym3YvK0SY482w0lFs5s/97nPeTKXLOKSQEAxRTyPTXOAHjp0qCezrfz3f//3hTacOVEb/7vvvuvJzz33nCc/+eSThTZLly71ZC4bytcE9I2NPJpNG2oTex0Ne8MaSWEKaySFKayRFJXasM45z+6LKWVetp88mtPxM88848n/9E//5MmnnXZaoQ2Pl21WbS2R14A5S7dm98aMn0shccZDLaNMKKtjzPdRZl08hvzabSMb2N6wRlKYwhpJYQprJIUprJEUlU+68gZ17GJxM/plli9f7sn/+Z//6cmf//znC23Y4YQdWzQnm1DEqBbZwJMs7TnxBsTRRx/tyZwOHihOzDjioFnfR5l0/PnJp026jIMGU1gjKUxhjaSoPGq2q3ZSV8s+xvbBdtKdd94ZbMOO1JymXYtU5VKd8+bN82TN2XnixImefP755xfOYUfwk08+2ZOvuaaYYYrHx2WcmgU/f94c0Zx58o44jbLL2BvWSApTWCMpTGGNpDCFNZKix0+62EDnxXoAGD58uCdzKvRt27YV2vBmAqfgefrppwttuJ4rR94uW7as0IZrvq5bt86TBw0aVGjDE8KzzjqrcA4/B06JdM455xTaTJo0yZNXrVpVOKcVxHif5TdQGqWJsjeskRSmsEZSxNQ4GCsiT4rIIhFZKCI3ZceHichjIrI8+zk0dC3D6C4xNuxeAF91zr0kIgMBvCgijwH4AmrlO28WkRmole/8WuhioahZ3hjg9JQnnnhioc1VV13lyf369fPk733ve4U2bOeyhz7bnkBxoZ0zp3A6eO0cXkTn2rNAsYTRuHHjCudw5AKnxWT7Gig6xPzmN7/x5FZFgPC8RYvMyH9n2nPsJKZ051rn3EvZ5x0AFgMYDSvfabSBLtmwIjIOwCkA5sDKdxptIHpZS0QGALgXwFecc9vpT3vd8p1WutNoJlEKKyJ9UFPW251znWnxosp3culOuq7WlyezbXbBBcXyYBdeeKEnc9nKyZMnF9pw1pMf/OAHnswO3kAxkx/btJojC6dynzZtmidfeeWVhTbs2MJ2PBB2BOf7A4AvfOELnnz33Xd7slZGlCmTrScmM2Fs9G3MKoEAuBXAYufcd3O/svKdRuXEvGHPBvB5AK+KyCvZsW+gVq7znqyU55sArm7NEA3j98SU7nwWQL13upXvNCrFdrqMpKjc+SU/WYhJ7cObAK+99lqhDafB5HSVWgQpL6z/7d/+rSdzenWg6PzCjjlaeiN2OAmlqgeKC/ha+vrNmzd7MjvRaF79xx13nCePGTPGkzXnndDYytCd2r/2hjWSwhTWSApTWCMppFnpEmPo1auXy9tsMakm2YbVHJ4vvfRST/7rv/5rT9acR3hhne1pzdGcF+e5TajcD1C8P+35szP57373u8I5bOufcMIJnjxs2LBgmwce8JfOb7rppkIbtpXZmac79mievC7s27cPzjl1ZcresEZSmMIaSWEKayRF5euweVtFWytk25ED8jQHjaeeesqTR4wY4cnTp08vtGEnaXayiXHY4DVJdo4Bio7hvI7MQYlAcW32/2/v/WO1qq78//e6FAQEhQuIV0B+CGqxo2KRH6laizKxpq06Y4x++nPihKapqaadRGyT5tukM1OdiU2mTeqQSAY7RsRiR0btUKRUq9O5/uKHCCI/FLl44QLy6yqiwPr+cc7Fs9dZz7P3Pfd5zvNsul7JzX3Wec4+Zz/nWXfftfZeey2ZLQbIf0YZMKNlyJEbF6U/MGfOnFwbGQS0fv16R5b2NuC3YbVnm9UF7Tn2YCOsERWmsEZUmMIaUWEKa0RF6QsHWedGC/yQWUFk/zRHTU7Yyywo2gLFRRdd5MhycUGbeB81alTV+2rBI3J3rnRaNOSu0XfffdfbRma/0fovdy7I2rJa+k2ZZl6eU0R/tO896wAeOHAAx44ds4UDI35MYY2oMIU1oqJ0GzZr92kTyDLARNqf1TLbVbqu9hll8ItcsNCyJMrgaznxLu2f0i7+AAAgAElEQVQ9IN9fGTwig3uAvA0r22jIhYKQHcny2WqLDdLOLVIaSV5XC0bKLoS89tpr6O7uNhvWiB9TWCMqTGGNqCjVhiUiztpN2vyoDHYJsUclRT5TiA3oa6Pdt4jNFxJMXguKlJAq8mylPyA3iUr27t2Ljz76yGxYI35MYY2oMIU1osIU1oiKUncctLS0OJH92iKAzxGo1S5NSYhjUwtnSH4+zfEMuY/PGQrpm2+RBsgH+MhdFppzKq8jHWktJXw2sKiaw2sjrBEVprBGVJjCGlFRqg3LzI49E2LDyoBtzV6VdpYMFtHuI9tIWe6iBfI7YEPsOd91tfJEcqJdK3UpA21k3zR8iyGaDSufvwy+1vrmy3AobVogWSwIaW8jrBEVprBGVIQU5RhIRC8S0dq0dOdP0uMTiaidiLYQ0aNElN9sZRg1JsSGPQpgDjN3p+WPniei3wH4PoCfM/NiInoAwO0AfuW7WNaO0jYUhmT3k8hAapkdRrOZZOlLeY6W0UTaVtLelpsfteuGlO6UG/20MqK+OVTNXvXNzWptpD0t/QPtmvI7k33T/IOsbVxtLj6kdCczc89Mb//0hwHMAfCb9LiV7jRKIciGJaJ+acmjLgArAGwFcICZe4acDiT1Zw2jrgQpLDMfZ+ZLAYwFMAPAhZ4mJyGieUT0MhG9XGbsrXFq0qtZAmY+AGAVgNkAhhFRjw08FsDOCm0WMPN0Zp4eEhRtGNXwOl1ENArAx8x8gIgGAZgL4F4kinszgMUILN1JRI6j5Uu7CPh3IAD5yWtp1GsLB/KYz6HSkM6EtrtV9kX+l9m+fXuujbyONqEvnR25QKE5mvI6si/aZ5bH5EKH5pzK71B+Hs3pyn4f1f4Th8wStAFYRET9kIzIS5j5SSLaAGAxEf0UwGok9WgNo66ElO5cB2CacnwbEnvWMErDVrqMqCh71+weJJW/RwLY6zm9WbC+1o9K/R3PzKOU4+Uq7MmbJlNc00u/cQGsr/WjSH/NJDCiwhTWiIpGKeyCBt23CNbX+tHr/jbEhjWMophJYERFqQpLRNcR0aY06Ht+mfcOgYgWElEXEa3PHGslohVEtDn9PbyRfeyBiMYR0Soi2pAG1t+ZHm+6/tZ0EwAzl/IDoB+SsMRJAAYAWAtgaln3D+zjVQAuA7A+c+w+APPT1/MB3NvofqZ9aQNwWfp6KIA3AUxtxv4CIABD0tf9AbQDmAVgCYBb0+MPAPiO91oldno2gOUZ+R4A9zT6YSr9nCAUdhOAtoySbGp0Hyv0+wkkgUlN3V8AgwG8CmAmkkWDT2n6UemnTJNgDIAdGTmWoO/RzNyZvt4FYHQjO6NBRBOQxHu0o0n7W6tNAOZ09QJOhoKmmlYhoiEAlgK4i5kPZd9rpv5yHzYBZClTYXcCGJeRKwZ9Nxm7iagNANLfXQ3uz0nSTaFLATzMzI+nh5u2v0CxTQBZylTYlwBMST3DAQBuBbCsxPsXZRmSAHUgMFC9DCiJZH8QwEZmvj/zVtP1l4hGEdGw9HXPJoCN+GQTABDa15IN7uuReLNbAfyo0Q6A0r9HAHQC+BiJTXU7gBEAVgLYDOAZAK2N7mfa1yuQ/LtfB2BN+nN9M/YXwMVIgvzXAVgP4Mfp8UkAXgSwBcBjAE7zXctWuoyoMKfLiApTWCMqTGGNqDCFNaLCFNaIClNYIypMYY2oMIU1osIU1ogKU1gjKvqksM2+5cU49SgcS5BmM3wTSeRNB5JorNuYeUPtumcYLn0pLDcDwBZOshiCiBYDuAFARYUlIs7md9X+WHxJj7X35TF53ZA/ypBky/UIFAopLqzlbS3yGX1FOYp8vpA2vX3+aWSW+oX0RWG1LS8zfZ3KJt7VPoiWvDeLrMQH5BPoygTHWmU9qSi++wL5JMhFvmB5X5mIGMhXo5GVXIB8wmJf9UEA+PDDDx1ZKrCW+Nk3GGiVEOUfmJZcudp9qn2WupfuJKJ5AObV+z7GXwZ9UdigLS/MvABpSpqWlhbnz1Mb1eRfuRxRtdFG/tXLv3DtPr6RI6T+VEgbeUx+Hq1vciTU0rLLOmPyOrJWGZAfDQcPHpw7x9cXOfpp/yHkMW0UloSk6Af6NksQ65YXI2IKj7DMfIyI7gCwHEmSjIXM/HrNemYYCn2yYZn5aQBP16gvhuHFVrqMqCh1E2JLSwtnazSF1M+SBrxWUNl3jZD7+GpYAWFTRz6ks6c5GyHzsNpn8r1fi/lpn7MK+KcIfd/hkSNHcPz4cXUe1kZYIypMYY2oMIU1oqLuK11ZmNmxA0Mmi6UtJieyAX+dVd8aukbIwkEtCFkO1Wxn2b+yfBF5n5DYDllbVluqzX6eap/FRlgjKkxhjagwhTWiolQbNgRp10pZs/mOHj3qyEXsOd+8JuCfk9TsuSKfJ2S+1Be/2yibFsjb3L45b8C1c6vNd9sIa0SFKawRFaawRlSYwhpRUarTRUSOs1BkD5Fm5NfCwQjZhCidhYEDBzryOeeck2szceJER5YT/m+99VauzZEjRxxZW2B5//33HVk6niFOpHRuiuyy0PDtANH6ll0QsoUD45TBFNaIClNYIypKt2G1vAJZfIHUWvCLz64KyTkQcs6QIUMcedq0aY78pS99Kdfm0ksvdeSxY8c68qFDTvFCAHlbsru7O3fOvn37ql5Hs403b97syC+99JIjd3R05NqE7HiVSH9AfufawkD2+dvCgXHKYAprRIUprBEVpQdwZ+fgQuzGWiRy0+YxpZ0o+6Jdc/jw4Y48ZcoUR77mmmtybSZPnuzI0p7T+hay0U8e8wWcAPlsMN/85jcd+d133/X2JeT9kO9VkrWVbR7WOGUwhTWiwhTWiApTWCMqSt9x4MvA7ds9UCTQJWTXrDyntbU1d45cKLj22msdecSIEbk20hmSjo/mHElHbPfu3blz5GLCmWee6cijR4/OtZEO0iWXXOLIzz//vLeNr6+AP/glxAmueL+gswyjSTCFNaLCFNaIiobumg1JGR+Cz64NsY9kkMfevXtz57z44ouOLINhDhw4kGszbNgwR3722WcdeceOHZCsXr3akd97773cOdJmveqqqxz529/+dq6NXLR45ZVXHFkLdJHPTtqf2rP3FfvQvo+QAHrARlgjMkxhjajwKiwRLSSiLiJanznWSkQriGhz+nt4tWsYRq0IsWH/A8AvATyUOTYfwEpm/llaY3Y+gLt9FyIixwbSstjJeUtp2xSxcTV8Wfi0vnV2djryE0884cj/+7//672vDLSWGw61Y9pnlhsgQ8opyQDuDRvcopXaZw6xWSXyWRbJHlkJ7wjLzM8BkFb/DQAWpa8XAbixZj0yjCoUtWFHM3PPcLMLQH5ZxTDqQJ+ntZiZiaji/4ls6c7QqQvDqETREXY3EbUBQPq7q9KJzLyAmacz83RTWKOvFB1hlwH4JoCfpb+fqH56wokTJxyHolZl1SUhaTCL3Ec6JQcPHnRkbUevdCJD7iNTrMudDgBw+eWXO/LcuXMdWasBu3XrVkeWNWyLPKeQlPEhhH7PIdNajwD4M4ALiKiDiG5HoqhziWgzgGtT2TDqjneEZebbKryV38BkGHXGVrqMqCg980vWtgpJhS7t3JAMeyHllGqBvI+W1cb3ec4666xcm8997nOOLO1VAJg9e7Yjy0CctWvX5to899xzjixt8pAyorJNvbJJVsJGWCMqTGGNqDCFNaKi9MwvWfumlkERvSUku4qvjQyi/uxnP5trIzf6yayDV199da7NrFmzHHnw4MG5c2Sw9fr16x35kUceybXZuHGjI8s5Ys2GlbaxnHsOCeAOeda+zakn+1jxHcNoQkxhjagwhTWiwhTWiIrSFw6yhr020S6DNqRjIDPDAH6HSbuPvE6IYyD7dv755zvyN77xjVybmTNnOrIMODn77LNzbaSjo+0EkOnen3rqKUfWsrjIUkkyyEZ7TrK/9djVDLgOX7V72AhrRIUprBEVprBGVJS+cOBbLPCVRdKQ9qcM2Bg6dGiujS+IIySoQ9rBWtC0vLe8hlxIAPI7YrXML6+++qojy2wxWhYa6Q8MGDDAkUMCi0KoZxsbYY2oMIU1osIU1oiK0rMXZufYtPk2aWdJu1DOHQJ5+0fasCG2WUggjrR7ZcDJP//zP3vvI7MZ7tmzx3sfza6Xz05mWyxiR44ZMyZ3TGa7CQmol4E5IZtCLfjFOCUxhTWiwhTWiApTWCMqGlr2KCRDiC9lOZB3QOQ5mnNXZHeuRDoXb7zxRu6cf/iHf6jal3HjxuXa/NM//ZMjT5o0KXfOGWec4cghCy6+8kNa+nrpAMr+a9+hdJRDUsaHLhjZCGtEhSmsERWmsEZUNF3pTnksJEBDIm2mkEn0kMUGibyuVjZo165djiztxv379+fabNq0yZEvuuii3DnS9pU2bchnlrtxtUBxHyHB8RLN7j399NNPvpaLR1lshDWiwhTWiApTWCMqTGGNqGhotJaGbzFBay8nqkMWAbQ6Vn1Fc3R8E+2ao7NixQpH/spXvpI7Z/Rot3CPTJukPUfZF1kzTOu/dHol2rOVTpN81ppT5nPUerAR1ogKU1gjKkKKcowjolVEtIGIXieiO9PjVm/WKJ0QG/YYgB8w86tENBTAK0S0AsC3UKDerC9lvLQ/5Q4DbceBtKPkBL5WNkjuTJX2XBFCPk/IgkRIwI/cjZudeK/URl5X1rTVnq20sWVpp5AFCm1BRVKzHQfM3MnMr6avDwPYCGAMrN6s0QB6ZcMS0QQA0wC0w+rNGg0geFqLiIYAWArgLmY+JIbwivVms7VmDaOvBCksEfVHoqwPM/Pj6eHdRNTGzJ3V6s0y8wIACwCgpaWFfVnq5PyhtDW1eUtf0IZWUlPab3K+MXRe0Icvo0yIrakFmEibNWQeVhIyPyqvU8QG7206/j7ZsJRc6UEAG5n5/sxbPfVmgV7UmzWMvhAywn4OwNcBvEZEa9JjP0RSX3ZJWnt2O4Bb6tNFw/iEkFqzzwOo9P/F6s0apWIrXUZUNHTHgRZY4UsZL50lwB9gojld8t5SPnz4cK5NEXxplDSH6pxzzql6DSC/0CHTa4akdi+SrinEgZLn9NYBtFRFximDKawRFaawRlSUbsP6as1Km1UGTmiBFNJGkkEcWrC2nLDXUqw3CpmSU3tO0paXzyVkR7JccNFsTfns5DWK2MrafbILRLI8UxYbYY2oMIU1osIU1oiK0m3YLEU27WnBItLOGjRokCPPmDEj10ZmXOno6HDknTt3Kj3uO3KeWSuVFFKCSQaqyPlc7Tn55oS1voTMoUqKbDQNvY+NsEZUmMIaUWEKa0SFKawRFU2XMt43mR1Sc6u7u9uRX3jhhVwb6Rj4MpwURfZfOjYTJkzItZk1a5YjazsB3nnnHUeW9WhDnC55jvZ9yOfywQcfOHJIwEwIoaUEbIQ1osIU1ogKU1gjKkq3YX27ZqVNJO2ZWgV1yCCbWtliPuRu17/6q7/KndPa2urI+/bty52zfft2R5ZB6tpnlosL8j5a+notYD6LFljkS/svs9YAbgr8DRs2VLyfjbBGVJjCGlFhCmtERak2LDOrGwLlOfW4r+9YSCByEaQtKcsTaTbgs88+68haGaDXXnvNkWXZzZDPI+erQ4LjJVr/ff5BV1c+SdCePXsqnp/FRlgjKkxhjagwhTWiwhTWiAqqh5NTiZaWFs4Gf2iOgS9Ao8gEvxYIIp2JkNSTRe4jJ81nzpzpyAcPHsy1kc6QXGwA8jtL3333XUfWHCj57Hw7YoH8c6pWB7YHGeATUvs325djx46BmVVvz0ZYIypMYY2oMIU1oqJUG5aIvDasb5dsSAB3EYrcJ2Snp7TnRowY4cgy8BrI24nablZJSJp2X2CRtgggj8nAIp89CoTZvdm+nDhxwmxY49TAFNaIipCiHAOJ6EUiWpuW7vxJenwiEbUT0RYiepSI6rMpyjAyeG3YtIrM6czcnZY/eh7AnQC+D+BxZl5MRA8AWMvMv6p2LTkPGxJkLG0mzR4K+AxaXxx58ODBjlyrDNzSnpPzslqAdIitLK8bslnTZ8NqyO8jpAynZgtXuybgfs99moflhJ6Z7P7pDwOYA+A36XEr3WmUQpANS0T90pJHXQBWANgK4AAz9wx3HUjqzxpGXQlSWGY+zsyXAhgLYAaAC0NvQETziOhlInq5zCk049SkV7MEzHwAwCoAswEMI6Ieg3QsADXdHzMvYObpzDy9SCY8w8jinZEmolEAPmbmA0Q0CMBcAPciUdybASxGYOlOIlIN7iy+2rIhSi8dKpl+E/AH0Wj3KeK0yMUR346LUIoEsvgyvYQEFkmnUWsjg3VkoI50cAH3e5bBP1lCtsi0AVhERP2QjMhLmPlJItoAYDER/RTAaiT1aA2jroSU7lwHYJpyfBsSe9YwSsNWuoyoKDv4ZQ+Syt8jAewt7cZ9w/paPyr1dzwzj9IalKqwJ2+aTHFNL/3GBbC+1o8i/TWTwIgKU1gjKhqlsAsadN8iWF/rR6/72xAb1jCKYiaBERWlKiwRXUdEm9Kg7/ll3jsEIlpIRF1EtD5zrJWIVhDR5vT38Eb2sQciGkdEq4hoQxpYf2d6vOn6W9NNAMxcyg+AfkjCEicBGABgLYCpZd0/sI9XAbgMwPrMsfsAzE9fzwdwb6P7mfalDcBl6euhAN4EMLUZ+wuAAAxJX/cH0A5gFoAlAG5Njz8A4Dvea5XY6dkAlmfkewDc0+iHqfRzglDYTQDaMkqyqdF9rNDvJ5AEJjV1fwEMBvAqgJlIFg0+pelHpZ8yTYIxALJJTGMJ+h7NzJ3p610ARjeyMxpENAFJvEc7mrS/tdoEYE5XL+BkKGiqaRUiGgJgKYC7mPlQ9r1m6i/3YRNAljIVdieAcRm5YtB3k7GbiNoAIP2dTx/dINJNoUsBPMzMj6eHm7a/QLFNAFnKVNiXAExJPcMBAG4FsKzE+xdlGZIAdSAwUL0M0t3MDwLYyMz3Z95quv4S0SgiGpa+7tkEsBGfbAIAQvtassF9PRJvdiuAHzXaAVD69wiATgAfI7GpbgcwAsBKAJsBPAOgtdH9TPt6BZJ/9+sArEl/rm/G/gK4GEmQ/zoA6wH8OD0+CcCLALYAeAzAab5r2UqXERXmdBlRYQprRIUprBEVprBGVJjCGlFhCmtEhSmsERWmsEZUmMIaUWEKa0RFnxS22be8GKcehWMJ0myGbyKJvOlAEo11GzNvqF33DMMlJN1mJWYA2MJJFkMQ0WIANwCoqLBE5P3rkDlL5R9UkaTIIW3kfWoVFCTv3ci+NAu+Z5BGZqkn9UVhtS0vMyucexJfhRFfJWitvU8pQqrIyOooIdX7QpAJnGVCYA15b5nUuSg+xdfe9w0gRe6rVXbMHquW9LkvChsEEc0DMK/e9zH+MuiLwgZteWHmBUhT0hARZ//atNFSpiCXI6GUAf9oGPJvuMgoFmKuyHNkX7UR6+jRo95zfIR85pDR02eeFDFxtBrD2bT+8vNn6cssQaxbXoyIKTzCMvMxIroDwHIkSTIWMvPrNeuZYSj0yYZl5qcBPF2jvhiGF1vpMqKi7rME1dCMb2mgSydLa+ObxipSUFmjSBvpREq5VtNn8jNrzqk8Rz7Lsp6Jb5qxmiNnI6wRFaawRlSYwhpRUboNm7V5NDvLZ/Np9o1c6guZnJf46rBqfQm5rmZz1wK56CKXgIcOHerty6FDh6q+DxRbmvX5IRrZhZtq97AR1ogKU1gjKkxhjaho6Dyshm9OVQtN880navaotPnkdTU7SoYghtinvr5ofZPHzjjjjNw5EyZMcORPf/rTjtza2ppr8/bbbzvyn/70J0cO+Twy9E/a9UCxmOa2traTr3fs2JF7vwcbYY2oMIU1osIU1ogKU1gjKkp3ukImkXuLbzJbcwwk2Yh3ADh8+LD3OiGT6NLB8E34A8CIESMc+bbbbsudc/XVVzvyxIkTvX15/vnnHXnNmjWOrDm0+/btc+SQZ+lDc7oOHDhw8nU1589GWCMqTGGNqDCFNaKiVBu2paUFp5122klZs2Xk5Ly0q7TdrUV2dsrJeHmfajs3+4K87xVXXJE7Z9q0aY78ta99LXfOmDFulUtp98lFAgA4cuSII4fY7bVY+JB2uy+wyIJfjFMGU1gjKkxhjahoaPCLZqvIedqQrCFFkLZwdh6wlkjbeMqUKY5833335dqcc845jjxw4EDvfbq7ux25s7Mzd85jjz3myB0dHY4cYreH+AdFvsPs868212sjrBEVprBGVJjCGlFhCmtERalOFzN7nSbfpLMWPFOLjCW1yOx9+umn584599xzHXnJkiWOfPbZZ3v79sEHH+TOkZP8cqHg9dfzefmkI1ZksaRIhpmQhYPsOXLxyLmft4eG0USYwhpRYQprREVDM79oFMn8Iq8pbSYtNb3c/VkkGHv06NGOfNNNN+XafOtb33JkuSigTZJL+/SNN97InSODr7du3erI27Zty7WZPHmyI7/33nuOHPJsi6SZlzZpSMBMJWyENaLCFNaICq/CEtFCIuoiovWZY61EtIKINqe/h9e3m4aR4C3dSURXAegG8BAzfyY9dh+A95j5Z2mN2eHMfLfvZv369eNs0HBIyR9fZkINGSxy5pln5s7ZtWuXI4fYsCNHjnTkG264wZHnzcuXI5s0aZIjS1tt8+bNuTYyq+Cjjz6aO+eVV15xZGmTa9liBg8eXPXeWsCML/NOyKZE6UNobWRhuePHj6tGrXeEZebnALwnDt8AYFH6ehGAG33XMYxaUNSGHc3MPX+OuwCMrnayYdSKPk9rMTNXK3qcLd1ZZPnTMLIUHWF3E1EbAKS/uyqdyMwLmHk6M083hTX6StERdhmAbwL4Wfr7iZBGzOw4TZqj40udqbWRRr10urSIfZ+zoFXdljtcv/SlLzmyln1lz549jvzUU0858nPPPZdrI59Be3t77hxth2uW7O7kHmQKTrlrVspaX0IcKImv3q481qcdB0T0CIA/A7iAiDqI6HYkijqXiDYDuDaVDaPueEdYZs4ndkq4psZ9MQwvttJlREWpwS9E5NhAWhYXH1ogizwmbSTNZpKBx/IaMiU7AFx55ZWOfMkllzjywYMHc20efvhhR37ooYccWQvOlsggFcAfFKR9ZnnOZz7zGUeeOXNmro1MK793717vfWTffM9a9q2aXtgIa0SFKawRFaawRlSUasOeOHHCCW7R5lR92fG0xQc5VyhtqPfff997H2lXSfsUAGbPnu3IMpjk97//fa7N008/7ci7d+/OnSORz6VI1mvt2crrXH755Y785S9/Oddm+/btjiwzcmubSouU7gzdSGojrBEVprBGVJjCGlFhCmtERUPTbfoygGiyZuT7ouLlTgEA2L9/vyPLYJGLLroo12b8+PGOvGnTJkdeuXJlro10skIi1opEtYU4OkOGDHFkWTpp3LhxuTZyEr9WwS6S7PdsKeONUwZTWCMqTGGNqCg9+CVrW/l2TwK933EJ5O1RGUStXUfajbKskHafN99805E3bNiQayNT0ctSnVrGwBCbT+JbCAHyCx0ySF17Tr6+hEz4h2SKtIUD45TEFNaIClNYIyoaOg+rzRVqG+GyaPOw0h6VQdEhQTa+jYzadeRc7o4dO3JtZLlMrcS7pMhGP3ldLduNDN6RAdsvvPBCro2cR5bzskWyn2s2bNa2t7JHximDKawRFaawRlSYwhpRUXrZo6yRrk1uS4NbTqxrTpc8JlOUhzhdsvyQFvwir9vV5WZo0nY2yM8jr6E5nnLhI2QHbFtbmyPLwBYA+O53v+vIcuFg+fLluTZy4aNIrd+QUklZXagW/GMjrBEVprBGVJjCGlHR0IUDzR6SWflksIhmz/kyHIaU2dGy/UnkOUOHDvVeQ9pr0qYNCVLRFhvkwsA117ipzm655ZZcmwsuuMCR5bOUmRWB/MJHkYUCSUj2nkrYCGtEhSmsERWmsEZUmMIaUVG605V1OjRD27fjslZpe+QxGeGlpbiUiwsyRfx5552Xa9Pd3e3I8vNoUVUy1efw4fm6fTJV5pw5cxz5s5/9bK6NdArXrl3ryLI+GFDsefuQiydADVPGG0YzEVLjYBwRrSKiDUT0OhHdmR638p1G6YSMsMcA/ICZpwKYBeC7RDQVwHwAK5l5CoCVqWwYdSWkKEcngM709WEi2ghgDJLynVenpy0C8EcAVevNEpFjR2k2rAx2keeElEoKQV6no6PDkbVSQ9K2lBH7Wpp5mW5z/fr1jqyluJSBN+ecc07uHFlLVi42hDxbWcO2yG7dEHob/FIzG5aIJgCYBqAdVr7TaADBCktEQwAsBXAXMzvuJCfDlbpmR0TziOhlInq5Tz01DAQqLBH1R6KsDzPz4+nhoPKd2dKdteiw8ZeN14alxAB5EMBGZr4/81ah8p1ZtPk4XybCkF2zIUg7Stp3WiDI9Onu35yc65TZDQHg0ksvdeRt27Y5slbuU9qfMgBIO0c+N+05ybnm1atXO/KHH36Ya1MPQgLqKxGycPA5AF8H8BoRrUmP/RCJoi5JS3luB5APDzKMGhMyS/A8gErqb+U7jVKxlS4jKkxhjagoPfgl6wxok9vSGZJOl+YY+Ax2baJaTpLLc7Tgl40bNzryhRde6MhyBwKQDzg599xzHVlLzST7EpKeUjpZWt3bLVu2OLJMDxpSc6sIvh0hvcFGWCMqTGGNqDCFNaKidBs2a79oE/7SfgsJ4PalzgyxYaW8c+fOXBtpA8pMLyG7QYcNG5Y7x0dIALrcbbxmzRpIfvnLXzpyyIKLfLZF7M+QXczZNJ5W9sg4ZTCFNaLCFNaIitKzF2bn+rSAYXlMZtiTgcpAfv7QV/4TyM/nSrtJZjwB8nbhf/3XfznyV7/61Vybs846y5F9mWA0tL688847jvzf//3fVfsG5O1yaUtqQTaSIqU85WfWMrCY7mAAACAASURBVORk59vlxk3nWt67GUYTYQprRIUprBEVprBGVFAtghuCb0bEWUM/JA2mREs9KdvIgBJt4UAGt8jnoNXpkg7fkCFDHLm1tTXX5tOf/rQjhzgpvqw0ANDZ2enIb731lreNz/nRMr/UInBFfj/SkQbcncEdHR04evSoqgg2whpRYQprRIUprBEVDQ1+Cdk9KSeztSBj2UYuCmgZAn3XkBPkQD7YRU7oa0Hf27dvd2RpR44bNy7XRtaw1YKxfQsfGvIzhmR6KZKOXyI/s7a7eMqUKSdf79u3r/K1vHczjCbCFNaIClNYIypKn4f1nSPtHTnXqZXHlMjPpAV1yKwzMkAmJLjcd1/tmLT5Quaii2wO1Poq57DlfWT2m5D7hNiwISWlss/7448/xokTJ2we1ogfU1gjKkxhjagwhTWiovSFg6yRHuIYSLTdA9JBkk6K5jjI4BbZRnMmfNcNcWCLZHXRnpPvXtr7voWCEAcq5DPL70g6uNrnyQYWVeunjbBGVJjCGlFhCmtERek2bNZ+0Sbnpf0iM6Vok+gyUEXaYiGLADLoWwvglrs55UR7iD0nFzG0SXWZBVGb0JcBMVqwjsRno2rv+3b5hixqSFn7PrLBPJb5xThlMIU1oiKk1uxAInqRiNamtWZ/kh6fSETtRLSFiB4lovxGHcOoMSE27FEAc5i5O63X9TwR/Q7A9wH8nJkXE9EDAG4H8CvfxbL2iWYzafOsWYoEgmg2kzwm7URtE59vA6HWd1/wi5a1W2YilHJIX0LmVEM2RMp58RBb2TfX7PuOq17bdwIn9Hgb/dMfBjAHwG/S44sA3Fi4F4YRSGglxH5pja4uACsAbAVwgJl7XPoOJAWTDaOuBCksMx9n5ksBjAUwA8CFniYnsVqzRi3p1SwBMx8AsArAbADDiKjHwBkLIJ+yGlZr1qgtIbVmRwH4mJkPENEgAHMB3ItEcW8GsBi9qDXrcwbkRLoMnNAcBemI+XYGAP4atiFOS8gChXQwpBPW1ZWvKS0/s9YXea+QHRNaxpUsIelPQ56tXHSRn0fbAZJ9/tWefcgsQRuARUTUD8mIvISZnySiDQAWE9FPAaxGUkDZMOpKSK3ZdQCmKce3IbFnDaM0bKXLiIqyd83uQVKqfiSAvaXduG9YX+tHpf6OZ+ZRWoNSFfbkTYlejmXWwPpaP4r010wCIypMYY2oaJTCLmjQfYtgfa0fve5vQ2xYwyiKmQRGVJSqsER0HRFtSoO+55d57xCIaCERdRHR+syxViJaQUSb09/DG9nHHohoHBGtIqINaWD9nenxputvTTcBMHMpPwD6IQlLnARgAIC1AKaWdf/APl4F4DIA6zPH7gMwP309H8C9je5n2pc2AJelr4cCeBPA1GbsLwACMCR93R9AO4BZAJYAuDU9/gCA73ivVWKnZwNYnpHvAXBPox+m0s8JQmE3AWjLKMmmRvexQr+fQBKY1NT9BTAYwKsAZiJZNPiUph+Vfso0CcYA2JGRYwn6Hs3MPUWxdgEY3cjOaBDRBCTxHu1o0v7WahOAOV29gJOhoKmmVYhoCIClAO5iZqcyXDP1l/uwCSBLmQq7E0C2ZErFoO8mYzcRtQFA+jsfwNog0k2hSwE8zMyPp4ebtr9AsU0AWcpU2JcATEk9wwEAbgWwrMT7F2UZkgB1oBeB6vWGkijnBwFsZOb7M281XX+JaBQRDUtf92wC2IhPNgEAoX0t2eC+Hok3uxXAjxrtACj9ewRAJ4CPkdhUtwMYAWAlgM0AngHQ2uh+pn29Asm/+3UA1qQ/1zdjfwFcjCTIfx2A9QB+nB6fBOBFAFsAPAbgNN+1bKXLiApzuoyoMIU1osIU1ogKU1gjKkxhjagwhTWiwhTWiApTWCMqTGGNqDCFNaKiTwrb7FtejFOPwrEEaTbDN5FE3nQgica6jZk31K57huHSl8JyMwBs4SSLIYhoMYAbAFRUWCLikLyrWYr8Qcl7hBQgrkVfevvZQgnJD1v0Or735WcOyYlbC5hZ7WxfFFbb8jKzWgMichIWawogj8mEutpD9VUp0RL5ymooWnUaia8atlaJXCYADvlDkedoVRmPHDnSq2to/ZPPTUtWLJ+LfLZalUZ5b6nUvupB1Z5z3Ut3EtE8APPqfR/jL4O+KGzQlhdmXoA0JU2/fv04+1espQ6XI0eRf+9yVNBqS8k2vpqq2jmyL9qoFlLXSiKvq41ivn/FWl98/0W0a8rr1Ct+OjvCVutnX2YJYt3yYkRM4RGWmY8R0R0AliNJkrGQmV+vWc8MQ6FPNiwzPw3g6Rr1xTC82EqXERV1nyXIwszOlIU2fSGdlCJzm9IxkHWiNEKcO990mXYf6cj4nD3tWEhBaJ9DqCGvWyuHqre12ABg0KBBJ19Xm9ayEdaIClNYIypMYY2oKN2Gzdqomv3ms6O090Mm/X34asJqx6Stpi3Nyr7IvmqLJ6effrojv/fee7lz5L19dWQB/zJ3rWxY+Rmlzar1NaSGLWAjrBEZprBGVJjCGlFRqg0LuHZTLWJdQ66jve+L6wxp8+GHH1a9hnadkGASGeziC2sE8nPAIfO70uaWn6dS/3qL/Dzadzh+/PiTrz/44IOK17IR1ogKU1gjKkxhjagwhTWiotQM3ETE2Qn6ECclJChFuY8jh+zXCrlukb4NHjzYkaVjE9K3Wn1HcsI+ZGeDpBYbLTWHMBv88sEHH+D48ePqjWyENaLCFNaIClNYIypKtWFbWlo4Gwih2UPa5LUPXxBHIyvl1CIAvV7IgB8N37MMWaCQ99Hs9mwQ0Icffmg2rHFqYAprRIUprBEVpQa/tLS0OPOSWvCyL2tLSGB1M9HMfZPz4CNHjsydI+3RkMAcGVQj76MFt2R9l2oB+DbCGlFhCmtEhSmsERWmsEZUlOp09evXD0OHDj0pa0l5a5HlWk5UaxPkRdJt+hzAkGwx0tHUkhVLp0TLKFOL3Rpyd+7EiRNzbbq7ux25o6PDkbV0otIR8yVFBtzgl/fffz/3fg82whpRYQprRIUprBEVpWd+ydpjmm0m7R9pq2nZVUaMGOHIc+fOdeQ77rgj1+aFF15w5N27dzvy5MmTc202b97syG+//bYjHz58ONdm2LBhjvyFL3zBkTUbds+ePY68b9++3DnyucjsMPIaQN4elZ9R2rQAsGLFCkeW9mWR4HjN1s/6ENXscxthjagwhTWiwquwRLSQiLqIaH3mWCsRrSCizenv4fXtpmEkhNiw/wHglwAeyhybD2AlM/8srTE7H8Ddvb15SMY6eU52vq6HqVOnOvLNN9/syNmsIj1Ie04GfrS2tubazJkzp+o1Dh48mGvT1tbmyEOGDHFkbR5TsyUlcg5b2vaaHSj9AxnIsnjxYu99i2SGDJkzDr2uV2OY+TkAMt/jDQAWpa8XAbgx6G6G0UeK2rCjmbkzfb0LwOga9ccwqtLnaS1mZiKqOOZnS3eG7CEyjGoUHWF3E1EbAKS/uyqdyMwLmHk6M08PzbJsGJUoOsIuA/BNAD9Lfz8R0uj48ePO5HpI5heJFuE+btw4R5ZOy6ZNm3JtduzY4cjSiXnjjTdybWRQiryP1vedO93yu3KifevWrbk2EyZMcORzzz03d4505qSTeNZZZ+XayGcnP+O2bdtybTo7O3PH+kpIitFKhExrPQLgzwAuIKIOIrodiaLOJaLNAK5NZcOoO94Rlplvq/DWNTXui2F4MaPSiIrSU8Zn7ZeQtOwSLVhEHtuyZYsj//73v8+1kZP+ckJfCziRNqws56MtAshgEWmraW1kkPd5552XO+emm25y5K985SuOrPkH77zzjiP/4he/cOT29vZcm0OHDjlyvXYBZx1y2zVrnDKYwhpRYQprREVDS3eGBP9KNJvvD3/4gyM/99xzjiwDrXv6Uk3W+uYrw6nZd7JNkU2U2tyzDCaXfdGyqyxfvtyRly5d6sjSXgWKfUeSkLKoWbtdC+zvwUZYIypMYY2oMIU1osIU1oiKUp0uInJK72gOlDwmnQmtjZwQl05KkSj5EIo4JCET79Ix0xZLLrjgAkeWixha8M5TTz3lyNIx0z5PLRYKepshp5pjaiOsERWmsEZUmMIaUdHQ4BcZcALkg0VCbChpe9XLZi0L2X8tgPv88893ZGmPPvvss7k2a9ascWS501YLovaVlAohZPEk63dY5hfjlMEU1ogKU1gjKkove5S1WzVbpkjpeN81NJq5HJGcU502bVruHDkP++abbzryypUrc23279/vyGeffbYja1l1ZDC5DGwPCRKSaNv9s59ZC/bpwUZYIypMYY2oMIU1osIU1oiKUp2uEydOOBPcmuPjC37RCHGyfISUPaoFsq9aCvwrr7zSkW+55ZbcOWeeeaYjywAgLYuLb1dCtt5rDzINvvzOtHrB8juUjpnmqNnCgXFKYgprRIUprBEVpQe/ZG1DzZbxBbKETPiHBAz7bMlqOzf7gryPnLwHgHnz5jmylvnlrbfecuQ//elPjizLIAH5zxRiwxax5eWzzQbtV7rm4MGDK/Yzi42wRlSYwhpRYQprRIUprBEVpS8cZFOza86Qz6kKSdEZUts0xDGrBfK6MrX71VdfnWszY8YMR+7qypeQ+PWvf+3Iv/vd7xxZc7qksyOjprQdyT40x1kuUMhnoDlV2f7awoFxyhBS42AcEa0iog1E9DoR3Zket/KdRumEjLDHAPyAmacCmAXgu0Q0FZ+U75wCYGUqG0ZdCSnK0QmgM319mIg2AhiDpHzn1elpiwD8EZ56szLzixZZLu2dkJSWPrQId3lMljDS7CzfvbVAnWHDhjnyN77xDUf+1re+lWsjA05kmkwAWLVqlSPv2rWrV30FwkoNye8jZCFB3jtkESb77KrtMumVDUtEEwBMA9AOK99pNIDgWQIiGgJgKYC7mPlQ9i+vWvnObOlOw+grQSMsEfVHoqwPM/Pj6eGg8p3Z0p31mjoy/nLwjrCUaNmDADYy8/2Zt3pdvlOmjC8SyFKEkJ230p4ukmXwjDPOyJ3z+c9/3pHnzJnjyLIEJwA8/PDDjvzb3/42d45MGR8yh1rWgFEkYCb0ew4xCT4H4OsAXiOinlw3P0SiqEvSUp7bAeTD4g2jxoTMEjwPoNKfppXvNErFVrqMqDCFNaKi9JTxvl2wRZyfkPtKRo92p41lVPzBgwe915U7RseOHZs75+///u8d+ZprXCtq06ZNuTbLli1zZC39e0j/JM2cninUIbQR1ogKU1gjKkxhjagofddsNuhEm9D32TJF7DDNbpYBJtqO0d4ycuTI3LHJkyc7sqyL+8Mf/jDXRgayyBSXQG1qwEq0IKGy0u9nv6Nq97QR1ogKU1gjKkxhjagofR42O3ep2ZbSRi2SxUXaQCEZZkJKAMn+ynJEWpZBeZ3vfe97jhySZbAe9iqQt1llqnogH3xdi0ww2neYvXfNArgNo9GYwhpRYQprRIUprBEVDU0ZX+mcLL5dtCHX0JALBdl0j5XuI50UGUCj1c5dvXq1I8tFgZCdw7XCd91sVp4eQp637z61TPtvI6wRFaawRlSYwhpRUXrwiw/fQkEtJq5DztHsLrm4IEsNyd2uANDZ2enIIdlWarFwoH1mX+p27dn6nrd2H9l/adtLfwEAhg//JDWbtphy8tpVe2MYTYYprBEVprBGVFCZG9OIiEVOLm+bIvOAtchwqNlu0oYdOHBg1feB/NymtEe1eVhJiN0ubUmtpKYvCEULYve10T6z/IwyqMYXLH/ixAkws+p42AhrRIUprBEVprBGVJjCGlFRqtPV0tLCWSNdmxCX/ZHOkDZRLc/x1aut0DfvOUUm0eXnkSk5tXTqsi9awJBvoSNkESDE0fShPTfpjEonS7tP9jrHjh3DiRMnzOky4scU1ogKU1gjKkoNfmFmx37R7GdpE2kT0xItY4m8ryRkZ62vTRG6u7u995X2aYifEbIAIZH3lsExQH4BQqam1/ovz/HthJbHrHSnccpgCmtERUit2YFE9CIRrU1rzf4kPT6RiNqJaAsRPUpE+f8nhlFjvPOwadmj05m5O63X9TyAOwF8H8DjzLyYiB4AsJaZf1XtWi0tLZy1iUJKyfvsU62NtKu0+VFfmSDNXq3FnLW0yUNs5yIlmELOCQlalzZsSJZH+Z355tYB93n3aR6WE3o8hf7pDwOYA+A36fFFAG70Xcsw+kpoJcR+aY2uLgArAGwFcICZe1zTDiQFk7W284joZSJ6uZlz7BtxEKSwzHycmS8FMBbADAAXht7ASncataRXswTMfADAKgCzAQwjoh6DbCyAnTXum2HkCKk1OwrAx8x8gIgGAZgL4F4kinszgMUIrDUr021qjo9vojok3aacAA9J6xmyg7QsamE6hVxDPietjQzOCfkvOWjQIEeWwTua05W9brVFkJCVrjYAi4ioH5IReQkzP0lEGwAsJqKfAliNpICyYdSVkFqz6wBMU45vQ2LPGkZp2EqXERVl75rdg6RU/UgAe0u7cd+wvtaPSv0dz8yjtAalKuzJmyZzstNLv3EBrK/1o0h/zSQwosIU1oiKRinsggbdtwjW1/rR6/42xIY1jKKYSWBERakKS0TXEdGmNOh7fpn3DoGIFhJRFxGtzxxrJaIVRLQ5/T282jXKgojGEdEqItqQBtbfmR5vuv7WdBMAM5fyA6AfkrDESQAGAFgLYGpZ9w/s41UALgOwPnPsPgDz09fzAdzb6H6mfWkDcFn6eiiANwFMbcb+AiAAQ9LX/QG0A5gFYAmAW9PjDwD4jvdaJXZ6NoDlGfkeAPc0+mEq/ZwgFHYTgLaMkmxqdB8r9PsJJIFJTd1fAIMBvApgJpJFg09p+lHpp0yTYAyAHRm5YtB3kzGamXsKFewCMLrayY2AiCYgifdoR5P2ty+bALKY09ULOBkKmmpahYiGAFgK4C5mPpR9r5n6y33YBJClTIXdCWBcRo4l6Hs3EbUBQPq7q8H9OUm6KXQpgIeZ+fH0cNP2F+j7JoAyFfYlAFNSz3AAgFsBLCvx/kVZhiRAHQgMVC+DdDfzgwA2MvP9mbearr9ENIqIhqWvezYBbMQnmwCA0L6WbHBfj8Sb3QrgR412AJT+PQKgE8DHSGyq2wGMALASwGYAzwBobXQ/075egeTf/ToAa9Kf65uxvwAuRhLkvw7AegA/To9PAvAigC0AHgNwmu9attJlRIU5XUZUmMIaUWEKa0SFKawRFaawRlSYwhpRYQprRIUprBEVprBGVJjCGlHRJ4Vt9i0vxqlH4ViCNJvhm0gibzqQRGPdxswbatc9w3DpS2G5GQC2cJLFEES0GMANACoqLBH1OdImpABxkUzf8hpaTtkiBd+K0KiAJO2+9fjMId8hM6tfYl8UVtvyMtPXyKdMvqraIcmJZcJcrY2v4vdpp52WayMTANei+qCW3Pfo0aOOHPKZfRViNGT/iyhskWo7WnXLbJu+JjTuE0Q0D8C8et/H+MugLwobtOWFmRcgTUlDRJz9iw0ZBeQIFFJzK8RE8KWEl6Ochq8+mNYXeV9tNAkZueW9Q+p/yXuH1OnyXaMIWt+y33M1vejLLEGsW16MiCk8wjLzMSK6A8ByJEkyFjLz6zXrmWEo9MmGZeanATxdo74Yhhdb6TKiou6zBNXQpj98jkGt7iMJmRaSNcSkQ6g5arKYcEgx5JC5T3lMXjfk2YY4p9IRq4XT5fs81b4vG2GNqDCFNaLCFNaIitJt2Kx9UmSiWmsjJ83lxLvWRh6T9qi2fDhw4MCq95E2LpC3YUMosn4fYhv7rhNi90pCnu3w4W5O5b1786W5Qm1jG2GNqDCFNaLCFNaIitJt2Kx9o4XwHTlypGp7GeIH5G1JaQNq95E2aog93d3d7cghtmWRWN0ic8+y/yFztyH3LWJPDxo0qOr72neYve5HH31Usa2NsEZUmMIaUWEKa0SFKawRFaVm4CYizjo7IfuB5IS+ZrDLHQfynBAHZOjQoY78/vvv59rIRYCQRQ3pgJx++unevkmHUHNE5UKBttAhkc9Jfp6QnQ5FNmv6FnbkdU+cOFFxE6KNsEZUmMIaUWEKa0RFqQsHROTYN5rd5du3X21SuYeQgBNpf8o2RWx7zSaXixaXXnqpI3/1q1/NtRk/frwjv/POO7lzOjo6HFn29+DBg9427e3t3vv47FptsUEGCZ1xxhmOvG/fvlybkOAdwEZYIzJMYY2oMIU1oqJUG7alpcWZ79TsIznnKO3CWgQql8mQIUMc+Y477nDkL37xi7k2Wr4tie+57Nq1K9dGHlu+fLkj//znP8+1kRsr5fej2bByrtmXmQewAG7jFMUU1ogKU1gjKkxhjago1ekaOHAgzj///JPy1q1bc+dI50EuFIRkb24UgwcPzh3767/+a0eePn26Iwdmo86dI5/T4cOHHVl7tiNHjnTkG2+80ZHlwgIA/N///Z8jv/HGG46sLeTs2bPHkWUAkOwH4C50VFv4sRHWiApTWCMqTGGNqGho9sIzzzwzd+yDDz5wZGm/hQQqy0lobVK6SEYTmcHkyiuvdOS//du/zbW5+OKLHVnarNImBIB169Y58qZNm3LnrF271pGl3ThixIhcm+9973uOfNVVVznyv/7rv3rbbNu2zZFDUuvLBaLRo0fnztEC5jVshDWiwhTWiAqvwhLRQiLqIqL1mWOtRLSCiDanv4dXu4Zh1IoQG/Y/APwSwEOZY/MBrGTmn6U1ZucDuNt3IWZ25u1kYC+QD9CQNp8WGCIDTMaNG+fI2lxnV1eXI0+ePNmRr7jiilyba665xpHPO+88Rz506FCujbQ1n3jiCUdetWpVro1kx44duWMHDhxwZPkMNGRgdUi2mP3793vP8SHnards2ZI7JzuHLf2YLN4RlpmfA/CeOHwDgEXp60UAboRhlEBRG3Y0M3emr3cByLt9hlEH+ux0cfI/ouL/CSKaR0QvE9HLRWqzGkaWogq7m4jaACD93VXpRGZewMzTmXl6yByqYVSjqAYtA/BNAD9Lfz9R/fSEjz76CDt3flKOVhtxfRPI2o6Ds846y5H/7u/+zpE15046LXI365gxY3JtZOT8a6+95siaMyGdKjnx/vbbb+faSOdI2wHry/xyzjnn5NrIzxyye0OeIx21IsFIWnBLdiGn2qJOyLTWIwD+DOACIuogotuRKOpcItoM4NpUNoy64x1hmfm2Cm9dU+G4YdQNW+kyoqJUL4iZHftFC5zw2T8hGQJlwIlcSADyE+27d+925D/+8Y+5NitWrHBkabNqNuG7777ryDLQWkM+g5BMNnIh5IUXXsidI3ezzpgxw5FlcI92jlwIkWn0AX+afG3xJ5txslpAjY2wRlSYwhpRYQprREWpNuzx48cdm6dIIIVmw8p5WJn9T+O999zwiIULFzqyDFIB8naitLWKBIpr9lyR5yLbaPeVQSXSNtb6cvnllzvyggULet03iTb/nu1Ln+ZhDaOZMIU1osIU1ogKU1gjKkpPGZ8N0tCcC1+ml1GjRuXayIUCWfboySefzLWRO0Q3b97syGVlk9EWG0LTp2eR/dWuIXdEaBlYJHJBRX4/Rertan0LjeSzEdaIClNYIypMYY2oKNWG7d+/P84++2xHlmzfvt2RpW2TzX7Yw9/8zd84cmtrqyOvX78eEhk43agMiGXe97LLLnNkOYEvA9QBOAH3Wpta9T/0OjbCGlFhCmtEhSmsERWlZ+CeOnXqSfncc8/NnfPb3/7WkaXNpG0OlFkQ5TzsJZdckmvTLFm7a4Wcr5b2KgBcd911jiwD37WMKzIrogyQKbIJUX4/gJv5pVqQu42wRlSYwhpRYQprRIUprBEVpTpdR48edYJMtFTo+/btc2Rp1G/cuDHXZu/evY4sjX6ZGh3ILy7I3QSxOWXS8Wxra8udI9ODSv7whz/kjj3++OOOXCT9pnTUTjvttNw52QUizZHrwUZYIypMYY2oMIU1oqL0XbPZSWEtaFfumJS7ZOVENgCsWbPGkT//+c87spbJ79vf/rYj/+IXv3BkLf17kcBqibTPitrK8rlkg4qA/DMA8nauzBT56KOP5trI51DkGci+atkks8/FbFjjlMEU1ogKU1gjKkxhjagoPd1mNr2PFuHuS7mjRfK8+uqrjix3LUyYMCHX5rbb3DzNcmettkAhU/sUcZjkJHpIoRItPdPYsWMd+Ytf/KIjX3311bk2R44cceSXX37Zkdvb23NtpNPlS72kIZ9TZ2dn7pzsZ6z2TGyENaIipMbBOCJaRUQbiOh1IrozPW7lO43SCRlhjwH4ATNPBTALwHeJaCo+Kd85BcDKVDaMuhJSlKMTQGf6+jARbQQwBkn5zqvT0xYB+CM89WZbWlqcVO3awoFW4ieLNqksbVZZr1bae9qxmTNnOrLMeALkFy2kDV5twruHELtX7ibWUrlLG1XuHM5G8Pcg7XK5UKClppc2t7RhQz5PyGJDXRYOiGgCgGkA2mHlO40GEKywRDQEwFIAdzGz4zpWK9+ZLd1ZxMM0jCxBCktE/ZEo68PM3BMgGVS+M1u6U5ueMYze4LVhKTEoHgSwkZnvz7zV6/Kdx48fd1K1ayOuzyaSc4lAvhzmgw8+6MiTJk3KtZHBIjIDohbMLNPMSxtWs8ml/SZtQlmKCACGDRvmyHPmzMmdI+eRZUYcGQgPAC+99JIjv/LKK44sMxMCtQnWCWmT1YVq54csHHwOwNcBvEZEPWFRP0SiqEvSUp7bAdwScC3D6BMhswTPA6jktln5TqNUzKg0osIU1oiK0oNfsgZ1SI0qafRrjoF0hmSdWBkcAwBz58515IkTJzqy1jfpVMm+acE88pyhQ4c6sraT9ctf/rIj33zzzblzpNMonVEteEc6XXJxRAs6KWv3cPbZWp0u45TBFNaIClNYIypKL3uUtem0lPESaUNpNpUvQPjuu/MxOZ/5zGccFhTIjAAABo5JREFUWe4o1XZ2ShtW2rlakIc8R9qw//Zv/5ZrI1OKaqWeZCD7M88848j//u//nmsjbXn5GWXtXKBYwHYRLGW8cUpiCmtEhSmsERWl2rBA+GazHoqUhgwJpJa22QUXXODI//Iv/5Jr8+tf/9qRpU0og1YAYMSIEY78j//4j46spcCXc81aIMt//ud/OvJDDz3kyG+99VaujbRRZbC8Nvcs/Qz53EJsXPl9aL5L9tnJefUsNsIaUWEKa0SFKawRFaawRlSU7nRlDXCtXpOsFVWL7CraToDu7m5HlsEkWp0r6ZjJXbSyLiuQd0rGjRvnyFowj6yD+z//8z+5c5YtW+bIHR0djqwF4vi2KGm7ZiW1yPyiOcUXXnjhyddasFIPNsIaUWEKa0SFKawRFVRmeZ9+/fpxtr6pZlP5bFjNhpI2kSyrk80208O0adMc+Wtf+5ojz5o1K9dGpp4PCX6RdqHs/wMPPJBr88ILLzjyhg0bcufIyXW5CBOSbUU+p3oFv8iFgptuuil3TjZI/e6778bWrVvV1R8bYY2oMIU1osIU1oiKUm3YlpYW1so2ZvFlBNRsM3lNX8AGkJ+blZsQr7322lybL3zhC44sbVoZBA4Ab7zxhiOvWLHCkRctWpRrI21JbX40JLBdIp+lfAbanLD0M3wykH/eMvOOlqEy+70fPHgQx44dMxvWiB9TWCMqTGGNqDCFNaKiVKdrwIABnA0yyS4i9CAnxKWTpfVXOl3yHM3Il9eVjpqWcl3uKBg92k063tbWlmuzY8cOR96yZYsjaw6V7FvIYkktdgJo+Jw77Ro+p1f7DrNp8ffv34+PP/7YnC4jfkxhjagwhTWiovTgl4EDB56UtV2zcjJb2kPaRLXcmSoDw/fu3ZtrI+1aOWle5Llo9pzsr/x8MnAcyGeH0Z6TzDz4/vvvO3JI8Ivsm/aZ5TmyL0V2NfsyQ3700Uc4ceKE2bBG/ISU7hxIRC8S0dq0dOdP0uMTiaidiLYQ0aNElN/vYhg1JmSEPQpgDjNfAuBSANcR0SwA9wL4OTNPBrAfwO3166ZhJIQU5WAAPTv2+qc/DGAOgP+XHl8E4P8D8Ktq1zpx4oQaJJxF2oEh2WEkMiufdo1a2KySkMyK48ePd+TW1tZcG2mTr169OneOfE5yTlv7zDKwKOTZShu2yPyutFmzfox2H20D5cnzvHdPOtAvLXnUBWAFgK0ADjBzzyfuQFJ/1jDqSpDCMvNxZr4UwFgAMwBc6GlykmzpzoJ9NIyT9GqWgJkPAFgFYDaAYUTUY1KMBZDflA+3dGefemoYCJslGEVEw9LXgwDMBbARieL27BwLKt1pGH0lJPNLG4BFRNQPiYIvYeYniWgDgMVE9FMAq5HUo+0VmpPiC+LQJuelIyevq0XSNwq5K/jQoUO5c7q63DrT2meWDpN0NGVWGiDv/ITsSJbHQhYbpFMl+6rV180udMhnlCVklmAdgGnK8W1I7FnDKA1b6TKiwhTWiIpSg1+IaA+SUvUjAeQjUpoT62v9qNTf8cycr/WEkhX25E2JXo5lmsv6Wj+K9NdMAiMqTGGNqGiUwi5o0H2LYH2tH73ub0NsWMMoipkERlSUqrBEdB0RbUp3Kcwv894hENFCIuoiovWZY61EtIKINqe/h1e7RlkQ0TgiWkVEG9KdIHemx5uuvzXdtcLMpfwA6IckjnYSgAEA1gKYWtb9A/t4FYDLAKzPHLsPwPz09XwA9za6n2lf2gBclr4eCuBNAFObsb8ACMCQ9HV/AO0AZgFYAuDW9PgDAL7jvVaJnZ4NYHlGvgfAPY1+mEo/JwiF3QSgLaMkmxrdxwr9fgJJJF1T9xfAYACvApiJZNHgU5p+VPop0yQYAyCbtyeWXQqjmbkzfb0LwOhqJzcCIpqAJECpHU3a31rtWjGnqxdwMhQ01bQKEQ0BsBTAXczsxCo2U3+5D7tWspSpsDsBZMsAVtyl0GTsJqI2AEh/d3nOLw0i6o9EWR9m5sfTw03bX6DYrpUsZSrsSwCmpJ7hAAC3AljmadMMLEOyowJoop0VlER1PwhgIzPfn3mr6fpb010rJRvc1yPxZrcC+FGjHQClf48A6ATwMRKb6nYAIwCsBLAZwDMAWhvdz7SvVyD5d78OwJr05/pm7C+Ai5HsSlkHYD2AH6fHJwF4EcAWAI8BOM13LVvpMqLCnC4jKkxhjagwhTWiwhTWiApTWCMqTGGNqDCFNaLCFNaIiv8fx1YzDW9nuK8AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 576x2160 with 10 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "_, axes = plt.subplots(10, 1, figsize=(8, 30))\n",
+    "for i in range(10):\n",
+    "    axes[i].imshow(fakes[i][0], cmap='gray')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -11,14 +11,11 @@ from skorch import NeuralNet
 from skorch.callbacks import EpochTimer
 from skorch.callbacks import PrintLog
 from skorch.callbacks import EpochScoring
-from skorch.callbacks import BatchScoring
+from skorch.callbacks import PassthroughScoring
 from skorch.dataset import CVSplit
 from skorch.utils import get_dim
 from skorch.utils import is_dataset
-from skorch.utils import noop
 from skorch.utils import to_numpy
-from skorch.utils import train_loss_score
-from skorch.utils import valid_loss_score
 
 
 neural_net_clf_doc_start = """NeuralNet for classification tasks
@@ -82,16 +79,12 @@ class NeuralNetClassifier(NeuralNet, ClassifierMixin):
     def _default_callbacks(self):
         return [
             ('epoch_timer', EpochTimer()),
-            ('train_loss', BatchScoring(
-                train_loss_score,
+            ('train_loss', PassthroughScoring(
                 name='train_loss',
                 on_train=True,
-                target_extractor=noop,
             )),
-            ('valid_loss', BatchScoring(
-                valid_loss_score,
+            ('valid_loss', PassthroughScoring(
                 name='valid_loss',
-                target_extractor=noop,
             )),
             ('valid_acc', EpochScoring(
                 'accuracy',
@@ -273,16 +266,12 @@ class NeuralNetBinaryClassifier(NeuralNet, ClassifierMixin):
     def _default_callbacks(self):
         return [
             ('epoch_timer', EpochTimer()),
-            ('train_loss', BatchScoring(
-                train_loss_score,
+            ('train_loss', PassthroughScoring(
                 name='train_loss',
                 on_train=True,
-                target_extractor=noop,
             )),
-            ('valid_loss', BatchScoring(
-                valid_loss_score,
+            ('valid_loss', PassthroughScoring(
                 name='valid_loss',
-                target_extractor=noop,
             )),
             ('valid_acc', EpochScoring(
                 'accuracy',

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -283,16 +283,19 @@ class NeuralNet:
         return self._default_callbacks
 
     def notify(self, method_name, **cb_kwargs):
-        """Call the callback method specified in ``method_name`` with
-        parameters specified in ``cb_kwargs``.
+        """Call the callback method specified in ``method_name``, as well as
+        the method on the net itself, with parameters specified in
+        ``cb_kwargs``.
 
         Method names can be one of:
-        * on_train_begin
-        * on_train_end
-        * on_epoch_begin
-        * on_epoch_end
-        * on_batch_begin
-        * on_batch_end
+
+        * ``on_train_begin``
+        * ``on_train_end``
+        * ``on_epoch_begin``
+        * ``on_epoch_end``
+        * ``on_batch_begin``
+        * ``on_batch_end``
+        * ``on_grad_computed``
 
         """
         getattr(self, method_name)(self, **cb_kwargs)

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -13,7 +13,7 @@ from torch.utils.data import DataLoader
 
 from skorch.callbacks import EpochTimer
 from skorch.callbacks import PrintLog
-from skorch.callbacks import BatchScoring
+from skorch.callbacks import PassthroughScoring
 from skorch.dataset import Dataset
 from skorch.dataset import CVSplit
 from skorch.dataset import get_len
@@ -28,13 +28,10 @@ from skorch.utils import check_is_fitted
 from skorch.utils import duplicate_items
 from skorch.utils import get_map_location
 from skorch.utils import is_dataset
-from skorch.utils import noop
 from skorch.utils import params_for
 from skorch.utils import to_device
 from skorch.utils import to_numpy
 from skorch.utils import to_tensor
-from skorch.utils import train_loss_score
-from skorch.utils import valid_loss_score
 
 
 # pylint: disable=too-many-instance-attributes
@@ -249,16 +246,12 @@ class NeuralNet:
     def _default_callbacks(self):
         return [
             ('epoch_timer', EpochTimer()),
-            ('train_loss', BatchScoring(
-                train_loss_score,
+            ('train_loss', PassthroughScoring(
                 name='train_loss',
                 on_train=True,
-                target_extractor=noop,
             )),
-            ('valid_loss', BatchScoring(
-                valid_loss_score,
+            ('valid_loss', PassthroughScoring(
                 name='valid_loss',
-                target_extractor=noop,
             )),
             ('print_log', PrintLog()),
         ]

--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -561,7 +561,10 @@ class TestBatchScoring:
 
     @pytest.fixture
     def train_loss(self, scoring_cls):
-        from skorch.utils import train_loss_score
+        # pylint: disable=unused-argument
+        def train_loss_score(net, X=None, y=None):
+            return net.history[-1, 'batches', -1, 'train_loss']
+
         return scoring_cls(
             train_loss_score,
             name='train_loss',
@@ -570,7 +573,10 @@ class TestBatchScoring:
 
     @pytest.fixture
     def valid_loss(self, scoring_cls):
-        from skorch.utils import valid_loss_score
+        # pylint: disable=unused-argument
+        def valid_loss_score(net, X=None, y=None):
+            return net.history[-1, 'batches', -1, 'valid_loss']
+
         return scoring_cls(
             valid_loss_score,
             name='valid_loss',

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -1450,9 +1450,8 @@ class TestNeuralNet:
         # does not raise
         net.fit(X, y)
 
-    @pytest.mark.parametrize('use_caching', [True, False])
     def test_net_initialized_with_custom_dataset_args(
-            self, net_cls, module_cls, data, dataset_cls, use_caching):
+            self, net_cls, module_cls, data, dataset_cls):
         side_effect = []
 
         class MyDataset(dataset_cls):
@@ -1465,22 +1464,15 @@ class TestNeuralNet:
             dataset=MyDataset,
             dataset__foo=123,
             max_epochs=1,
-            callbacks__train_loss__use_caching=use_caching,
-            callbacks__valid_loss__use_caching=use_caching,
-            callbacks__valid_acc__use_caching=use_caching,
         )
         net.fit(*data)
+        assert side_effect == [123]
 
-        if not use_caching:
-            # train/valid split, scoring predict
-            assert side_effect == [123, 123]
-        else:
-            # train/valid split
-            assert side_effect == [123]
-
+    @pytest.mark.skip
     @pytest.mark.xfail
     def test_net_initialized_with_initalized_dataset(
             self, net_cls, module_cls, data, dataset_cls):
+        # TODO: What to do of this test now??
         net = net_cls(
             module_cls,
             dataset=dataset_cls(*data),

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -422,16 +422,6 @@ def open_file_like(f, mode):
             f.close()
 
 
-# pylint: disable=unused-argument
-def train_loss_score(net, X=None, y=None):
-    return net.history[-1, 'batches', -1, 'train_loss']
-
-
-# pylint: disable=unused-argument
-def valid_loss_score(net, X=None, y=None):
-    return net.history[-1, 'batches', -1, 'valid_loss']
-
-
 class FirstStepAccumulator:
     """Store and retrieve the train step data.
 


### PR DESCRIPTION
The motivation for this PR is to make skorch easier to customize so that things like [DCGAN](https://github.com/pytorch/examples/tree/master/dcgan) can be implemented with less effort. See the attached [notebook](https://github.com/skorch-dev/skorch/blob/feature-facilitate-customization-of-net/notebooks/dcgan.ipynb) for an illustration of this.

To achieve this, I introduced 2 major changes:

## `PassthroughScoring`

Currently, when adding new losses on a batch level, it's very fiddly to log them on an epoch level. You have to define a custom function that picks the right value from `history` and passes it through without modification, then add a `BatchScoring` callback that uses this mock scoring function, defines the name of the score again, and pass `noop`.

Here is the code before and after:

```python
# somewhere in the net code
    ...
    self.history.record_batch('my_loss', my_loss)
    ...

# before
from skorch.callbacks import BatchScoring
from skorch.utils import noop

def my_loss_score(net, X=None, y=None):
    return net.history[-1, 'batches', -1, 'my_loss']

callbacks = [
    BatchScoring(
        my_loss_score,
        name='my_loss',
        target_extractor=noop,
    ),
]

# after
from skorch.callbacks import PassthroughScoring

callbacks = [
    PassthroughScoring(name='my_loss'),
]
```

I replaced `BatchScoring` with `PassthroughScoring` in the existing code for train and valid loss.

## Facilitate adding custom torch modules and optimizers

Right now, if a user wants to add their own modules or optimizers to `NeuralNet`, there are a few non-obvious steps they need to take for everything to work well:

1. Make sure to extend `prefixes_` attribute to make `set_params` work (but don't mutate or else woe!)
2. Make sure to extend `cuda_dependent_attributes_` to avoid subtle bugs (but again, don't mutate!)
3. Use "private" methods like `self._get_params_for` or `self._get_params_for_optimizer`.

The changes introduces in this PR automatically take care of 1. and 2. by using some `__setattr__` magic. This is of course a dangerous thing to do, so please think about cases where this could go wrong.

For 3., I have not found a better solution right now then to make the mentioned methods public. I was experimenting with automating this step completely with some magic things happening behind the door but this was a) a bit hacky and b) we cannot know which module parameters should be passed to an optimizer, i.e. we cannot fully automate this.

If anyone has a suggestion to make this easier for the user, please come ahead.

## Conclusion

To illustrate how all these changes help, please have a look at the attached [notebook](https://github.com/skorch-dev/skorch/blob/feature-facilitate-customization-of-net/notebooks/dcgan.ipynb). This replaces the notebook shown in #587 and sticks much closer to the original pytorch implementation of DCGAN.

If we find this solution okay, I would add more documentation, docstrings, and tests.

ping @zachbellay @cgarciae @YannDubs 