### PR TITLE
Add logger to Weights & Biases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `NeptuneLogger` callback for logging experiment metadata to neptune.ai
 - Add DataFrameTransformer, an sklearn compatible transformer that helps working with pandas DataFrames by transforming the DataFrame into a representation that works well with neural networks (#507)
+- Added `WandbLogger` callback for logging to Weights & Biases
 
 ### Changed
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ pytest-cov
 sphinx
 sphinx_rtd_theme
 tensorboard>=1.14.0
+wandb

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,4 +14,4 @@ pytest-cov
 sphinx
 sphinx_rtd_theme
 tensorboard>=1.14.0
-wandb
+wandb>=0.8.30

--- a/skorch/callbacks/__init__.py
+++ b/skorch/callbacks/__init__.py
@@ -17,4 +17,4 @@ __all__ = ['Callback', 'EpochTimer', 'NeptuneLogger', 'PrintLog', 'ProgressBar',
            'LRScheduler', 'WarmRestartLR', 'GradientNormClipping',
            'BatchScoring', 'EpochScoring', 'Checkpoint', 'EarlyStopping',
            'Freezer', 'Unfreezer', 'Initializer', 'ParamMapper',
-           'LoadInitState', 'TrainEndCheckpoint']
+           'LoadInitState', 'TrainEndCheckpoint', 'WandbLogger']

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -227,6 +227,9 @@ class WandbLogger(Callback):
 
     >>> # Create a wandb Run
     ... wandb_run = wandb.init()
