### PR TITLE
add PassthroughScoring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `NeptuneLogger` callback for logging experiment metadata to neptune.ai
-- Add DataFrameTransformer, an sklearn compatible transformer that helps working with pandas DataFrames by transforming the DataFrame into a representation that works well with neural networks (#507)
+- Add `DataFrameTransformer`, an sklearn compatible transformer that helps working with pandas DataFrames by transforming the DataFrame into a representation that works well with neural networks (#507)
+- Add `PassthroughScoring`, a scoring callback that just calculates the average score of a metric determined at batch level and then writes it to the epoch level
 
 ### Changed
 

--- a/docs/user/FAQ.rst
+++ b/docs/user/FAQ.rst
@@ -341,16 +341,19 @@ in skorch. Here is an example:
 
 .. code:: python
 
-    class MyNet(NeuralNetClassifier):
-        def check_data(self, X, y):
-            super().check_data(X, y)
+    class InputShapeSetter(skorch.callbacks.Callback):
+        def on_train_begin(self, net, X, y):
+            net.set_params(module__input_dim=X.shape[1])
 
-            if self.module_.input_units != X.shape[1]:
-                self.set_params(module__input_units=X.shape[1])
-                self.initialize()
+
+    net = skorch.NeuralNetClassifier(
+        ClassifierModule,
+        callbacks=[InputShapeSetter()],
+    )
 
 This assumes that your module accepts an argument called
 ``input_units``, which determines the number of units of the input
 layer, and that the number of features can be determined by
 ``X.shape[1]``. If those assumptions are not true for your case,
-adjust the code accordingly.
+adjust the code accordingly. A fully working example can be found
+on `stackoverflow <https://stackoverflow.com/a/60170023/1643939>`_.

--- a/docs/user/callbacks.rst
+++ b/docs/user/callbacks.rst
@@ -142,14 +142,14 @@ compare the performance once with and once without the callback.
 Scoring
 -------
 
-skorch provides two scoring callbacks by default,
+skorch provides two callbacks that calculate scores by default,
 :class:`.EpochScoring` and :class:`.BatchScoring`. They work basically
 in the same way, except that :class:`.EpochScoring` calculates scores
 after each epoch and :class:`.BatchScoring` after each batch. Use the
 former if averaging of batch-wise scores is imprecise (say for AUC
 score) and the latter if you are very tight for memory.
 
-In general, the scoring callbacks are useful when the default scores
+In general, these scoring callbacks are useful when the default scores
 determined by the :class:`.NeuralNet` are not enough. They allow you
 to easily add new metrics to be logged during training. For an example
 of how to add a new score to your model, look `at this notebook
@@ -198,6 +198,26 @@ should be a function or callable that is applied to the target before
 it is passed to the scoring function. The main reason why we need this
 is that sometimes, the target is not of a form expected by sklearn and
 we need to process it before passing it on.
+
+On top of the two described scoring callbacks, skorch also provides
+:class:`.PassthroughScoring`. This callback does not actually calculate
+any new scores. Instead it uses an existing score that is calculated
+for each batch and determines the average of this score, which is
+then written to the epoch level of the net's ``history``. This is very
+useful if the score was already calculated and logged on the batch
+level and you're only interested to see the averaged score on the
+epoch level.
+
+For this callback, you only need to provide the ``name`` of the score
+in the ``history``. Moreover, you may again specify if
+``lower_is_better`` and if the score should be calculated ``on_train``
+or not.
+
+.. note:: Both :class:`.BatchScoring` and :class:`.PassthroughScoring`
+           honor the batch size when calculating the average. This can
+           make a difference when not all batch sizes are equal, which
+           is typically the case because the last batch of an epoch
+           contains fewer samples than the rest.
 
 
 Checkpoint

--- a/docs/user/callbacks.rst
+++ b/docs/user/callbacks.rst
@@ -200,13 +200,13 @@ is that sometimes, the target is not of a form expected by sklearn and
 we need to process it before passing it on.
 
 On top of the two described scoring callbacks, skorch also provides
-:class:`.PassthroughScoring`. This callback does not actually calculate
-any new scores. Instead it uses an existing score that is calculated
-for each batch and determines the average of this score, which is
-then written to the epoch level of the net's ``history``. This is very
-useful if the score was already calculated and logged on the batch
-level and you're only interested to see the averaged score on the
-epoch level.
+:class:`.PassthroughScoring`. This callback does not actually
+calculate any new scores. Instead it uses an existing score that is
+calculated for each batch (the train loss, for example) and determines
+the average of this score, which is then written to the epoch level of
+the net's ``history``. This is very useful if the score was already
+calculated and logged on the batch level and you're only interested to
+see the averaged score on the epoch level.
 
 For this callback, you only need to provide the ``name`` of the score
 in the ``history``. Moreover, you may again specify if

--- a/skorch/callbacks/__init__.py
+++ b/skorch/callbacks/__init__.py
@@ -17,4 +17,4 @@ __all__ = ['Callback', 'EpochTimer', 'NeptuneLogger', 'PrintLog', 'ProgressBar',
            'LRScheduler', 'WarmRestartLR', 'GradientNormClipping',
            'BatchScoring', 'EpochScoring', 'Checkpoint', 'EarlyStopping',
            'Freezer', 'Unfreezer', 'Initializer', 'ParamMapper',
-           'LoadInitState', 'TrainEndCheckpoint']
+           'LoadInitState', 'TrainEndCheckpoint', 'PassthroughScoring']

--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -474,7 +474,30 @@ class EpochScoring(ScoringBase):
 
 
 class PassthroughScoring(Callback):
-    """TODO"""
+    """Creates scores on epoch level based on batch level scores
+
+    This callback doesn't calculate any new scores but instead passes
+    through a score that was created on the batch level. Based on that
+    score, an average across the batch is created (honoring the batch
+    size) and recorded in the history for the given epoch.
+
+    Use this callback when there already is a score calculated on the
+    batch level. If that score has yet to be calculated, use
+    :class:`.BatchScoring` instead.
+
+    Parameters
+    ----------
+    name : str
+      Name of the score recorded on a batch level in the history.
+
+    lower_is_better : bool (default=True)
+      Whether lower (e.g. log loss) or higher (e.g. accuracy) scores
+      are better.
+
+    on_train : bool (default=False)
+      Whether this should be called during train or validation.
+
+    """
     def __init__(
             self,
             name,
@@ -487,6 +510,7 @@ class PassthroughScoring(Callback):
 
     def initialize(self):
         self.best_score_ = np.inf if self.lower_is_better else -np.inf
+        return self
 
     def _is_best_score(self, current_score):
         if self.lower_is_better is None:

--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -197,12 +197,13 @@ class BatchScoring(ScoringBase):
     average score is the best score yet and that information is also
     stored in the history.
 
-    In contrast to ``EpochScoring``, this callback determines the
-    score for each batch and then averages the score at the end of the
-    epoch. This can be disadvantageous for some scores if the batch
-    size is small -- e.g. area under the ROC will return incorrect
-    scores in this case. Therefore, it is recommnded to use
-    ``EpochScoring`` unless you really need the scores for each batch.
+    In contrast to :class:`.EpochScoring`, this callback determines
+    the score for each batch and then averages the score at the end of
+    the epoch. This can be disadvantageous for some scores if the
+    batch size is small -- e.g. area under the ROC will return
+    incorrect scores in this case. Therefore, it is recommnded to use
+    :class:`.EpochScoring` unless you really need the scores for each
+    batch.
 
     If ``y`` is None, the ``scoring`` function with signature (model, X, y)
     must be able to handle ``X`` as a ``Tensor`` and ``y=None``.
@@ -218,7 +219,7 @@ class BatchScoring(ScoringBase):
 
     lower_is_better : bool (default=True)
       Whether lower (e.g. log loss) or higher (e.g. accuracy) scores
-      are better
+      are better.
 
     on_train : bool (default=False)
       Whether this should be called during train or validation.
@@ -234,6 +235,7 @@ class BatchScoring(ScoringBase):
       Re-use the model's prediction for computing the loss to calculate
       the score. Turning this off will result in an additional inference
       step for each batch.
+
     """
     # pylint: disable=unused-argument,arguments-differ
 

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -11,14 +11,11 @@ from skorch import NeuralNet
 from skorch.callbacks import EpochTimer
 from skorch.callbacks import PrintLog
 from skorch.callbacks import EpochScoring
-from skorch.callbacks import BatchScoring
+from skorch.callbacks import PassthroughScoring
 from skorch.dataset import CVSplit
 from skorch.utils import get_dim
 from skorch.utils import is_dataset
-from skorch.utils import noop
 from skorch.utils import to_numpy
-from skorch.utils import train_loss_score
-from skorch.utils import valid_loss_score
 
 
 neural_net_clf_doc_start = """NeuralNet for classification tasks
@@ -82,16 +79,12 @@ class NeuralNetClassifier(NeuralNet, ClassifierMixin):
     def _default_callbacks(self):
         return [
             ('epoch_timer', EpochTimer()),
-            ('train_loss', BatchScoring(
-                train_loss_score,
+            ('train_loss', PassthroughScoring(
                 name='train_loss',
                 on_train=True,
-                target_extractor=noop,
             )),
-            ('valid_loss', BatchScoring(
-                valid_loss_score,
+            ('valid_loss', PassthroughScoring(
                 name='valid_loss',
-                target_extractor=noop,
             )),
             ('valid_acc', EpochScoring(
                 'accuracy',
@@ -273,16 +266,12 @@ class NeuralNetBinaryClassifier(NeuralNet, ClassifierMixin):
     def _default_callbacks(self):
         return [
             ('epoch_timer', EpochTimer()),
-            ('train_loss', BatchScoring(
-                train_loss_score,
+            ('train_loss', PassthroughScoring(
                 name='train_loss',
                 on_train=True,
-                target_extractor=noop,
             )),
-            ('valid_loss', BatchScoring(
-                valid_loss_score,
+            ('valid_loss', PassthroughScoring(
                 name='valid_loss',
-                target_extractor=noop,
             )),
             ('valid_acc', EpochScoring(
                 'accuracy',

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -13,7 +13,7 @@ from torch.utils.data import DataLoader
 
 from skorch.callbacks import EpochTimer
 from skorch.callbacks import PrintLog
-from skorch.callbacks import BatchScoring
+from skorch.callbacks import PassthroughScoring
 from skorch.dataset import Dataset
 from skorch.dataset import CVSplit
 from skorch.dataset import get_len
@@ -28,13 +28,10 @@ from skorch.utils import check_is_fitted
 from skorch.utils import duplicate_items
 from skorch.utils import get_map_location
 from skorch.utils import is_dataset
-from skorch.utils import noop
 from skorch.utils import params_for
 from skorch.utils import to_device
 from skorch.utils import to_numpy
 from skorch.utils import to_tensor
-from skorch.utils import train_loss_score
-from skorch.utils import valid_loss_score
 
 
 # pylint: disable=too-many-instance-attributes
@@ -249,16 +246,12 @@ class NeuralNet:
     def _default_callbacks(self):
         return [
             ('epoch_timer', EpochTimer()),
-            ('train_loss', BatchScoring(
-                train_loss_score,
+            ('train_loss', PassthroughScoring(
                 name='train_loss',
                 on_train=True,
-                target_extractor=noop,
             )),
-            ('valid_loss', BatchScoring(
-                valid_loss_score,
+            ('valid_loss', PassthroughScoring(
                 name='valid_loss',
-                target_extractor=noop,
             )),
             ('print_log', PrintLog()),
         ]

--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -932,3 +932,128 @@ class TestBatchScoring:
         # the bug, the cache would be exhausted early because of the
         # train split, and we would get back less.
         assert len(y_pred) == len(X)
+
+
+class TestPassthrougScoring:
+    @pytest.fixture
+    def scoring_cls(self, request):
+        from skorch.callbacks import PassthroughScoring
+        return PassthroughScoring
+
+    @pytest.fixture
+    def train_loss(self, scoring_cls):
+        # use train batch size to stand in for batch-level scores
+        return scoring_cls(name='train_batch_size', on_train=True)
+
+    @pytest.fixture
+    def valid_loss(self, scoring_cls):
+        # use valid batch size to stand in for batch-level scores
+        return scoring_cls(name='valid_batch_size')
+
+    @pytest.fixture
+    def net(self, classifier_module, train_loss, valid_loss, classifier_data):
+        from skorch import NeuralNetClassifier
+        net = NeuralNetClassifier(
+            classifier_module,
+            batch_size=10,
+            # use train and valid batch size to stand in for
+            # batch-level scores
+            callbacks=[train_loss, valid_loss],
+            max_epochs=2)
+
+        X, y = classifier_data
+        n = 75
+        # n=75 with a 4/5 train/valid split -> 60/15 samples; with a
+        # batch size of 10, that leads to train batch sizes of
+        # [10,10,10,10] and valid batich sizes of [10,5]
+        return net.fit(X[:n], y[:n])
+
+    @pytest.fixture
+    def history(self, net):
+        return net.history
+
+    @pytest.fixture
+    def history_empty(self):
+        from skorch.history import History
+        return History()
+
+    def test_correct_train_pass_through_scores(self, history):
+        # train: average of [10,10,10,10,10] is 10
+        train_scores = history[:, 'train_batch_size']
+        assert np.allclose(train_scores, 10.0)
+
+    def test_correct_valid_pass_through_scores(self, history):
+        # valid: average of [10,5] with weights also being [10,5] =
+        # (10*10 + 5*5)/15
+        expected = (10 * 10 + 5 * 5) / 15  # 8.333..
+        valid_losses = history[:, 'valid_batch_size']
+        assert np.allclose(valid_losses, [expected, expected])
+
+    def test_missing_entry_in_epoch(self, scoring_cls, history_empty):
+        """We skip one entry in history_empty. This batch should simply be
+        ignored.
+
+        """
+        history_empty.new_epoch()
+        history_empty.new_batch()
+        history_empty.record_batch('score', 10)
+        history_empty.record_batch('train_batch_size', 10)
+
+        history_empty.new_batch()
+        # this score is ignored since it has no associated batch size
+        history_empty.record_batch('score', 20)
+
+        net = Mock(history=history_empty)
+        cb = scoring_cls(name='score', on_train=True).initialize()
+        cb.on_epoch_end(net)
+
+        train_score = history_empty[-1, 'score']
+        assert np.isclose(train_score, 10.0)
+
+    @pytest.mark.parametrize('lower_is_better, expected', [
+        (True, [True, True, True, False, False]),
+        (False, [True, False, False, True, False]),
+        (None, []),
+    ])
+    def test_lower_is_better_is_honored(
+            self, net_cls, module_cls, scoring_cls, train_split, data,
+            history_empty, lower_is_better, expected,
+    ):
+        # results in expected patterns of True and False
+        scores = [10, 8, 6, 11, 7]
+
+        cb = scoring_cls(
+            name='score',
+            lower_is_better=lower_is_better,
+        ).initialize()
+
+        net = Mock(history=history_empty)
+        for score in scores:
+            history_empty.new_epoch()
+            history_empty.new_batch()
+            history_empty.record_batch('score', score)
+            history_empty.record_batch('valid_batch_size', 55)  # doesn't matter
+            cb.on_epoch_end(net)
+
+        if lower_is_better is not None:
+            is_best = history_empty[:, 'score_best']
+            assert is_best == expected
+        else:
+            # if lower_is_better==None, don't write score
+            with pytest.raises(KeyError):
+                # pylint: disable=pointless-statement
+                history_empty[:, 'score_best']
+
+    def test_no_error_when_no_valid_data(
+            self, net_cls, module_cls, scoring_cls, data,
+    ):
+        # we set the name to 'valid_batch_size' but disable
+        # train/valid split -- there should be no error
+        net = net_cls(
+            module_cls,
+            callbacks=[scoring_cls(name='valid_batch_size')],
+            max_epochs=1,
+            train_split=None,
+        )
+        # does not raise
+        net.fit(*data)

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -1468,7 +1468,7 @@ class TestNeuralNet:
         net.fit(*data)
         assert side_effect == [123]
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(raises=ValueError)
     def test_net_initialized_with_initalized_dataset(
             self, net_cls, module_cls, data, dataset_cls):
         net = net_cls(

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -1450,9 +1450,8 @@ class TestNeuralNet:
         # does not raise
         net.fit(X, y)
 
-    @pytest.mark.parametrize('use_caching', [True, False])
     def test_net_initialized_with_custom_dataset_args(
-            self, net_cls, module_cls, data, dataset_cls, use_caching):
+            self, net_cls, module_cls, data, dataset_cls):
         side_effect = []
 
         class MyDataset(dataset_cls):
@@ -1465,22 +1464,15 @@ class TestNeuralNet:
             dataset=MyDataset,
             dataset__foo=123,
             max_epochs=1,
-            callbacks__train_loss__use_caching=use_caching,
-            callbacks__valid_loss__use_caching=use_caching,
-            callbacks__valid_acc__use_caching=use_caching,
         )
         net.fit(*data)
+        assert side_effect == [123]
 
-        if not use_caching:
-            # train/valid split, scoring predict
-            assert side_effect == [123, 123]
-        else:
-            # train/valid split
-            assert side_effect == [123]
-
+    @pytest.mark.skip
     @pytest.mark.xfail
     def test_net_initialized_with_initalized_dataset(
             self, net_cls, module_cls, data, dataset_cls):
+        # TODO: What to do of this test now??
         net = net_cls(
             module_cls,
             dataset=dataset_cls(*data),

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -1468,11 +1468,9 @@ class TestNeuralNet:
         net.fit(*data)
         assert side_effect == [123]
 
-    @pytest.mark.skip
     @pytest.mark.xfail
     def test_net_initialized_with_initalized_dataset(
             self, net_cls, module_cls, data, dataset_cls):
-        # TODO: What to do of this test now??
         net = net_cls(
             module_cls,
             dataset=dataset_cls(*data),


### PR DESCRIPTION
As mentioned [here](https://github.com/skorch-dev/skorch/pull/593#issuecomment-586739727), I factored out the addition of `PassthroughScoring` from the PR #593 

Here is a copy of the reasoning:

----------

Currently, when adding new losses on a batch level, it's very fiddly to log them on an epoch level. You have to define a custom function that picks the right value from history and passes it through without modification, then add a BatchScoring callback that uses this mock scoring function, defines the name of the score again, and pass noop.

Here is the code before and after:

```python
# somewhere in the net code
    ...
    self.history.record_batch('my_loss', my_loss)
    ...

# before
from skorch.callbacks import BatchScoring
from skorch.utils import noop

def my_loss_score(net, X=None, y=None):
    return net.history[-1, 'batches', -1, 'my_loss']

callbacks = [
    BatchScoring(
        my_loss_score,
        name='my_loss',
        target_extractor=noop,
    ),
]

# after
from skorch.callbacks import PassthroughScoring

callbacks = [
    PassthroughScoring(name='my_loss'),
]
```
----------

I replaced `BatchScoring` with `PassthroughScoring` in the existing code for train and valid loss. Even though `skorch.utils.train_loss_score` and `skorch.utils.valid_loss_score` would not be needed anymore with this change, I still left them in place. This is for 2 reasons:

* someone might use them directly (after all, they're public functions)
* if they are removed, old pickled nets cannot be unpickled anymore

The latter could be fixed by introducing a special case in `__getstate__` and replacing the old `BatchScoring` with the new `PassthroughScoring` which doesn't require these functions, but this seems to be far too much work for very little gain. Instead, I propose to leave those functions for now, maybe deprecate them at some future time.

I'm not quite certain what to do with `test_net_initialized_with_initalized_dataset`. I'll think of something, but if anyone has an idea, I'll be glad to hear it.