### PR TITLE
ENH : set train / valid of criterion.

### DIFF
--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1099,6 +1099,10 @@ class NeuralNet:
 
         """
         y_true = to_tensor(y_true, device=self.device)
+
+        if isinstance(self.criterion_, torch.nn.Module):
+            self.criterion_.train(training)
+
         return self.criterion_(y_pred, y_true)
 
     def get_dataset(self, X, y=None):


### PR DESCRIPTION
closes #565

Usually criterions in pytorch inherit from nn.Module, meaning that they should have a `self.training` option that says whether it is during train or validation. yet skorch does not update it. This is useful for cases where there are multiple losses and the weights of each loss change during training (but not testing). E.g. beta-vae with annealing, Gans ....

@BenjaminBossan 