### PR TITLE
[MRG] LRScheduler batch option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed support for schedulers with a `batch_step()` method in `LRScheduler`. 
 - Raise `FutureWarning` in `CVSplit` when `random_state` is not used. Will raise an exception in a future (#620)
 - The behavior of method `net.get_params` changed to make it more consistent with sklearn: it will no longer return "learned" attributes like `module_`; therefore, functions like `sklearn.base.clone`, when called with a fitted net, will no longer return a fitted net but instead an uninitialized net; if you want a copy of a fitted net, use `copy.deepcopy` instead;`net.get_params` is used under the hood by many sklearn functions and classes, such as `GridSearchCV`, whose behavior may thus be affected by the change. (#521, #527)
-- Raise `FutureWarning` when using `CyclicLR` scheduler, because the default behavior has changed from taking a step every batch to taking a step every epoch.
+- Raise `FutureWarning` when using `CyclicLR` scheduler, because the default behavior has changed from taking a step every batch to taking a step every epoch. (#626)
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added the `event_name` argument for `LRScheduler` for optional recording of LR changes inside `net.history`. NOTE: Supported only in Pytorch>=1.4
+- Added the `step_every` argument for `LRScheduler` to set whether the scheduler step should be taken on every epoch or on every batch.
 
 ### Changed
 
 - Removed support for schedulers with a `batch_step()` method in `LRScheduler`. 
 - Raise `FutureWarning` in `CVSplit` when `random_state` is not used. Will raise an exception in a future (#620)
+- Raise `FutureWarning` when using `CyclicLR` scheduler, because the default behavior has changed from taking a step every batch to taking a step every epoch.
 
 ### Fixed
 

--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -162,7 +162,7 @@ class LRScheduler(Callback):
                     score = -np.inf
                 elif self.lr_scheduler_.mode == 'min':
                     score = np.inf
-                elif epoch:
+                else:
                     score = net.history[-1, self.monitor]
 
             self.lr_scheduler_.step(score, epoch)

--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -116,8 +116,8 @@ class LRScheduler(Callback):
         self.lr_scheduler_ = None
         self.batch_idx_ = 0
         # TODO: Remove this warning on 0.10 release
-        if self.policy_ == TorchCyclicLR or self.policy_ == "TorchCyclicLR" \
-                and self.step_every == 'epoch':
+        if (self.policy_ == TorchCyclicLR or self.policy_ == "TorchCyclicLR"
+                and self.step_every == 'epoch'):
             warnings.warn(
                 "The LRScheduler now makes a step every epoch by default. "
                 "To have the cyclic lr scheduler update "

--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -3,6 +3,8 @@
 import sys
 
 # pylint: disable=unused-import
+import warnings
+
 import numpy as np
 import torch
 from torch.optim.lr_scheduler import _LRScheduler
@@ -57,9 +59,9 @@ class LRScheduler(Callback):
       Pass ``None`` to disable placing events in history.
       **Note:** This feature works only for pytorch version >=1.4
 
-    step_every: str, (default='epoch'_
-      Value for when to apply the learning scheduler step. Can be either 'batch' or
-      'epoch'.
+    step_every: str, (default='epoch')
+      Value for when to apply the learning scheduler step. Can be either 'batch'
+       or 'epoch'.
 
     kwargs
       Additional arguments passed to the lr scheduler.
@@ -77,6 +79,14 @@ class LRScheduler(Callback):
         self.event_name = event_name
         self.step_every = step_every
         vars(self).update(kwargs)
+        if policy == TorchCyclicLR or policy == "TorchCyclicLR":
+            warnings.warn(
+                "The LRScheduler callback makes a step "
+                "every epoch by default from now on. To have the cyclic lr "
+                "scheduler update every batch, "
+                "set step_every='batch'",
+                DeprecationWarning,
+            )
 
     def simulate(self, steps, initial_lr):
         """

--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -79,14 +79,6 @@ class LRScheduler(Callback):
         self.event_name = event_name
         self.step_every = step_every
         vars(self).update(kwargs)
-        if policy == TorchCyclicLR or policy == "TorchCyclicLR":
-            warnings.warn(
-                "The LRScheduler callback makes a step "
-                "every epoch by default from now on. To have the cyclic lr "
-                "scheduler update every batch, "
-                "set step_every='batch'",
-                DeprecationWarning,
-            )
 
     def simulate(self, steps, initial_lr):
         """
@@ -123,6 +115,15 @@ class LRScheduler(Callback):
         self.policy_ = self._get_policy_cls()
         self.lr_scheduler_ = None
         self.batch_idx_ = 0
+        # TODO: Remove this warning on 0.10 release
+        if self.policy_ == TorchCyclicLR or self.policy_ == "TorchCyclicLR":
+            warnings.warn(
+                "The LRScheduler now makes a step every epoch by default. "
+                "To have the cyclic lr scheduler update "
+                "every batch set step_every='batch'",
+                FutureWarning
+            )
+
         return self
 
     def _get_policy_cls(self):

--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -116,7 +116,8 @@ class LRScheduler(Callback):
         self.lr_scheduler_ = None
         self.batch_idx_ = 0
         # TODO: Remove this warning on 0.10 release
-        if self.policy_ == TorchCyclicLR or self.policy_ == "TorchCyclicLR":
+        if self.policy_ == TorchCyclicLR or self.policy_ == "TorchCyclicLR" \
+                and self.step_every == 'epoch':
             warnings.warn(
                 "The LRScheduler now makes a step every epoch by default. "
                 "To have the cyclic lr scheduler update "

--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -143,7 +143,7 @@ class LRScheduler(Callback):
     def on_epoch_end(self, net, **kwargs):
         if not self.step_every == 'epoch':
             return
-        epoch = len(net.history) - 1
+        epoch = len(net.history)
         if isinstance(self.lr_scheduler_, ReduceLROnPlateau):
             if callable(self.monitor):
                 score = self.monitor(net)
@@ -161,7 +161,7 @@ class LRScheduler(Callback):
             if self.event_name is not None and hasattr(
                     self.lr_scheduler_, "get_last_lr"):
                 net.history.record(self.event_name, self.lr_scheduler_.get_last_lr()[0])
-            self.lr_scheduler_.step()
+            self.lr_scheduler_.step(epoch)
 
     def on_batch_end(self, net, training, **kwargs):
         if not training or not self.step_every == 'batch':

--- a/skorch/tests/callbacks/test_lr_scheduler.py
+++ b/skorch/tests/callbacks/test_lr_scheduler.py
@@ -94,7 +94,7 @@ class TestLRCallbacks:
         )
         net.fit(X, y)
         # pylint: disable=protected-access
-        assert lr_policy.lr_scheduler_.last_epoch == max_epochs - 1
+        assert lr_policy.lr_scheduler_.last_epoch == max_epochs
 
     @pytest.mark.parametrize('policy, kwargs', [
         (TorchCyclicLR, {'base_lr': 1e-3, 'max_lr': 6e-3, 'step_every': 'batch'}),

--- a/skorch/tests/callbacks/test_lr_scheduler.py
+++ b/skorch/tests/callbacks/test_lr_scheduler.py
@@ -32,7 +32,7 @@ class TestLRCallbacks:
     @pytest.mark.parametrize('policy', [TorchCyclicLR])
     def test_simulate_lrs_batch_step(self, policy):
         lr_sch = LRScheduler(
-            policy, base_lr=1, max_lr=5, step_size_up=4)
+            policy, base_lr=1, max_lr=5, step_size_up=4, step_every='batch')
         lrs = lr_sch.simulate(11, 1)
         expected = np.array([1, 2, 3, 4, 5, 4, 3, 2, 1, 2, 3])
         assert np.allclose(expected, lrs)
@@ -97,7 +97,7 @@ class TestLRCallbacks:
         assert lr_policy.lr_scheduler_.last_epoch == max_epochs - 1
 
     @pytest.mark.parametrize('policy, kwargs', [
-        (TorchCyclicLR, {'base_lr': 1e-3, 'max_lr': 6e-3}),
+        (TorchCyclicLR, {'base_lr': 1e-3, 'max_lr': 6e-3, 'step_every': 'batch'}),
     ])
     def test_lr_callback_batch_steps_correctly(
             self,
@@ -126,7 +126,7 @@ class TestLRCallbacks:
         assert lr_policy.batch_idx_ == expected
 
     @pytest.mark.parametrize('policy, kwargs', [
-        (TorchCyclicLR, {'base_lr': 1e-3, 'max_lr': 6e-3}),
+        (TorchCyclicLR, {'base_lr': 1e-3, 'max_lr': 6e-3, 'step_every': 'batch'}),
     ])
     def test_lr_callback_batch_steps_correctly_fallback(
             self,
@@ -177,7 +177,8 @@ class TestLRCallbacks:
         clone(scheduler)  # does not raise
 
     def test_lr_scheduler_set_params(self, classifier_module, classifier_data):
-        scheduler = LRScheduler(TorchCyclicLR, base_lr=123, max_lr=999)
+        scheduler = LRScheduler(
+            TorchCyclicLR, base_lr=123, max_lr=999, step_every='batch')
         net = NeuralNetClassifier(
             classifier_module,
             max_epochs=0,
@@ -205,7 +206,7 @@ class TestLRCallbacks:
         net = NeuralNetClassifier(
             classifier_module,
             max_epochs=epochs,
-            lr=123,
+            lr=123.,
             callbacks=[('scheduler', scheduler)]
         )
         net.fit(*classifier_data)
@@ -219,7 +220,13 @@ class TestLRCallbacks:
         X, y = classifier_data
         batch_size = 128
 
-        scheduler = LRScheduler(TorchCyclicLR, base_lr=1, max_lr=5, step_size_up=4)
+        scheduler = LRScheduler(
+            TorchCyclicLR,
+            base_lr=1,
+            max_lr=5,
+            step_size_up=4,
+            step_every='batch'
+        )
         net = NeuralNetClassifier(
             classifier_module,
             max_epochs=1,

--- a/skorch/tests/callbacks/test_lr_scheduler.py
+++ b/skorch/tests/callbacks/test_lr_scheduler.py
@@ -241,6 +241,32 @@ class TestLRCallbacks:
         )
         assert np.all(net.history[-1, 'batches', :, 'event_lr'] == new_lrs)
 
+    @pytest.mark.parametrize('policy, kwargs', [
+        (TorchCyclicLR, {'base_lr': 123, 'max_lr': 999})
+    ])
+    def test_cyclic_lr_with_epoch_step_warning(self,
+                                               classifier_module,
+                                               classifier_data,
+                                               policy,
+                                               kwargs):
+        with pytest.warns(None) as record:
+            scheduler = LRScheduler(
+                policy, **kwargs)
+            net = NeuralNetClassifier(
+                classifier_module,
+                max_epochs=0,
+                callbacks=[('scheduler', scheduler)],
+            )
+            net.initialize()
+        assert len(record) == 1
+        warning = record[0].message
+        assert isinstance(warning, FutureWarning)
+        assert warning.args[0] == (
+            "The LRScheduler now makes a step every epoch by default. "
+            "To have the cyclic lr scheduler update "
+            "every batch set step_every='batch'"
+        )
+
 
 class TestReduceLROnPlateau:
 

--- a/skorch/tests/callbacks/test_lr_scheduler.py
+++ b/skorch/tests/callbacks/test_lr_scheduler.py
@@ -241,17 +241,15 @@ class TestLRCallbacks:
         )
         assert np.all(net.history[-1, 'batches', :, 'event_lr'] == new_lrs)
 
-    @pytest.mark.parametrize('policy, kwargs', [
-        (TorchCyclicLR, {'base_lr': 123, 'max_lr': 999})
-    ])
     def test_cyclic_lr_with_epoch_step_warning(self,
                                                classifier_module,
-                                               classifier_data,
-                                               policy,
-                                               kwargs):
-        with pytest.warns(None) as record:
+                                               classifier_data):
+        msg = ("The LRScheduler now makes a step every epoch by default. "
+               "To have the cyclic lr scheduler update "
+               "every batch set step_every='batch'")
+        with pytest.warns(FutureWarning, match=msg) as record:
             scheduler = LRScheduler(
-                policy, **kwargs)
+                TorchCyclicLR, base_lr=123, max_lr=999)
             net = NeuralNetClassifier(
                 classifier_module,
                 max_epochs=0,
@@ -259,13 +257,6 @@ class TestLRCallbacks:
             )
             net.initialize()
         assert len(record) == 1
-        warning = record[0].message
-        assert isinstance(warning, FutureWarning)
-        assert warning.args[0] == (
-            "The LRScheduler now makes a step every epoch by default. "
-            "To have the cyclic lr scheduler update "
-            "every batch set step_every='batch'"
-        )
 
 
 class TestReduceLROnPlateau:


### PR DESCRIPTION
Closes #610 

I could use some assistance with schedulers that update once an epoch:

`optim._LRScheduler` initializes with `self.last_epoch=0`. This means that if we're training for `0,1,2,3,4` epochs, the respective values for `last_epoch` at the end of every epoch (where we update LR) will be `1,2,3,4,5`. This requires changes I made in the tests:

`assert lr_policy.lr_scheduler_.last_epoch == max_epochs-1` => `assert lr_policy.lr_scheduler_.last_epoch == max_epochs`

The reason this seems to have worked until now is in fact because of what I think is a bug:

It seems like until now, inside `on_epoch_end`, `epoch=len(net.history)-1=>epoch=0`. This means  that when `self.lr_scheduler_.step(epoch)` is called for the first time, the scheduler does not actually take a step because `self.last_step==epoch==0`, and `last_epoch` would stay at 0 for one extra epoch, which is why the test above passes (the one with `max_epochs - 1`).

I changed this code so that `epoch=len(history)` so the step would make sense, and replaced the order of `history.record` with `lr_scheduler_.step` so that from now on `history.record` will record **the LR with which the step was performed rather than the LR with which the next step will be performed** (which was this way until now).

Finally, I feel like as far as I can tell, all is in order. Except for `ReduceLROnPlateau`, which I'm struggling to understand how it works in general, and how the unique code for it inside `on_epoch_end` works.

Thanks!