### PR TITLE
Raise a FutureWarning if Python version is < 3.6

### DIFF
--- a/skorch/__init__.py
+++ b/skorch/__init__.py
@@ -1,5 +1,8 @@
 """skorch base imports"""
 
+import sys
+import warnings
+
 import pkg_resources
 from pkg_resources import parse_version
 
@@ -12,6 +15,15 @@ from . import callbacks
 
 
 MIN_TORCH_VERSION = '1.1.0'
+
+
+# TODO: remove in skorch 0.10.0
+if sys.version_info < (3, 6):
+    warnings.warn(
+        "Official support for Python 3.5 will be dropped starting from "
+        "skorch version 0.10.0",
+        FutureWarning,
+    )
 
 try:
     # pylint: disable=wrong-import-position

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -6,10 +6,10 @@ Should not have any dependency on other skorch packages.
 
 from collections.abc import Sequence
 from contextlib import contextmanager
+from distutils.version import LooseVersion
 from enum import Enum
 from functools import partial
 from itertools import tee
-from distutils.version import LooseVersion
 import pathlib
 import warnings
 


### PR DESCRIPTION
In skorch 0.10.0, this Python version will no longer be officially supported.

Also, use correct import order in utils.py.