### PR TITLE
Implements fix to #631

### DIFF
--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -288,7 +288,7 @@ class NeuralNetBinaryClassifier(NeuralNet, ClassifierMixin):
     # pylint: disable=signature-differs
     def check_data(self, X, y):
         super().check_data(X, y)
-        if get_dim(y) != 1:
+        if (not is_dataset(X)) and (get_dim(y) != 1):
             raise ValueError("The target data should be 1-dimensional.")
 
     def infer(self, x, **fit_params):

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -71,7 +71,8 @@ class TestNeuralNet:
         X, y = data
         accuracy = net_fit.score(X, y)
         assert 0. <= accuracy <= 1.
-    def test_check_data_accepts_dataloader(self, net, data):
+
+    def test_check_data_accepts_skorch_dataset(self, net, data):
         from skorch.dataset import Dataset
 
         X, y = data

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -71,6 +71,12 @@ class TestNeuralNet:
         X, y = data
         accuracy = net_fit.score(X, y)
         assert 0. <= accuracy <= 1.
+    def test_check_data_accepts_dataloader(self, net, data):
+        from skorch.dataset import Dataset
+
+        X, y = data
+        dataset = Dataset(X, y)
+        assert net.check_data(dataset, y=None) is None
 
     # classifier-specific test
     def test_takes_log_with_nllloss(self, net_cls, module_cls, data):

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -72,15 +72,6 @@ class TestNeuralNet:
         accuracy = net_fit.score(X, y)
         assert 0. <= accuracy <= 1.
 
-    def test_fit_with_dataset_and_y_none(self, net_cls, module_cls, data):
-        from skorch.dataset import Dataset
-
-        # deactivate train split since it requires y
-        net = net_cls(module_cls, train_split=False, max_epochs=1)
-        X, y = data
-        dataset = Dataset(X, y)
-        assert net.fit(dataset, y=None)
-
     # classifier-specific test
     def test_takes_log_with_nllloss(self, net_cls, module_cls, data):
         net = net_cls(module_cls, criterion=nn.NLLLoss, max_epochs=1)
@@ -275,6 +266,15 @@ class TestNeuralNetBinaryClassifier:
         X, y = data
         accuracy = net_fit.score(X, y)
         assert 0. <= accuracy <= 1.
+
+    def test_fit_with_dataset_and_y_none(self, net_cls, module_cls, data):
+        from skorch.dataset import Dataset
+
+        # deactivate train split since it requires y
+        net = net_cls(module_cls, train_split=False, max_epochs=1)
+        X, y = data
+        dataset = Dataset(X, y)
+        assert net.fit(dataset, y=None)
 
     def test_target_2d_raises(self, net, data):
         X, y = data

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -72,12 +72,14 @@ class TestNeuralNet:
         accuracy = net_fit.score(X, y)
         assert 0. <= accuracy <= 1.
 
-    def test_check_data_accepts_skorch_dataset(self, net, data):
+    def test_fit_with_dataset_and_y_none(self, net_cls, module_cls, data):
         from skorch.dataset import Dataset
 
+        # deactivate train split since it requires y
+        net = net_cls(module_cls, train_split=False, max_epochs=1)
         X, y = data
         dataset = Dataset(X, y)
-        assert net.check_data(dataset, y=None) is None
+        assert net.fit(dataset, y=None)
 
     # classifier-specific test
     def test_takes_log_with_nllloss(self, net_cls, module_cls, data):


### PR DESCRIPTION
Only check `get_dim(y) != 1` if `X` is not a dataset.