### PR TITLE
Fix a failing test with sklearn 0.21.2

### DIFF
--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -965,7 +965,10 @@ class TestPassthrougScoring:
         n = 75
         # n=75 with a 4/5 train/valid split -> 60/15 samples; with a
         # batch size of 10, that leads to train batch sizes of
-        # [10,10,10,10] and valid batich sizes of [10,5]
+        # [10,10,10,10] and valid batch sizes of [10,5]; all labels
+        # are set to 0 to ensure that the stratified split is exactly
+        # equal to the desired split
+        y = np.zeros_like(y)
         return net.fit(X[:n], y[:n])
 
     @pytest.fixture


### PR DESCRIPTION
The test relied upon 75 samples being split into 60/15 for the
internal train/valid split. However, with certain sklearn versions,
the split would be 59/16 because of stratification. As a solution, the
target values are all set to 0. Since they are not important for the
tests, this solution works.

This is kinda blocking a release, as it affects the tests during the
release build.