### PR TITLE
Feature: support dict-like input for to_numpy and to_device

### DIFF
--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -8,7 +8,7 @@ from torch.nn.utils.rnn import PackedSequence
 from torch.nn.utils.rnn import pack_padded_sequence
 
 from skorch.tests.conftest import pandas_installed
-
+from copy import deepcopy
 
 class TestToTensor:
     @pytest.fixture
@@ -223,21 +223,25 @@ class TestToDevice:
         (None, None),
     ])
     def test_check_device_dict_torch_tensor(
-            self, to_device, x_dict, device_from, device_to):
+        self, to_device, x_dict, device_from, device_to):
         if 'cuda' in (device_from, device_to) and not torch.cuda.is_available():
             pytest.skip()
 
-        prev_devices = [None for _ in range(len(list(x_dict.keys())))]
+        original_x_dict = deepcopy(x_dict)
+
+        prev_devices=[None for _ in range(len(list(x_dict.keys())))]
         if None in (device_from, device_to):
             prev_devices = [x.device.type for x in x_dict.values()]
 
-        x_dict = to_device(x_dict, device=device_from)
-        for xi, prev_d in zip(x_dict.values(), prev_devices):
+        new_x_dict = to_device(x_dict, device=device_from)
+        for xi, prev_d in zip(new_x_dict.values(), prev_devices):
             self.check_device_type(xi, device_from, prev_d)
 
-        x_dict = to_device(x_dict, device=device_to)
-        for xi, prev_d in zip(x_dict.values(), prev_devices):
+        new_x_dict = to_device(new_x_dict, device=device_to)
+        for xi, prev_d in zip(new_x_dict.values(), prev_devices):
             self.check_device_type(xi, device_to, prev_d)
+
+        assert x_dict == original_x_dict
             
     @pytest.mark.parametrize('device_from, device_to', [
         ('cpu', 'cpu'),

--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -241,7 +241,9 @@ class TestToDevice:
         for xi, prev_d in zip(new_x_dict.values(), prev_devices):
             self.check_device_type(xi, device_to, prev_d)
 
-        assert x_dict == original_x_dict
+        assert x_dict.keys() == original_x_dict.keys()
+        for k in x_dict:
+            assert np.allclose(x_dict[k], original_x_dict[k])
             
     @pytest.mark.parametrize('device_from, device_to', [
         ('cpu', 'cpu'),

--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -223,7 +223,7 @@ class TestToDevice:
         (None, None),
     ])
     def test_check_device_dict_torch_tensor(
-        self, to_device, x_dict, device_from, device_to):
+            self, to_device, x_dict, device_from, device_to):
         if 'cuda' in (device_from, device_to) and not torch.cuda.is_available():
             pytest.skip()
 

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -154,7 +154,7 @@ def to_device(X, device):
 
     # PackedSequence class inherits from a namedtuple
     if isinstance(X, tuple) and (type(X) != PackedSequence):
-        return tuple(to_device(x) for x in X)
+        return tuple(x.to(device) for x in X)
     return X.to(device)
 
 

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -138,6 +138,7 @@ def to_device(X, device):
 
          * torch tensor
          * tuple of torch tensors
+         * dict of torch tensors
          * PackSequence instance
          * torch.nn.Module
 

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -110,6 +110,9 @@ def to_numpy(X):
     if isinstance(X, np.ndarray):
         return X
 
+    if isinstance(X, dict):
+        return {key: to_numpy(val) for key, val in X.items()}
+
     if is_pandas_ndframe(X):
         return X.values
 
@@ -145,6 +148,9 @@ def to_device(X, device):
     """
     if device is None:
         return X
+
+    if isinstance(X, dict):
+        return {key: val.to(device) for key, val in X.items()}
 
     # PackedSequence class inherits from a namedtuple
     if isinstance(X, tuple) and (type(X) != PackedSequence):

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -150,11 +150,11 @@ def to_device(X, device):
         return X
 
     if isinstance(X, dict):
-        return {key: val.to(device) for key, val in X.items()}
+        return {key: to_device(val) for key, val in X.items()}
 
     # PackedSequence class inherits from a namedtuple
     if isinstance(X, tuple) and (type(X) != PackedSequence):
-        return tuple(x.to(device) for x in X)
+        return tuple(to_device(x) for x in X)
     return X.to(device)
 
 

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -150,7 +150,7 @@ def to_device(X, device):
         return X
 
     if isinstance(X, dict):
-        return {key: to_device(val) for key, val in X.items()}
+        return {key: to_device(val,device) for key, val in X.items()}
 
     # PackedSequence class inherits from a namedtuple
     if isinstance(X, tuple) and (type(X) != PackedSequence):


### PR DESCRIPTION
dict like input is possible for user customized dataset or output function,but will get error in current code such as forward_iter 
And current to_tensor support dict input, but to_device doesn't support