### PR TITLE
Add tensorboard to __all__ list

### DIFF
--- a/skorch/callbacks/__init__.py
+++ b/skorch/callbacks/__init__.py
@@ -13,8 +13,25 @@ from .scoring import *
 from .training import *
 from .lr_scheduler import *
 
-__all__ = ['Callback', 'EpochTimer', 'NeptuneLogger', 'PrintLog', 'ProgressBar',
-           'LRScheduler', 'WarmRestartLR', 'GradientNormClipping',
-           'BatchScoring', 'EpochScoring', 'Checkpoint', 'EarlyStopping',
-           'Freezer', 'Unfreezer', 'Initializer', 'ParamMapper',
-           'LoadInitState', 'TrainEndCheckpoint']
+
+__all__ = [
+    'BatchScoring',
+    'Callback',
+    'Checkpoint',
+    'EarlyStopping',
+    'EpochScoring',
+    'EpochTimer',
+    'Freezer',
+    'GradientNormClipping',
+    'Initializer',
+    'LRScheduler',
+    'LoadInitState',
+    'NeptuneLogger',
+    'ParamMapper',
+    'PrintLog',
+    'ProgressBar',
+    'TrainEndCheckpoint',
+    'TensorBoard',
+    'Unfreezer',
+    'WarmRestartLR',
+]


### PR DESCRIPTION
The `TensorBoard` callback was missing from `__all__`, which led to it not being listed in the docs.

In addition, I sorted the list and changed it to only contain one item per line because it was getting confusing.