### PR TITLE
Call zero grad on each train step

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a bug where `CyclicLR` scheduler would update during both training and validation rather than just during training.
+- Fixed a bug introduced by moving the `optimizer.zero_grad()` call outside of the train step function, making it incompatible with LBFGS and other optimizers that call the train step several times per batch (#636)
 
 ## [0.8.0] - 2019-04-11
 

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -652,12 +652,14 @@ class NeuralNet:
 
         """
         step_accumulator = self.get_train_step_accumulator()
+
         def step_fn():
+            self.optimizer_.zero_grad()
             step = self.train_step_single(Xi, yi, **fit_params)
             step_accumulator.store_step(step)
             return step['loss']
+
         self.optimizer_.step(step_fn)
-        self.optimizer_.zero_grad()
         return step_accumulator.get_step()
 
     def evaluation_step(self, Xi, training=False):

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2138,13 +2138,21 @@ class TestNeuralNet:
         assert net.history[:, "train_batch_count"] == [train_batch_count]
         assert net.history[:, "valid_batch_count"] == [valid_batch_count]
 
+    @flaky(max_runs=3)
     def test_fit_lbfgs_optimizer(self, net_cls, module_cls, data):
         X, y = data
         net = net_cls(
             module_cls,
             optimizer=torch.optim.LBFGS,
-            batch_size=len(X))
+            lr=1.0,
+            batch_size=-1,
+        )
         net.fit(X, y)
+
+        last_epoch = net.history[-1]
+        assert last_epoch['train_loss'] < 1.0
+        assert last_epoch['valid_loss'] < 1.0
+        assert last_epoch['valid_acc'] > 0.75
 
     def test_accumulator_that_returns_last_value(
             self, net_cls, module_cls, data):


### PR DESCRIPTION
This fixes a bug introduced by moving the `optimizer.zero_grad()` call
outside of the train step function, making it incompatible with LBFGS
and other optimizers that call the train step several times per
batch and expect the gradient to be reset after each call.

I extended the existing test for LBFGS to actually check the
training and validation scores after the fit call. With the
faulty behavior, the scores are actually diverging, and with the
bugfix, we get reasonable scores.

In #636, I wrote

> So we could introduce a parameter like perform_zero_grad_each_step=True or so (not a very nice name) and if a user wants to do their custom stuff with gradients, they need to turn it off.

After some thinking, I believe it's not actually necessary to
introduce an argument to turn off the `zero_grad` call during
each train step. The reason is that if a user wants to do some
custom stuff like gradient accumulation, they'll have to override
`train_step` anyway, which means they'll control how exactly
`zero_grad` will be called.