### PR TITLE
Feature save params arbitrary modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the `event_name` argument for `LRScheduler` for optional recording of LR changes inside `net.history`. NOTE: Supported only in Pytorch>=1.4
 - Make it easier to add custom modules or optimizers to a neural net class by automatically registering them where necessary and by making them available to set_params
 - Added the `step_every` argument for `LRScheduler` to set whether the scheduler step should be taken on every epoch or on every batch.
+- Added the possibility to save the criterion with `save_params` and with checkpoint callbacks
+- Added the possibility to save custom modules with `save_params` and with checkpoint callbacks
 
 ### Changed
 

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -11,6 +11,7 @@ from itertools import product
 import numpy as np
 from skorch.callbacks import Callback
 from skorch.exceptions import SkorchException
+from skorch.utils import _check_f_arguments
 from skorch.utils import noop
 from skorch.utils import open_file_like
 from skorch.utils import freeze_parameter
@@ -23,8 +24,6 @@ __all__ = ['Checkpoint', 'EarlyStopping', 'ParamMapper', 'Freezer',
 
 class Checkpoint(Callback):
     """Save the model during training if the given metric improved.
-
-    TODO: ADJUST
 
     This callback works by default in conjunction with the validation
     scoring callback since it creates a ``valid_loss_best`` value
@@ -39,8 +38,12 @@ class Checkpoint(Callback):
 
       - model parameters (see ``f_params`` parameter);
       - optimizer state (see ``f_optimizer`` parameter);
+      - criterion state (see ``f_criterion`` parameter);
       - training history (see ``f_history`` parameter);
       - entire model object (see ``f_pickle`` parameter).
+
+    If you've created a custom module, e.g. ``net.mymodule_``, you
+    can save that as well by passing ``f_mymodule``.
 
     You can implement your own save protocol by subclassing
     ``Checkpoint`` and overriding :func:`~Checkpoint.save_model`.
@@ -89,6 +92,13 @@ class Checkpoint(Callback):
 
     f_optimizer : file-like object, str, None (default='optimizer.pt')
       File path to the file or file-like object where the optimizer
+      state should be saved. Pass ``None`` to disable saving
+      model parameters.
+
+      Supports the same format specifiers as ``f_params``.
+
+    f_criterion : file-like object, str, None (default='criterion.pt')
+      File path to the file or file-like object where the criterion
       state should be saved. Pass ``None`` to disable saving
       model parameters.
 
@@ -147,8 +157,16 @@ class Checkpoint(Callback):
         self.dirname = dirname
         self.event_name = event_name
         self.sink = sink
-        vars(self).update(_validate_f_arguments(self, kwargs))
+        self._check_kwargs(kwargs)
+        vars(self).update(**kwargs)
         self._validate_filenames()
+
+    def _check_kwargs(self, kwargs):
+        for key in kwargs:
+            if not key.startswith('f_'):
+                raise TypeError(
+                    "{cls_name} got an unexpected argument '{key}', did you mean "
+                    "'f_{key}'?".format(cls_name=self.__class__.__name__, key=key))
 
     def initialize(self):
         self._validate_filenames()
@@ -185,6 +203,10 @@ class Checkpoint(Callback):
                 len(net.history) + 1
             ), net.verbose)
 
+    def _f_kwargs(self):
+        return {key: getattr(self, key) for key in dir(self)
+                if key.startswith('f_') and (key != 'f_history_')}
+
     def save_model(self, net):
         """Save the model.
 
@@ -192,23 +214,31 @@ class Checkpoint(Callback):
 
           - model parameters;
           - optimizer state;
+          - criterion state;
           - training history;
+          - custom modules;
           - entire model object.
+
         """
-        if self.f_params is not None:
-            f = self._format_target(net, self.f_params, -1)
-            self._save_params(f, net, "f_params", "model parameters")
+        kwargs_module, kwargs_other = _check_f_arguments(
+            self.__class__.__name__, **self._f_kwargs())
 
-        if self.f_optimizer is not None:
-            f = self._format_target(net, self.f_optimizer, -1)
-            self._save_params(f, net, "f_optimizer", "optimizer state")
+        for key, val in kwargs_module.items():
+            if val is None:
+                continue
 
-        if self.f_history is not None:
+            f = self._format_target(net, val, -1)
+            key = key[:-1]  # remove trailing '_'
+            self._save_params(f, net, 'f_' + key, key + " state")
+
+        f_history = kwargs_other.get('f_history')
+        if f_history is not None:
             f = self.f_history_
             self._save_params(f, net, "f_history", "history")
 
-        if self.f_pickle:
-            f_pickle = self._format_target(net, self.f_pickle, -1)
+        f_pickle = kwargs_other.get('f_pickle')
+        if f_pickle:
+            f_pickle = self._format_target(net, f_pickle, -1)
             with open_file_like(f_pickle, 'wb') as f:
                 pickle.dump(net, f)
 
@@ -232,12 +262,9 @@ class Checkpoint(Callback):
             for i, v in enumerate(net.history[:, self.event_name]):
                 if v:
                     idx = i
-        return {
-            "f_params": self._format_target(net, self.f_params, idx),
-            "f_optimizer": self._format_target(net, self.f_optimizer, idx),
-            "f_history": self.f_history_,
-            "f_pickle": self._format_target(net, self.f_pickle, idx)
-        }
+
+        return {key: self._format_target(net, val, idx) for key, val
+                in self._f_kwargs().items()}
 
     def _save_params(self, f, net, f_name, log_name):
         try:
@@ -267,18 +294,15 @@ class Checkpoint(Callback):
         conjunction with dirname.
 
         """
+        _check_f_arguments(self.__class__.__name__, **self._f_kwargs())
+
         if not self.dirname:
             return
 
         def _is_truthy_and_not_str(f):
             return f and not isinstance(f, str)
 
-        if (
-                _is_truthy_and_not_str(self.f_optimizer) or
-                _is_truthy_and_not_str(self.f_params) or
-                _is_truthy_and_not_str(self.f_history) or
-                _is_truthy_and_not_str(self.f_pickle)
-        ):
+        if any(_is_truthy_and_not_str(val) for val in self._f_kwargs().values()):
             raise SkorchException(
                 'dirname can only be used when f_* are strings')
 
@@ -603,8 +627,6 @@ class TrainEndCheckpoint(Callback):
     """Saves the model parameters, optimizer state, and history at the end of
     training. The default ``fn_prefix`` is 'train_end_'.
 
-    TODO: ADJUST
-
     Examples
     --------
 
@@ -641,6 +663,13 @@ class TrainEndCheckpoint(Callback):
 
       Supports the same format specifiers as ``f_params``.
 
+    f_criterion : file-like object, str, None (default='criterion.pt')
+      File path to the file or file-like object where the criterion
+      state should be saved. Pass ``None`` to disable saving
+      model parameters.
+
+      Supports the same format specifiers as ``f_params``.
+
     f_history : file-like object, str, None (default='history.json')
       File path to the file or file-like object where the model
       training history should be saved. Pass ``None`` to disable
@@ -664,6 +693,7 @@ class TrainEndCheckpoint(Callback):
       The target that the information about created checkpoints is
       sent to. This can be a logger or ``print`` function (to send to
       stdout). By default the output is discarded.
+
     """
     def __init__(
             self,
@@ -685,10 +715,12 @@ class TrainEndCheckpoint(Callback):
         self.fn_prefix = fn_prefix
         self.dirname = dirname
         self.sink = sink
-        vars(self).update(_validate_f_arguments(self, kwargs))
+        Checkpoint._check_kwargs(self, kwargs)
+        vars(self).update(**kwargs)
 
-    def f_kwargs(self):
-        return {name: getattr(self, name) for name in dir(self) if name.startswith('f_')}
+    def _f_kwargs(self):
+        return {name: getattr(self, name) for name in dir(self)
+                if name.startswith('f_')}
 
     def initialize(self):
         self.checkpoint_ = Checkpoint(
@@ -697,7 +729,7 @@ class TrainEndCheckpoint(Callback):
             dirname=self.dirname,
             event_name=None,
             sink=self.sink,
-            **self.f_kwargs()
+            **self._f_kwargs()
         )
         self.checkpoint_.initialize()
 

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -24,6 +24,8 @@ __all__ = ['Checkpoint', 'EarlyStopping', 'ParamMapper', 'Freezer',
 class Checkpoint(Callback):
     """Save the model during training if the given metric improved.
 
+    TODO: ADJUST
+
     This callback works by default in conjunction with the validation
     scoring callback since it creates a ``valid_loss_best`` value
     in the history which the callback uses to determine if this
@@ -126,22 +128,26 @@ class Checkpoint(Callback):
             monitor='valid_loss_best',
             f_params='params.pt',
             f_optimizer='optimizer.pt',
+            f_criterion='criterion.pt',
             f_history='history.json',
             f_pickle=None,
             fn_prefix='',
             dirname='',
             event_name='event_cp',
             sink=noop,
+            **kwargs
     ):
         self.monitor = monitor
         self.f_params = f_params
         self.f_optimizer = f_optimizer
+        self.f_criterion = f_criterion
         self.f_history = f_history
         self.f_pickle = f_pickle
         self.fn_prefix = fn_prefix
         self.dirname = dirname
         self.event_name = event_name
         self.sink = sink
+        vars(self).update(_validate_f_arguments(self, kwargs))
         self._validate_filenames()
 
     def initialize(self):
@@ -597,6 +603,8 @@ class TrainEndCheckpoint(Callback):
     """Saves the model parameters, optimizer state, and history at the end of
     training. The default ``fn_prefix`` is 'train_end_'.
 
+    TODO: ADJUST
+
     Examples
     --------
 
@@ -661,31 +669,36 @@ class TrainEndCheckpoint(Callback):
             self,
             f_params='params.pt',
             f_optimizer='optimizer.pt',
+            f_criterion='criterion.pt',
             f_history='history.json',
             f_pickle=None,
             fn_prefix='train_end_',
             dirname='',
             sink=noop,
+            **kwargs
     ):
         self.f_params = f_params
         self.f_optimizer = f_optimizer
+        self.f_criterion = f_criterion
         self.f_history = f_history
         self.f_pickle = f_pickle
         self.fn_prefix = fn_prefix
         self.dirname = dirname
         self.sink = sink
+        vars(self).update(_validate_f_arguments(self, kwargs))
+
+    def f_kwargs(self):
+        return {name: getattr(self, name) for name in dir(self) if name.startswith('f_')}
 
     def initialize(self):
         self.checkpoint_ = Checkpoint(
             monitor=None,
-            f_params=self.f_params,
-            f_optimizer=self.f_optimizer,
-            f_history=self.f_history,
-            f_pickle=self.f_pickle,
             fn_prefix=self.fn_prefix,
             dirname=self.dirname,
             event_name=None,
-            sink=self.sink)
+            sink=self.sink,
+            **self.f_kwargs()
+        )
         self.checkpoint_.initialize()
 
     def on_train_end(self, net, **kwargs):

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1717,7 +1717,12 @@ class NeuralNet:
         super().__delattr__(name)
 
     def save_params(
-            self, f_params=None, f_optimizer=None, f_history=None):
+            self,
+            f_params=None,
+            f_optimizer=None,
+            f_criterion=None,
+            f_history=None,
+            **kwargs):
         """Saves the module's parameters, history, and optimizer,
         not the whole object.
 
@@ -1728,6 +1733,8 @@ class NeuralNet:
 
         ``f_params`` and ``f_optimizer`` uses PyTorchs'
         :func:`~torch.save`.
+
+        TODO: ADJUST
 
         Parameters
         ----------
@@ -1744,12 +1751,12 @@ class NeuralNet:
         --------
         >>> before = NeuralNetClassifier(mymodule)
         >>> before.save_params(f_params='model.pkl',
-        >>>                    f_optimizer='optimizer.pkl',
-        >>>                    f_history='history.json')
+        ...                    f_optimizer='optimizer.pkl',
+        ...                    f_history='history.json')
         >>> after = NeuralNetClassifier(mymodule).initialize()
         >>> after.load_params(f_params='model.pkl',
-        >>>                   f_optimizer='optimizer.pkl',
-        >>>                   f_history='history.json')
+        ...                   f_optimizer='optimizer.pkl',
+        ...                   f_history='history.json')
 
         """
         if f_params is not None:
