### PR TITLE
Enhancement/auto device option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `NeptuneLogger` callback for logging experiment metadata to neptune.ai
 - Add DataFrameTransformer, an sklearn compatible transformer that helps working with pandas DataFrames by transforming the DataFrame into a representation that works well with neural networks (#507)
-- Added `None` option to `device` which leaves the device(s) unmodified by Skorch. (#600)
+- Added `None` option to `device` which leaves the device(s) unmodified. (#600)
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `NeptuneLogger` callback for logging experiment metadata to neptune.ai
 - Add DataFrameTransformer, an sklearn compatible transformer that helps working with pandas DataFrames by transforming the DataFrame into a representation that works well with neural networks (#507)
+- Added `auto` and `None` options to automatically use the fastest device available or to leave the device type unmodified respectively. (#600)
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `NeptuneLogger` callback for logging experiment metadata to neptune.ai
 - Add DataFrameTransformer, an sklearn compatible transformer that helps working with pandas DataFrames by transforming the DataFrame into a representation that works well with neural networks (#507)
-- Added `auto` and `None` options to automatically use the fastest device available or to leave the device type unmodified respectively. (#600)
+- Added `None` option to `device` which leaves the device(s) unmodified by Skorch. (#600)
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `NeptuneLogger` callback for logging experiment metadata to neptune.ai
 - Add DataFrameTransformer, an sklearn compatible transformer that helps working with pandas DataFrames by transforming the DataFrame into a representation that works well with neural networks (#507)
-- Added `None` option to `device` which leaves the device(s) unmodified. (#600)
+- Added `None` option to `device` which leaves the device(s) unmodified (#600)
 
 ### Changed
 

--- a/docs/user/FAQ.rst
+++ b/docs/user/FAQ.rst
@@ -341,16 +341,19 @@ in skorch. Here is an example:
 
 .. code:: python
 
-    class MyNet(NeuralNetClassifier):
-        def check_data(self, X, y):
-            super().check_data(X, y)
+    class InputShapeSetter(skorch.callbacks.Callback):
+        def on_train_begin(self, net, X, y):
+            net.set_params(module__input_dim=X.shape[1])
 
-            if self.module_.input_units != X.shape[1]:
-                self.set_params(module__input_units=X.shape[1])
-                self.initialize()
+
+    net = skorch.NeuralNetClassifier(
+        ClassifierModule,
+        callbacks=[InputShapeSetter()],
+    )
 
 This assumes that your module accepts an argument called
 ``input_units``, which determines the number of units of the input
 layer, and that the number of features can be determined by
 ``X.shape[1]``. If those assumptions are not true for your case,
-adjust the code accordingly.
+adjust the code accordingly. A fully working example can be found
+on `stackoverflow <https://stackoverflow.com/a/60170023/1643939>`_.

--- a/examples/benchmarks/mnist.py
+++ b/examples/benchmarks/mnist.py
@@ -34,6 +34,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.model_selection import StratifiedKFold
 from sklearn.metrics import accuracy_score
 from sklearn.utils import shuffle
+from skorch.utils import to_device
 from skorch import NeuralNetClassifier
 from skorch.callbacks import EpochScoring
 import torch
@@ -141,7 +142,7 @@ def train_torch(
         lr,
         max_epochs,
 ):
-    model.to(device)
+    model = to_device(model, device)
 
     idx_train, idx_valid = next(iter(StratifiedKFold(
         5, random_state=0).split(np.arange(len(X)), y)))
@@ -191,7 +192,7 @@ def train_step(model, dataset, device, criterion, batch_size, optimizer):
     batch_sizes = []
     tic = time.time()
     for Xi, yi in torch.utils.data.DataLoader(dataset, batch_size=batch_size):
-        Xi, yi = Xi.to(device), yi.to(device)
+        Xi, yi = to_device(Xi, device), to_device(yi, device)
         optimizer.zero_grad()
         y_pred = model(Xi)
         y_pred = torch.log(y_pred)
@@ -221,7 +222,7 @@ def valid_step(model, dataset, device, criterion, batch_size):
         for Xi, yi in torch.utils.data.DataLoader(
                 dataset, batch_size=batch_size,
         ):
-            Xi, yi = Xi.to(device), yi.to(device)
+            Xi, yi = to_device(Xi, device), to_device(yi, device)
             y_pred = model(Xi)
             y_pred = torch.log(y_pred)
             loss = criterion(y_pred, yi)

--- a/examples/word_language_model/data.py
+++ b/examples/word_language_model/data.py
@@ -1,5 +1,7 @@
 import os
 
+from skorch.utils import to_device
+
 import torch
 from torch.autograd import Variable
 
@@ -70,7 +72,7 @@ class Loader:
         data = data.narrow(0, 0, nbatch * bsz)
         # Evenly divide the data across the bsz batches.
         data = data.view(bsz, -1).t().contiguous()
-        return data.to(self.device)
+        return to_device(data, self.device)
 
     def get_batch(self, i):
         seq_len = min(self.bptt, len(self.batches) - 1 - i)

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -156,8 +156,8 @@ class NeuralNet:
     device : str, torch.device (default='cpu')
       The compute device to be used. If set to 'cuda', data in torch
       tensors will be pushed to cuda tensors before being sent to the
-      module. If set to 'auto', computer device will select 'cuda' if
-      available, otherwise it will use the default. If set to None, then
+      module. If set to 'auto', 'cuda' will be selected if available,
+      otherwise the default will be used. If set to None, then
       all compute devices will be left unmodified.
 
     Attributes

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -156,9 +156,8 @@ class NeuralNet:
     device : str, torch.device (default='cpu')
       The compute device to be used. If set to 'cuda', data in torch
       tensors will be pushed to cuda tensors before being sent to the
-      module. If set to 'auto', 'cuda' will be selected if available,
-      otherwise the default will be used. If set to None, then
-      all compute devices will be left unmodified.
+      module. If set to None, then all compute devices will be left
+      unmodified.
 
     Attributes
     ----------

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -156,7 +156,9 @@ class NeuralNet:
     device : str, torch.device (default='cpu')
       The compute device to be used. If set to 'cuda', data in torch
       tensors will be pushed to cuda tensors before being sent to the
-      module.
+      module. If set to 'auto', computer device will select 'cuda' if
+      available, otherwise it will use the default. If set to None, then
+      all compute devices will be left unmodified.
 
     Attributes
     ----------
@@ -431,7 +433,7 @@ class NeuralNet:
         criterion_params = self._get_params_for('criterion')
         self.criterion_ = self.criterion(**criterion_params)
         if isinstance(self.criterion_, torch.nn.Module):
-            self.criterion_ = self.criterion_.to(self.device)
+            self.criterion_ = to_device(self.criterion_, self.device)
         return self
 
     def _format_reinit_msg(self, name, kwargs=None, triggered_directly=True):
@@ -472,7 +474,7 @@ class NeuralNet:
 
             module = module(**kwargs)
 
-        self.module_ = module.to(self.device)
+        self.module_ = to_device(module, self.device)
         return self
 
     def _is_virtual_param(self, key):

--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -160,13 +160,8 @@ class TestToDevice:
         if None is device_input:
             assert tensor.device.type == prev_device
 
-        elif device_input == "auto":
-            expected = 'cuda' if torch.cuda.is_available() else 'cpu'
-            assert tensor.device.type == expected
-
         else:
             assert tensor.device.type == device_input
-
 
     @pytest.mark.parametrize('device_from, device_to', [
         ('cpu', 'cpu'),
@@ -174,7 +169,6 @@ class TestToDevice:
         ('cuda', 'cpu'),
         ('cuda', 'cuda'),
         (None, None),
-        ('auto', 'auto'),
     ])
     def test_check_device_torch_tensor(self, to_device, x, device_from, device_to):
         if 'cuda' in (device_from, device_to) and not torch.cuda.is_available():
@@ -196,7 +190,6 @@ class TestToDevice:
         ('cuda', 'cpu'),
         ('cuda', 'cuda'),
         (None, None),
-        ('auto', 'auto'),
     ])
     def test_check_device_tuple_torch_tensor(
             self, to_device, x_tup, device_from, device_to):
@@ -221,7 +214,6 @@ class TestToDevice:
         ('cuda', 'cpu'),
         ('cuda', 'cuda'),
         (None, None),
-        ('auto', 'auto'),
     ])
     def test_check_device_packed_padded_sequence(
             self, to_device, x_pad_seq, device_from, device_to):

--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -151,9 +151,9 @@ class TestToDevice:
 
     @pytest.fixture
     def x_pad_seq(self):
-        input = torch.zeros((5, 3)).float()
+        value = torch.zeros((5, 3)).float()
         length = torch.as_tensor([2, 2, 1])
-        return pack_padded_sequence(input,length )
+        return pack_padded_sequence(value, length)
 
     def check_device_type(self, tensor, device_input, prev_device):
         """assert expected device type conditioned on the input argument for `to_device`"""
@@ -203,17 +203,17 @@ class TestToDevice:
         if 'cuda' in (device_from, device_to) and not torch.cuda.is_available():
             pytest.skip()
 
-        prev_device = [None for _ in range(len(x_tup))]
+        prev_devices = [None for _ in range(len(x_tup))]
         if None in (device_from, device_to):
-            prev_device = [x.device.type for x in x_tup]
+            prev_devices = [x.device.type for x in x_tup]
 
         x_tup = to_device(x_tup, device=device_from)
-        for idx, xi in enumerate(x_tup):
-            self.check_device_type(xi, device_from, prev_device[idx])
+        for xi, prev_d in zip(x_tup, prev_devices):
+            self.check_device_type(xi, device_from, prev_d)
 
         x_tup = to_device(x_tup, device=device_to)
-        for idx, xi in enumerate(x_tup):
-            self.check_device_type(xi, device_to, prev_device[idx])
+        for xi, prev_d in zip(x_tup, prev_devices):
+            self.check_device_type(xi, device_to, prev_d)
 
     @pytest.mark.parametrize('device_from, device_to', [
         ('cpu', 'cpu'),

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -80,7 +80,7 @@ def to_tensor(X, device, accept_sparse=False):
     to_tensor_ = partial(to_tensor, device=device)
 
     if is_torch_data_type(X):
-        return X.to(device)
+        return to_device(X, device)
     if isinstance(X, dict):
         return {key: to_tensor_(val) for key, val in X.items()}
     if isinstance(X, (list, tuple)):
@@ -126,12 +126,33 @@ def to_numpy(X):
 
 
 def to_device(X, device):
-    """Generic function to move module output(s) to a device.
+    """Generic function to modify the device type of the tensor(s)/module inputted.
 
-    Deals with X being a torch tensor or a tuple of torch tensors.
+    Parameters
+    ----------
+    X : input data
+        Deals with X being a:
+
+         * torch tensor
+         * tuple of torch tensors
+         * PackSequence instance
+         * torch.nn.Module
+
+    device : str, torch.device
+        The compute device to be used. If device="auto" it is set to
+        "cuda" if available otherwise "cpu". If device=None, return
+        the input unmodified
 
     """
-    if isinstance(X, tuple):
+    if device is None:
+        return X
+
+    if device == "auto":
+        use_cuda = torch.cuda.is_available()
+        device = "cuda" if use_cuda else "cpu"
+
+    # PackedSequence class inherits from a namedtuple
+    if isinstance(X, tuple) & (type(X) != PackedSequence):
         return tuple(x.to(device) for x in X)
     return X.to(device)
 

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -139,17 +139,12 @@ def to_device(X, device):
          * torch.nn.Module
 
     device : str, torch.device
-        The compute device to be used. If device="auto" it is set to
-        "cuda" if available otherwise "cpu". If device=None, return
-        the input unmodified
+        The compute device to be used. If device=None, return the input
+        unmodified
 
     """
     if device is None:
         return X
-
-    if device == "auto":
-        use_cuda = torch.cuda.is_available()
-        device = "cuda" if use_cuda else "cpu"
 
     # PackedSequence class inherits from a namedtuple
     if isinstance(X, tuple) and (type(X) != PackedSequence):
@@ -503,6 +498,9 @@ def get_map_location(target_device, fallback_device='cpu'):
     """Determine the location to map loaded data (e.g., weights)
     for a given target device (e.g. 'cuda').
     """
+    if target_device is None:
+        target_device = fallback_device
+
     map_location = torch.device(target_device)
 
     # The user wants to use CUDA but there is no CUDA device

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -126,7 +126,7 @@ def to_numpy(X):
 
 
 def to_device(X, device):
-    """Generic function to modify the device type of the tensor(s)/module inputted.
+    """Generic function to modify the device type of the tensor(s) or module.
 
     Parameters
     ----------
@@ -152,7 +152,7 @@ def to_device(X, device):
         device = "cuda" if use_cuda else "cpu"
 
     # PackedSequence class inherits from a namedtuple
-    if isinstance(X, tuple) & (type(X) != PackedSequence):
+    if isinstance(X, tuple) and (type(X) != PackedSequence):
         return tuple(x.to(device) for x in X)
     return X.to(device)
 


### PR DESCRIPTION
# Context

We would like to modify the `to_device` function to add the option for users to choose `"auto"` or `None`. By selecting `"auto"` the user will be allowing the skorch tool to automatically detect if GPU's is available. This functionality will mean that the user is no longer burdens with writing repetitive boiler plate code like the following:

```
_ = "cuda" if torch.cuda.is_available() else "cpu"
```
By selecting, `None`, we leave all tensors and modules unmodified so that a user can still customise how they allocate the devices themselves without us interfering. 

# Changes

- `CHANGES.md`: Added note about changes
- `examples/benchmarks/mnist.py`: Updated Mnist example to use `to_device` function.
- `examples/word_language_model/data.py`: Updated language model example to use `to_device` function.
- `skorch/net.py`: Updated device parameter description and added `to_device` where needed.
- `skorch/tests/test_utils.py`: Added tests for new `"auto"` and `None` options in `to_device`.
- `skorch/utils.py`: Updated `to_device` function to automatically find the fastest device or leave the input unmodified, depending on the argument passed.

# Tests
- Modified existing tests in `class TestToDevice` to update the expected value depending on the argument passed to `to_device`.
- Added a new test to test for when a `Packed Sequence` object is passed to `to_device` as this object needs special handling. It is a child of a namedTuple, however, if `to_device` operated on a `PackedSequence` object the same way it does to a regular tuple, it would break the execution as some of its attributes aren't tensors.