+    >>> # Alternative: Create a wandb Run without having a W&B account
+    ... wandb_run = wandb.init(anonymous="allow)
+
     >>> # Log hyper-parameters (optional)
     ... wandb.config.update({"learning rate": 1e-3, "batch size": 32})
 
@@ -239,7 +242,8 @@ class WandbLogger(Callback):
       wandb Run used to log data.
 
     save_model : bool (default=True)
-      Whether to save a checkpoint of the best model.
+      Whether to save a checkpoint of the best model and upload it
+      to your Run on W&B servers.
 
     keys_ignored : str or list of str (default=None)
       Key or list of keys that should not be logged to

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -214,6 +214,8 @@ class WandbLogger(Callback):
     your net's history, model topology and computer resources to Weights & Biases
     after each epoch.
 
+    Every file saved in `wandb_run.dir` is automatically logged to W&B servers.
+
     See `example run
     <https://app.wandb.ai/borisd13/skorch/runs/s20or4ct/overview?workspace=user-borisd13>`_
 
@@ -231,7 +233,7 @@ class WandbLogger(Callback):
     ... wandb_run = wandb.init(anonymous="allow)
 
     >>> # Log hyper-parameters (optional)
-    ... wandb.config.update({"learning rate": 1e-3, "batch size": 32})
+    ... wandb_run.config.update({"learning rate": 1e-3, "batch size": 32})
 
     >>> net = NeuralNet(..., callbacks=[WandbLogger(wandb_run)])
     >>> net.fit(X, y)

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -210,15 +210,21 @@ class NeptuneLogger(Callback):
 class WandbLogger(Callback):
     """Logs best model and metrics to `Weights & Biases <https://docs.wandb.com/>`_
 
-    "Use this callback to automatically log best trained model and all metrics from
-    your net's history to Weights & Biases after each epoch.
+    Use this callback to automatically log best trained model, all metrics from
+    your net's history, model topology and computer resources to Weights & Biases
+    after each epoch.
+
+    See `example run <https://app.wandb.ai/borisd13/skorch/runs/s20or4ct/overview?workspace=user-borisd13>`_
 
     Examples
     --------
+    >>> # Install wandb
+    ... pip install wandb
     >>> import wandb
     >>> from skorch.callbacks import WandbLogger
     >>> wandb_run = wandb.init()
-    >>> wandb.config.update({"learning rate": 1e-3, "batch size": 32})  # optional
+    >>> # Log hyper-parameters (optional)
+    ... wandb.config.update({"learning rate": 1e-3, "batch size": 32})
     >>> net = NeuralNet(..., callbacks=[WandbLogger(wandb_run)])
     >>> net.fit(X, y)
 
@@ -228,7 +234,7 @@ class WandbLogger(Callback):
       wandb Run used to log data.
 
     save_model : bool (default=True)
-      Saves best trained model.
+      Whether to save a checkpoint of the best model.
 
     keys_ignored : str or list of str (default=None)
       Key or list of keys that should not be logged to
@@ -266,7 +272,7 @@ class WandbLogger(Callback):
             self.wandb_run.watch(net.module_)
 
     def on_epoch_end(self, net, **kwargs):
-        """Automatically log values from the last history step."""
+        """Log values from the last history step and save best model"""
         hist = net.history[-1]
         keys_kept = filter_log_keys(hist, keys_ignored=self.keys_ignored_)
         logged_vals = dict((k, hist[k]) for k in keys_kept if k in hist)

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -260,7 +260,6 @@ class WandbLogger(Callback):
         self.wandb_run = wandb_run
         self.save_model = save_model
         self.keys_ignored = keys_ignored
-        self.model_path = Path(wandb_run.dir) / 'best_model.pth'
 
     def initialize(self):
         keys_ignored = self.keys_ignored
@@ -280,12 +279,13 @@ class WandbLogger(Callback):
         """Log values from the last history step and save best model"""
         hist = net.history[-1]
         keys_kept = filter_log_keys(hist, keys_ignored=self.keys_ignored_)
-        logged_vals = dict((k, hist[k]) for k in keys_kept if k in hist)
+        logged_vals = {k: hist[k] for k in keys_kept if k in hist}
         self.wandb_run.log(logged_vals)
 
         # save best model
         if self.save_model and hist['valid_loss_best']:
-            with self.model_path.open('wb') as model_file:
+            model_path = Path(self.wandb_run.dir) / 'best_model.pth'
+            with model_path.open('wb') as model_file:
                 net.save_params(f_params=model_file)
 
 

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -278,7 +278,7 @@ class WandbLogger(Callback):
         """Log values from the last history step and save best model"""
         hist = net.history[-1]
         keys_kept = filter_log_keys(hist, keys_ignored=self.keys_ignored_)
-        logged_vals = {k: hist[k] for k in keys_kept if k in hist}
+        logged_vals = {k: hist[k] for k in keys_kept}
         self.wandb_run.log(logged_vals)
 
         # save best model

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -214,17 +214,22 @@ class WandbLogger(Callback):
     your net's history, model topology and computer resources to Weights & Biases
     after each epoch.
 
-    See `example run <https://app.wandb.ai/borisd13/skorch/runs/s20or4ct/overview?workspace=user-borisd13>`_
+    See `example run
+    <https://app.wandb.ai/borisd13/skorch/runs/s20or4ct/overview?workspace=user-borisd13>`_
 
     Examples
     --------
     >>> # Install wandb
     ... pip install wandb
+
     >>> import wandb
     >>> from skorch.callbacks import WandbLogger
-    >>> wandb_run = wandb.init()
+
+    >>> # Create a wandb Run
+    ... wandb_run = wandb.init()
     >>> # Log hyper-parameters (optional)
     ... wandb.config.update({"learning rate": 1e-3, "batch size": 32})
+
     >>> net = NeuralNet(..., callbacks=[WandbLogger(wandb_run)])
     >>> net.fit(X, y)
 

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -248,9 +248,6 @@ class WandbLogger(Callback):
       '_best' are ignored by default.
     """
 
-    # Record if watch has been called previously (even in another instance)
-    _watch_called = False
-
     def __init__(
             self,
             wandb_run,
@@ -271,9 +268,7 @@ class WandbLogger(Callback):
 
     def on_train_begin(self, net, **kwargs):
         """Log model topology and add a hook for gradients"""
-        if not WandbLogger._watch_called:
-            WandbLogger._watch_called = True
-            self.wandb_run.watch(net.module_)
+        self.wandb_run.watch(net.module_)
 
     def on_epoch_end(self, net, **kwargs):
         """Log values from the last history step and save best model"""

--- a/skorch/tests/callbacks/test_logging.py
+++ b/skorch/tests/callbacks/test_logging.py
@@ -226,21 +226,6 @@ class TestWandb:
         mock.dir = '.'
         return mock
 
-    @pytest.fixture
-    def net_fitted(
-            self,
-            net_cls,
-            classifier_module,
-            data,
-            wandb_logger_cls,
-            mock_run,
-    ):
-        return net_cls(
-            classifier_module,
-            callbacks=[wandb_logger_cls(mock_run)],
-            max_epochs=3,
-        ).fit(*data)
-
     def test_ignore_keys(
             self,
             net_cls,

--- a/skorch/tests/callbacks/test_logging.py
+++ b/skorch/tests/callbacks/test_logging.py
@@ -11,6 +11,7 @@ import torch
 from torch import nn
 
 from skorch.tests.conftest import neptune_installed
+from skorch.tests.conftest import wandb_installed
 from skorch.tests.conftest import tensorboard_installed
 
 
@@ -189,6 +190,101 @@ class TestNeptune:
 
         npt.on_batch_end(net)
         assert npt.first_batch_ is False
+
+@pytest.mark.skipif(
+    not wandb_installed, reason='wandb is not installed')
+class TestWandb:
+    @pytest.fixture
+    def net_cls(self):
+        from skorch import NeuralNetClassifier
+        return NeuralNetClassifier
+
+    @pytest.fixture
+    def data(self, classifier_data):
+        X, y = classifier_data
+        # accelerate training since we don't care for the loss
+        X, y = X[:40], y[:40]
+        return X, y
+
+    @pytest.fixture
+    def wandb_logger_cls(self):
+        from skorch.callbacks import WandbLogger
+        return WandbLogger
+
+    @pytest.fixture
+    def wandb_run_cls(self):
+        import wandb
+        os.environ['WANDB_MODE'] = 'dryrun' # run offline
+        with wandb.init(anonymous="allow") as run:
+            return run
+
+    @pytest.fixture
+    def mock_run(self):
+        mock = Mock()
+        mock.log = Mock()
+        mock.watch = Mock()
+        mock.dir = '.'
+        return mock
+
+    @pytest.fixture
+    def net_fitted(
+            self,
+            net_cls,
+            classifier_module,
+            data,
+            wandb_logger_cls,
+            mock_run,
+    ):
+        return net_cls(
+            classifier_module,
+            callbacks=[wandb_logger_cls(mock_run)],
+            max_epochs=3,
+        ).fit(*data)
+
+    def test_ignore_keys(
+            self,
+            net_cls,
+            classifier_module,
+            data,
+            wandb_logger_cls,
+            mock_run,
+    ):
+        # ignore 'dur' and 'valid_loss', 'unknown' doesn't exist but
+        # this should not cause a problem
+        wandb_cb = wandb_logger_cls(
+            mock_run, keys_ignored=['dur', 'valid_loss', 'unknown'])
+        net_cls(
+            classifier_module,
+            callbacks=[wandb_cb],
+            max_epochs=3,
+        ).fit(*data)
+
+        # 3 epochs = 3 calls
+        assert mock_run.log.call_count == 3
+        assert mock_run.watch.call_count == 1
+        call_args = [args[0][0] for args in mock_run.log.call_args_list]
+        assert 'valid_loss' not in call_args
+
+    def test_keys_ignored_is_string(self, wandb_logger_cls, mock_run):
+        wandb_cb = wandb_logger_cls(
+            mock_run, keys_ignored='a-key').initialize()
+        expected = {'a-key', 'batches'}
+        assert wandb_cb.keys_ignored_ == expected
+
+    def test_fit_with_real_experiment(
+            self,
+            net_cls,
+            classifier_module,
+            data,
+            wandb_logger_cls,
+            wandb_run_cls,
+    ):
+        net = net_cls(
+            classifier_module,
+            callbacks=[wandb_logger_cls(wandb_run_cls)],
+            max_epochs=5,
+        )
+        net.fit(*data)
 
 class TestPrintLog:
     @pytest.fixture

--- a/skorch/tests/conftest.py
+++ b/skorch/tests/conftest.py
@@ -142,6 +142,15 @@ try:
 except ImportError:
     pass
 
+wandb_installed = False
+try:
+    # pylint: disable=unused-import
+    import wandb
+
+    wandb_installed = True
+except ImportError:
+    pass
+
 pandas_installed = False
 try:
     # pylint: disable=unused-import


### PR DESCRIPTION
Add support for logging through Weights & Biases.

`WandbLogger` automatically logs metrics, model topology, gradients and best trained model.

Sample run: https://app.wandb.ai/borisd13/skorch/runs/1vs6725x?workspace=user-borisd13
You can switch tabs on the left and see computer resources, model graph, logged files, etc