@@ -1789,10 +1796,17 @@ class NeuralNet:
         return requested_device
 
     def load_params(
-            self, f_params=None, f_optimizer=None, f_history=None,
-            checkpoint=None):
+            self,
+            f_params=None,
+            f_optimizer=None,
+            f_criterion=None,
+            f_history=None,
+            checkpoint=None,
+            **kwargs):
         """Loads the the module's parameters, history, and optimizer,
         not the whole object.
+
+        TODO: ADJUST
 
         To save and load the whole object, use pickle.
 

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1718,12 +1718,12 @@ class NeuralNet:
         super().__delattr__(name)
 
     def _get_module(self, name, msg):
-        """Return the PyTorch module attribute with the given name
+        """Return the PyTorch module with the given name
 
         If a module with such a name doesn't exist, also check the
         name without trailing underscore.
 
-        raises
+        Raises
         ------
         AttributeError
           If no module with the given name could be found, with a
@@ -1755,7 +1755,7 @@ class NeuralNet:
         ``classes_`` attribute on
         :class:`skorch.classifier.NeuralNetClassifier`.
 
-        ``f_params``, ``f_optimizer``, etc. use PyTorchs'
+        ``f_params``, ``f_optimizer``, etc. use PyTorch's
         :func:`~torch.save`.
 
         If you've created a custom module, e.g. ``net.mymodule_``, you
@@ -1850,7 +1850,7 @@ class NeuralNet:
 
         To save and load the whole object, use pickle.
 
-        ``f_params``, ``f_optimizer``, etc. uses PyTorchs'
+        ``f_params``, ``f_optimizer``, etc. uses PyTorch's
         :func:`~torch.load`.
 
         If you've created a custom module, e.g. ``net.mymodule_``, you
@@ -1907,11 +1907,9 @@ class NeuralNet:
             if val:
                 kwargs_full[key] = val
 
-        kwargs_module, kwargs_other = _check_f_arguments(
-            'load_params',
-            **kwargs_full)
+        kwargs_module, kwargs_other = _check_f_arguments('load_params', **kwargs_full)
 
-        if not kwargs_module and not kwargs_other and not checkpoint:
+        if not kwargs_module and not kwargs_other:
             print("Nothing to load")
             return
 

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -24,6 +24,7 @@ from skorch.history import History
 from skorch.setter import optimizer_setter
 from skorch.utils import FirstStepAccumulator
 from skorch.utils import TeeGenerator
+from skorch.utils import _check_f_arguments
 from skorch.utils import check_is_fitted
 from skorch.utils import duplicate_items
 from skorch.utils import get_map_location
@@ -1716,6 +1717,29 @@ class NeuralNet:
         self._unregister_attribute(name)
         super().__delattr__(name)
 
+    def _get_module(self, name, msg):
+        """Return the PyTorch module attribute with the given name
+
+        If a module with such a name doesn't exist, also check the
+        name without trailing underscore.
+
+        raises
+        ------
+        AttributeError
+          If no module with the given name could be found, with a
+          message formatted according to the passed ``msg`` argument.
+
+        """
+        try:
+            module = getattr(self, name)
+            if not hasattr(module, 'state_dict'):
+                raise AttributeError
+            return module
+        except AttributeError:
+            if name.endswith('_'):
+                name = name[:-1]
+            raise AttributeError(msg.format(name=name))
+
     def save_params(
             self,
             f_params=None,
@@ -1731,10 +1755,11 @@ class NeuralNet:
         ``classes_`` attribute on
         :class:`skorch.classifier.NeuralNetClassifier`.
 
-        ``f_params`` and ``f_optimizer`` uses PyTorchs'
+        ``f_params``, ``f_optimizer``, etc. use PyTorchs'
         :func:`~torch.save`.
 
-        TODO: ADJUST
+        If you've created a custom module, e.g. ``net.mymodule_``, you
+        can save that as well by passing ``f_mymodule``.
 
         Parameters
         ----------
@@ -1743,6 +1768,9 @@ class NeuralNet:
 
         f_optimizer : file-like object, str, None (default=None)
           Path of optimizer. Pass ``None`` to not save
+
+        f_criterion : file-like object, str, None (default=None)
+          Path of criterion. Pass ``None`` to not save
 
         f_history : file-like object, str, None (default=None)
           Path to history. Pass ``None`` to not save
@@ -1759,22 +1787,36 @@ class NeuralNet:
         ...                   f_history='history.json')
 
         """
