### PR TITLE
Change: new get params behavior and bugfix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The behavior of method `net.get_params` changed to make it more consistent with sklearn: it will no longer return "learned" attributes like `module_`; therefore, functions like `sklearn.base.clone`, when called with a fitted net, will no longer return a fitted net but instead an uninitialized net; if you want a copy of a fitted net, use `copy.deepcopy` instead;`net.get_params` is used under the hood by many sklearn functions and classes, such as `GridSearchCV`, whose behavior may thus be affected by the change. (#521, #527)
+
 ### Fixed
 
 ## [0.8.0] - 2019-04-11

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1274,14 +1274,6 @@ class NeuralNet:
         return [pgroups], kwargs
 
     def _get_param_names(self):
-        return (k for k in self.__dict__.keys() if k != 'history_')
-
-    def _get_param_names_new(self):
-        # TODO: This will be the new behavior for _get_param_names in
-        # a future release. This is to make get_params work as in
-        # sklearn, i.e. not returning "learned" attributes (ending on
-        # '_'). Once the transition period has passed, remove the old
-        # code and use the new one instead.
         return (k for k in self.__dict__ if not k.endswith('_'))
 
     def _get_params_callbacks(self, deep=True):

--- a/skorch/tests/conftest.py
+++ b/skorch/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 from sklearn.datasets import make_classification
 from sklearn.datasets import make_regression
 from sklearn.preprocessing import StandardScaler
+import torch
 from torch import nn
 
 F = nn.functional
@@ -17,6 +18,14 @@ INFERENCE_METHODS = ['predict', 'predict_proba', 'forward', 'forward_iter']
 ###################
 # shared fixtures #
 ###################
+
+
+@pytest.fixture(autouse=True)
+def seeds_fixed():
+    torch.manual_seed(0)
+    torch.cuda.manual_seed(0)
+    np.random.seed(0)
+
 
 @pytest.fixture
 def module_cls():

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -16,9 +16,6 @@ from torch import nn
 from skorch.tests.conftest import INFERENCE_METHODS
 
 
-torch.manual_seed(0)
-
-
 class TestNeuralNet:
     @pytest.fixture(scope='module')
     def data(self, classifier_data):

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -1269,23 +1269,13 @@ class TestNeuralNet:
         net.initialize()
         net.get_params()
 
-    @pytest.mark.new_get_params_behavior
-    @pytest.mark.xfail(strict=True)
     def test_get_params_no_learned_params(self, net_fit):
-        # TODO: This test should fail for now but should succeed once
-        # we change the behavior of get_params to be more in line with
-        # sklearn. At that point, remove the decorators.
         params = net_fit.get_params()
         params_learned = set(filter(lambda x: x.endswith('_'), params))
         assert not params_learned
 
-    @pytest.mark.new_get_params_behavior
-    @pytest.mark.xfail(strict=True)
     def test_clone_results_in_uninitialized_net(
             self, net_fit, data):
-        # TODO: This test should fail for now but should succeed once
-        # we change the behavior of get_params to be more in line with
-        # sklearn. At that point, remove the decorators.
         X, y = data
         accuracy = accuracy_score(net_fit.predict(X), y)
         assert accuracy > ACCURACY_EXPECTED  # make sure net has learned
@@ -1298,7 +1288,6 @@ class TestNeuralNet:
 
         assert not net_cloned.history
 
-    @pytest.mark.new_get_params_behavior
     def test_clone_copies_parameters(self, net_cls, module_cls):
         kwargs = dict(
             module__hidden_units=20,

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -34,7 +34,6 @@ from skorch.utils import to_numpy
 from skorch.utils import is_torch_data_type
 
 
-torch.manual_seed(0)
 ACCURACY_EXPECTED = 0.65
 
 

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -88,10 +88,21 @@ class TestNeuralNet:
         ])
 
     @pytest.fixture(scope='module')
-    def net_fit(self, net, data):
-        # Careful, don't call additional fits on this, since that would have
-        # side effects on other tests.
+    def net_fit(self, net_cls, module_cls, dummy_callback, data):
+        # Careful, don't call additional fits or set_params on this,
+        # since that would have side effects on other tests.
         X, y = data
+
+        # We need a new instance of the net and cannot reuse the net
+        # fixture, because otherwise fixture net and net_fit refer to
+        # the same object; also, we cannot clone(net) because this
+        # will result in the dummy_callback not being the mock anymore
+        net = net_cls(
+            module_cls,
+            callbacks=[('dummy', dummy_callback)],
+            max_epochs=10,
+            lr=0.1,
+        )
         return net.fit(X, y)
 
     @pytest.fixture

--- a/skorch/tests/test_regressor.py
+++ b/skorch/tests/test_regressor.py
@@ -13,9 +13,6 @@ import torch
 from skorch.tests.conftest import INFERENCE_METHODS
 
 
-torch.manual_seed(0)
-
-
 class TestNeuralNetRegressor:
     @pytest.fixture(scope='module')
     def data(self, regression_data):


### PR DESCRIPTION
This change was announced in release 0.7 and now is a good time
to actually make the change. We just had a release, and since this
change could break existing code, we want it to be on master for
some time before making a new release.

This PR contains the main change and a bugfix that surfaced because
of the change.

Fixes #521

## main change

get_params no longer returns learnable parameters like module_. This
is in line with what sklearn expects but can potentially break old
code that relied on it implicitly. Since get_params is often uesd
under the hood in sklearn (e.g. by GridSearchCV), this could affect a
lot of code.

Still this new behavior is better so we decided to go along with
it. We had an announcement for 0.7 that warned about this. Now it's
coming in 0.9 (probably 1 year later or so, thus enough time to
adapt).

## incidental changes

### random seed

Use an autouse fixture so that all our tests are now using the same
random seed. This is better than fixing the seed at the beginning of
the module (which is the previous implementation) because it results
in more consistent behavior when only running a subset of all tests.

### bugfix in unit test

We had fixtures net and net_fit. However, they both referenced the
same object. Therefore, after doing net.set_params, we actually
mutated net_fit as well. This is no longer happening.

Note that I first wanted to do `net_fit = clone(net).fit(X, y)`.
However, clone(net) was no good because there is a callback defined as
`Mock(spec=Callback)` that, when cloned, turns into Callback. This is
not desired, so I decided to create a completely new instance for
net_fit.