-        if f_params is not None:
-            msg = (
-                "Cannot save parameters of an un-initialized model. "
-                "Please initialize first by calling .initialize() "
-                "or by fitting the model with .fit(...).")
-            self.check_is_fitted(msg=msg)
-            torch.save(self.module_.state_dict(), f_params)
+        kwargs_module, kwargs_other = _check_f_arguments(
+            'save_params',
+            f_params=f_params,
+            f_optimizer=f_optimizer,
+            f_criterion=f_criterion,
+            f_history=f_history,
+            **kwargs)
 
-        if f_optimizer is not None:
-            msg = (
-                "Cannot save state of an un-initialized optimizer. "
-                "Please initialize first by calling .initialize() "
-                "or by fitting the model with .fit(...).")
-            self.check_is_fitted(attributes=['optimizer_'], msg=msg)
-            torch.save(self.optimizer_.state_dict(), f_optimizer)
+        if not kwargs_module and not kwargs_other:
+            print("Nothing to save")
+            return
 
+        msg_init = (
+            "Cannot save state of an un-initialized model. "
+            "Please initialize first by calling .initialize() "
+            "or by fitting the model with .fit(...).")
+        msg_module = (
+            "You are trying to save 'f_{name}' but for that to work, the net "
+            "needs to have an attribute called 'net.{name}_' that is a PyTorch "
+            "Module; make sure that it exists and check for typos.")
+
+        for attr, f_name in kwargs_module.items():
+            # valid attrs can be 'module_', 'optimizer_', etc.
+            if attr[:-1] in self.prefixes_:
+                self.check_is_fitted([attr], msg=msg_init)
+            module = self._get_module(attr, msg=msg_module)
+            torch.save(module.state_dict(), f_name)
+
+        # only valid key in kwargs_other is f_history
+        f_history = kwargs_other.get('f_history')
         if f_history is not None:
             self.history.to_file(f_history)
 
@@ -1806,12 +1848,13 @@ class NeuralNet:
         """Loads the the module's parameters, history, and optimizer,
         not the whole object.
 
-        TODO: ADJUST
-
         To save and load the whole object, use pickle.
 
-        ``f_params`` and ``f_optimizer`` uses PyTorchs'
-        :func:`~torch.save`.
+        ``f_params``, ``f_optimizer``, etc. uses PyTorchs'
+        :func:`~torch.load`.
+
+        If you've created a custom module, e.g. ``net.mymodule_``, you
+        can save that as well by passing ``f_mymodule``.
 
         Parameters
         ----------
@@ -1820,6 +1863,9 @@ class NeuralNet:
 
         f_optimizer : file-like object, str, None (default=None)
           Path of optimizer. Pass ``None`` to not load.
+
+        f_criterion : file-like object, str, None (default=None)
+          Path of criterion. Pass ``None`` to not save
 
         f_history : file-like object, str, None (default=None)
           Path to history. Pass ``None`` to not load.
@@ -1846,35 +1892,50 @@ class NeuralNet:
             self.device = self._check_device(self.device, map_location)
             return torch.load(f, map_location=map_location)
 
-        if f_history is not None:
-            self.history = History.from_file(f_history)
-
+        kwargs_full = {}
         if checkpoint is not None:
             if not self.initialized_:
                 self.initialize()
             if f_history is None and checkpoint.f_history is not None:
                 self.history = History.from_file(checkpoint.f_history_)
-            formatted_files = checkpoint.get_formatted_files(self)
-            f_params = f_params or formatted_files['f_params']
-            f_optimizer = f_optimizer or formatted_files['f_optimizer']
+            kwargs_full.update(**checkpoint.get_formatted_files(self))
 
-        if f_params is not None:
-            msg = (
-                "Cannot load parameters of an un-initialized model. "
-                "Please initialize first by calling .initialize() "
-                "or by fitting the model with .fit(...).")
-            self.check_is_fitted(msg=msg)
-            state_dict = _get_state_dict(f_params)
-            self.module_.load_state_dict(state_dict)
+        # explicit arguments may override checkpoint arguments
+        kwargs_full.update(**kwargs)
+        for key, val in [('f_params', f_params), ('f_optimizer', f_optimizer),
+                         ('f_criterion', f_criterion), ('f_history', f_history)]:
+            if val:
+                kwargs_full[key] = val
 
-        if f_optimizer is not None:
-            msg = (
-                "Cannot load state of an un-initialized optimizer. "
-                "Please initialize first by calling .initialize() "
-                "or by fitting the model with .fit(...).")
-            self.check_is_fitted(attributes=['optimizer_'], msg=msg)
-            state_dict = _get_state_dict(f_optimizer)
-            self.optimizer_.load_state_dict(state_dict)
+        kwargs_module, kwargs_other = _check_f_arguments(
+            'load_params',
+            **kwargs_full)
+
+        if not kwargs_module and not kwargs_other and not checkpoint:
+            print("Nothing to load")
+            return
+
+        # only valid key in kwargs_other is f_history
+        f_history = kwargs_other.get('f_history')
+        if f_history is not None:
+            self.history = History.from_file(f_history)
+
+        msg_init = (
+            "Cannot load state of an un-initialized model. "
+            "Please initialize first by calling .initialize() "
+            "or by fitting the model with .fit(...).")
+        msg_module = (
+            "You are trying to load 'f_{name}' but for that to work, the net "
+            "needs to have an attribute called 'net.{name}_' that is a PyTorch "
+            "Module; make sure that it exists and check for typos.")
+
+        for attr, f_name in kwargs_module.items():
+            # valid attrs can be 'module_', 'optimizer_', etc.
+            if attr[:-1] in self.prefixes_:
+                self.check_is_fitted([attr], msg=msg_init)
+            module = self._get_module(attr, msg=msg_module)
+            state_dict = _get_state_dict(f_name)
+            module.load_state_dict(state_dict)
 
     def __repr__(self):
         to_include = ['module']

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -367,9 +367,9 @@ class TestCheckpoint:
     ):
         # checkpointing custom modules works
         from skorch import NeuralNetRegressor
-        from skorch.toy import make_regressor
 
         class MyNet(NeuralNetRegressor):
+            """Net with custom module"""
             def __init__(self, *args, mymodule=module_cls, **kwargs):
                 self.mymodule = mymodule
                 super().__init__(*args, **kwargs)

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -51,6 +51,17 @@ class TestCheckpoint:
         y = np.zeros((10, 1), dtype='float32')
         return X, y
 
+    def test_init_with_wrong_kwarg_name_raises(self, checkpoint_cls):
+        checkpoint_cls(f_foobar='foobar.pt').initialize()  # works
+        msg = "Checkpoint got an unexpected argument 'foobar', did you mean 'f_foobar'?"
+        with pytest.raises(TypeError, match=msg):
+            checkpoint_cls(foobar='foobar.pt').initialize()
+
+    def test_init_with_f_params_and_f_module_raises(self, checkpoint_cls):
+        msg = "Checkpoint called with both f_params and f_module, please choose one"
+        with pytest.raises(TypeError, match=msg):
+            checkpoint_cls(f_module='weights.pt', f_params='params.pt').initialize()
+
     def test_none_monitor_saves_always(
             self, save_params_mock, net_cls, checkpoint_cls, data):
         sink = Mock()
@@ -60,20 +71,43 @@ class TestCheckpoint:
         ])
         net.fit(*data)
 
-        assert save_params_mock.call_count == 3*len(net.history)
+        assert save_params_mock.call_count == 4 * len(net.history)
         assert sink.call_count == len(net.history)
         assert all((x is True) for x in net.history[:, 'event_another'])
 
     @pytest.mark.parametrize('message,files', [
-        ('Unable to save model parameters to params.pt, '
+        ('Unable to save module state to params.pt, '
          'Exception: encoding error',
-         {'f_params': 'params.pt', 'f_optimizer': None, 'f_history': None}),
+         {
+             'f_params': 'params.pt',
+             'f_optimizer': None,
+             'f_criterion': None,
+             'f_history': None,
+         }),
         ('Unable to save optimizer state to optimizer.pt, '
          'Exception: encoding error',
-         {'f_params': None, 'f_optimizer': 'optimizer.pt', 'f_history': None}),
+         {
+             'f_params': None,
+             'f_optimizer': 'optimizer.pt',
+             'f_criterion': None,
+             'f_history': None,
+         }),
+        ('Unable to save criterion state to criterion.pt, '
+         'Exception: encoding error',
+         {
+             'f_params': None,
+             'f_optimizer': None,
+             'f_criterion': 'criterion.pt',
+             'f_history': None,
+         }),
         ('Unable to save history to history.json, '
          'Exception: encoding error',
-         {'f_params': None, 'f_optimizer': None, 'f_history': 'history.json'})
+         {
+             'f_params': None,
+             'f_optimizer': None,
+             'f_criterion': None,
+             'f_history': 'history.json',
+         }),
     ])
     def test_outputs_to_sink_when_save_params_errors(
             self, save_params_mock, net_cls, checkpoint_cls, data,
@@ -93,6 +127,7 @@ class TestCheckpoint:
     @pytest.mark.parametrize('f_name, mode', [
         ('f_params', 'w'),
         ('f_optimizer', 'w'),
+        ('f_criterion', 'w'),
         ('f_history', 'w'),
         ('f_pickle', 'wb')
     ])
@@ -113,6 +148,7 @@ class TestCheckpoint:
     @pytest.mark.parametrize('f_name, mode', [
         ('f_params', 'w'),
         ('f_optimizer', 'w'),
+        ('f_criterion', 'w'),
         ('f_history', 'w'),
         ('f_pickle', 'wb')
     ])
@@ -165,26 +201,33 @@ class TestCheckpoint:
             monitor='epoch_3_scorer_best',
             f_params='model_{last_epoch[epoch]}_{net.max_epochs}.pt',
             f_optimizer='optimizer_{last_epoch[epoch]}_{net.max_epochs}.pt',
+            f_criterion='criterion_{last_epoch[epoch]}_{net.max_epochs}.pt',
             sink=sink)
         net = net_cls(callbacks=[
             ('my_score', scoring), cb
         ])
         net.fit(*data)
 
-        assert save_params_mock.call_count == 6
+        assert save_params_mock.call_count == 8
         assert cb.get_formatted_files(net) == {
             'f_params': 'model_3_10.pt',
             'f_optimizer': 'optimizer_3_10.pt',
+            'f_criterion': 'criterion_3_10.pt',
             'f_history': 'history.json',
             'f_pickle': None
         }
         save_params_mock.assert_has_calls(
-            [call(f_params='model_1_10.pt'),
-             call(f_optimizer='optimizer_1_10.pt'),
-             call(f_history='history.json'),
-             call(f_params='model_3_10.pt'),
-             call(f_optimizer='optimizer_3_10.pt'),
-             call(f_history='history.json')]
+            [
+                call(f_module='model_1_10.pt'),  # params is turned into module
+                call(f_optimizer='optimizer_1_10.pt'),
+                call(f_criterion='criterion_1_10.pt'),
+                call(f_history='history.json'),
+                call(f_module='model_3_10.pt'),  # params is turned into module
+                call(f_optimizer='optimizer_3_10.pt'),
+                call(f_criterion='criterion_3_10.pt'),
+                call(f_history='history.json'),
+            ],
+            any_order=True,
         )
         assert sink.call_count == 2
         # The first epoch will always be saved. `epoch_3_scorer` returns 1 at
@@ -197,20 +240,27 @@ class TestCheckpoint:
             net_cls, checkpoint_cls, data):
         net = net_cls(callbacks=[
             checkpoint_cls(
-                monitor=None, f_params='params.pt',
-                f_history='history.json', f_pickle='model.pkl',
-                f_optimizer='optimizer.pt'),
+                monitor=None,
+                f_params='params.pt',
+                f_pickle='model.pkl',
+                f_optimizer='optimizer.pt',
+                f_criterion='criterion.pt',
+                f_history='history.json',
+            ),
         ])
         net.fit(*data)
 
-        assert save_params_mock.call_count == 3*len(net.history)
+        assert save_params_mock.call_count == 4 * len(net.history)
         assert pickle_dump_mock.call_count == len(net.history)
 
-        print(save_params_mock.call_args_list)
         save_params_mock.assert_has_calls(
-            [call(f_params='params.pt'),
-             call(f_optimizer='optimizer.pt'),
-             call(f_history='history.json')] * len(net.history)
+            [
+                call(f_module='params.pt'),  # params is turned into module
+                call(f_optimizer='optimizer.pt'),
+                call(f_criterion='criterion.pt'),
+                call(f_history='history.json'),
+            ] * len(net.history),
+            any_order=True,
         )
 
     def test_save_all_targets_with_prefix(
@@ -220,20 +270,26 @@ class TestCheckpoint:
         cp = checkpoint_cls(
             monitor=None,
             f_params='params.pt',
-            f_history='history.json',
             f_pickle='model.pkl',
             f_optimizer='optimizer.pt',
-            fn_prefix="exp1_")
+            f_criterion='criterion.pt',
+            f_history='history.json',
+            fn_prefix="exp1_",
+        )
         net = net_cls(callbacks=[cp])
         net.fit(*data)
 
         assert cp.f_history_ == "exp1_history.json"
-        assert save_params_mock.call_count == 3*len(net.history)
+        assert save_params_mock.call_count == 4 * len(net.history)
         assert pickle_dump_mock.call_count == len(net.history)
         save_params_mock.assert_has_calls(
-            [call(f_params='exp1_params.pt'),
-             call(f_optimizer='exp1_optimizer.pt'),
-             call(f_history='exp1_history.json')] * len(net.history)
+            [
+                call(f_module='exp1_params.pt'),  # params is turned into module
+                call(f_optimizer='exp1_optimizer.pt'),
+                call(f_criterion='exp1_criterion.pt'),
+                call(f_history='exp1_history.json'),
+            ] * len(net.history),
+            any_order=True,
         )
 
     def test_save_all_targets_with_prefix_and_dirname(
@@ -248,6 +304,7 @@ class TestCheckpoint:
             f_history='history.json',
             f_pickle='model.pkl',
             f_optimizer='optimizer.pt',
+            f_criterion='criterion.pt',
             fn_prefix="unet_",
             dirname=str(skorch_dir))
         net = net_cls(callbacks=[cp])
@@ -255,15 +312,20 @@ class TestCheckpoint:
 
         f_params = skorch_dir.join('unet_params.pt')
         f_optimizer = skorch_dir.join('unet_optimizer.pt')
+        f_criterion = skorch_dir.join('unet_criterion.pt')
         f_history = skorch_dir.join('unet_history.json')
 
         assert cp.f_history_ == str(f_history)
-        assert save_params_mock.call_count == 3*len(net.history)
+        assert save_params_mock.call_count == 4 * len(net.history)
         assert pickle_dump_mock.call_count == len(net.history)
         save_params_mock.assert_has_calls(
-            [call(f_params=str(f_params)),
-             call(f_optimizer=str(f_optimizer)),
-             call(f_history=str(f_history))] * len(net.history)
+            [
+                call(f_module=str(f_params)),  # params is turned into module 
+                call(f_optimizer=str(f_optimizer)),
+                call(f_criterion=str(f_criterion)),
+                call(f_history=str(f_history)),
+            ] * len(net.history),
+            any_order=True,
         )
         assert skorch_dir.exists()
 
@@ -272,8 +334,13 @@ class TestCheckpoint:
             net_cls, checkpoint_cls, data):
         net = net_cls(callbacks=[
             checkpoint_cls(
-                monitor=None, f_params=None, f_optimizer=None,
-                f_history=None, f_pickle=None),
+                monitor=None,
+                f_params=None,
+                f_optimizer=None,
+                f_criterion=None,
+                f_history=None,
+                f_pickle=None,
+            ),
         ])
         net.fit(*data)
 
@@ -282,8 +349,8 @@ class TestCheckpoint:
 
     def test_warnings_when_monitor_appears_in_history(
             self, net_cls, checkpoint_cls, save_params_mock, data):
-        net = net_cls(callbacks=[
-            checkpoint_cls(monitor="valid_loss")],
+        net = net_cls(
+            callbacks=[checkpoint_cls(monitor="valid_loss")],
             max_epochs=1)
 
         exp_warn = (
@@ -293,7 +360,44 @@ class TestCheckpoint:
 
         with pytest.warns(UserWarning, match=exp_warn):
             net.fit(*data)
-        assert save_params_mock.call_count == 3
+        assert save_params_mock.call_count == 4
+
+    def test_save_custom_module(
+            self, save_params_mock, module_cls, checkpoint_cls, data,
+    ):
+        # checkpointing custom modules works
+        from skorch import NeuralNetRegressor
+        from skorch.toy import make_regressor
+
+        class MyNet(NeuralNetRegressor):
+            def __init__(self, *args, mymodule=module_cls, **kwargs):
+                self.mymodule = mymodule
+                super().__init__(*args, **kwargs)
+
+            def initialize_module(self, *args, **kwargs):
+                super().initialize_module(*args, **kwargs)
+
+                params = self.get_params_for('mymodule')
+                self.mymodule_ = self.mymodule(**params)
+
+                return self
+
+        cp = checkpoint_cls(
+            monitor=None,
+            f_params=None,
+            f_optimizer=None,
+            f_criterion=None,
+            f_history=None,
+            f_mymodule='mymodule.pt',
+        )
+        net = MyNet(module_cls, callbacks=[cp])
+        net.fit(*data)
+
+        assert save_params_mock.call_count == 1 * len(net.history)
+        save_params_mock.assert_has_calls(
+            [call(f_mymodule='mymodule.pt')] * len(net.history)
+        )
+
 
 
 class TestEarlyStopping:
@@ -735,12 +839,14 @@ class TestLoadInitState:
         skorch_dir = tmpdir.mkdir('skorch')
         f_params = skorch_dir.join('params.pt')
         f_optimizer = skorch_dir.join('optimizer.pt')
+        f_criterion = skorch_dir.join('criterion.pt')
         f_history = skorch_dir.join('history.json')
 
         cp = checkpoint_cls(
             monitor=None,
             f_params=str(f_params),
             f_optimizer=str(f_optimizer),
+            f_criterion=str(f_criterion),
             f_history=str(f_history)
         )
         load_init_state = loadinitstate_cls(cp)
@@ -749,6 +855,7 @@ class TestLoadInitState:
 
         assert f_params.exists()
         assert f_optimizer.exists()
+        assert f_criterion.exists()
         assert f_history.exists()
 
         assert len(net.history) == 10
@@ -774,6 +881,8 @@ class TestLoadInitState:
             'model_epoch_{last_epoch[epoch]}.pt')
         f_optimizer = skorch_dir.join(
             'optimizer_epoch_{last_epoch[epoch]}.pt')
+        f_criterion = skorch_dir.join(
+            'criterion_epoch_{last_epoch[epoch]}.pt')
         f_history = skorch_dir.join(
             'history.json')
 
@@ -781,6 +890,7 @@ class TestLoadInitState:
             monitor='epoch_3_scorer_best',
             f_params=str(f_params),
             f_optimizer=str(f_optimizer),
+            f_criterion=str(f_criterion),
             f_history=str(f_history)
         )
         load_init_state = loadinitstate_cls(cp)
@@ -790,6 +900,7 @@ class TestLoadInitState:
 
         assert skorch_dir.join('model_epoch_3.pt').exists()
         assert skorch_dir.join('optimizer_epoch_3.pt').exists()
+        assert skorch_dir.join('criterion_epoch_3.pt').exists()
         assert skorch_dir.join('history.json').exists()
 
         assert len(net.history) == 10
@@ -848,6 +959,19 @@ class TestTrainEndCheckpoint:
         y = np.zeros((10, 1), dtype='float32')
         return X, y
 
+    def test_init_with_wrong_kwarg_name_raises(self, trainendcheckpoint_cls):
+        trainendcheckpoint_cls(f_foobar='foobar.pt').initialize()  # works
+        msg = ("TrainEndCheckpoint got an unexpected argument 'foobar', "
+               "did you mean 'f_foobar'?")
+        with pytest.raises(TypeError, match=msg):
+            trainendcheckpoint_cls(foobar='foobar.pt').initialize()
+
+    def test_init_with_f_params_and_f_module_raises(self, trainendcheckpoint_cls):
+        msg = "Checkpoint called with both f_params and f_module, please choose one"
+        with pytest.raises(TypeError, match=msg):
+            trainendcheckpoint_cls(
+                f_module='weights.pt', f_params='params.pt').initialize()
+
     def test_saves_at_end(
             self, save_params_mock, net_cls, trainendcheckpoint_cls, data):
         sink = Mock()
@@ -857,34 +981,46 @@ class TestTrainEndCheckpoint:
         ])
         net.fit(*data)
 
-        assert save_params_mock.call_count == 3
+        assert save_params_mock.call_count == 4
         assert sink.call_args == call("Final checkpoint triggered")
-        save_params_mock.assert_has_calls([
-            call(f_params='exp1/train_end_params.pt'),
-            call(f_optimizer='exp1/train_end_optimizer.pt'),
-            call(f_history='exp1/train_end_history.json')
-        ])
+        save_params_mock.assert_has_calls(
+            [
+                # params is turned into module
+                call(f_module='exp1/train_end_params.pt'),
+                call(f_optimizer='exp1/train_end_optimizer.pt'),
+                call(f_criterion='exp1/train_end_criterion.pt'),
+                call(f_history='exp1/train_end_history.json'),
+            ],
+            any_order=True,
+        )
 
     def test_saves_at_end_with_custom_formatting(
             self, save_params_mock, net_cls, trainendcheckpoint_cls, data):
         sink = Mock()
         net = net_cls(callbacks=[
             trainendcheckpoint_cls(
-                sink=sink, dirname='exp1',
+                sink=sink,
+                dirname='exp1',
                 f_params='model_{last_epoch[epoch]}.pt',
                 f_optimizer='optimizer_{last_epoch[epoch]}.pt',
-                fn_prefix='train_end_'
+                f_criterion='criterion_{last_epoch[epoch]}.pt',
+                fn_prefix='train_end_',
             )
         ])
         net.fit(*data)
 
-        assert save_params_mock.call_count == 3
+        assert save_params_mock.call_count == 4
         assert sink.call_args == call("Final checkpoint triggered")
-        save_params_mock.assert_has_calls([
-            call(f_params='exp1/train_end_model_10.pt'),
-            call(f_optimizer='exp1/train_end_optimizer_10.pt'),
-            call(f_history='exp1/train_end_history.json')
-        ])
+        save_params_mock.assert_has_calls(
+            [
+                # params is turned into module
+                call(f_module='exp1/train_end_model_10.pt'),
+                call(f_optimizer='exp1/train_end_optimizer_10.pt'),
+                call(f_criterion='exp1/train_end_criterion_10.pt'),
+                call(f_history='exp1/train_end_history.json'),
+            ],
+            any_order=True,
+        )
 
     def test_cloneable(self, trainendcheckpoint_cls):
         # reproduces bug #459
@@ -914,3 +1050,36 @@ class TestTrainEndCheckpoint:
         # the same score as after the end of training of the initial
         # net should be obtained
         assert np.isclose(score_loaded, score_after)
+
+    def test_save_custom_module(
+            self, save_params_mock, module_cls, trainendcheckpoint_cls, data,
+    ):
+        # checkpointing custom modules works
+        from skorch import NeuralNetRegressor
+
+        class MyNet(NeuralNetRegressor):
+            """Net with custom module"""
+            def __init__(self, *args, mymodule=module_cls, **kwargs):
+                self.mymodule = mymodule
+                super().__init__(*args, **kwargs)
+
+            def initialize_module(self, *args, **kwargs):
+                super().initialize_module(*args, **kwargs)
+
+                params = self.get_params_for('mymodule')
+                self.mymodule_ = self.mymodule(**params)
+
+                return self
+
+        cp = trainendcheckpoint_cls(
+            f_params=None,
+            f_optimizer=None,
+            f_criterion=None,
+            f_history=None,
+            f_mymodule='mymodule.pt',
+        )
+        net = MyNet(module_cls, callbacks=[cp])
+        net.fit(*data)
+
+        assert save_params_mock.call_count == 1
+        save_params_mock.assert_has_calls([call(f_mymodule='train_end_mymodule.pt')])


### PR DESCRIPTION
Solves #635 by implementing my proposal [here](https://github.com/skorch-dev/skorch/issues/635#issuecomment-628862698).

With this change, `save_params`, `Checkpoint` and `TrainEndCheckpoint` now support storing the criterion. But not only that, they support storing any custom pytorch module. So if the user has defined `net.mymodule_`, that can be saved by calling with `net.save_params(f_mymodule=...)`.

This change turned out to be more involved than initially thought:

* giving nice error messages is complicated with `**kwargs`
* we called the module argument `f_params` instead of `f_module`, whereas everything else is called `f_<attribute-name>`, so I had to handle that outlier
* I hadn't considered that `Checkpoint` and `TrainEndCheckpoint` were also affected

For these reasons, it took me the better part of a day to implement this and the PR got quite big, sorry for that.
