### PR TITLE
Add predict nonlinearity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the `event_name` argument for `LRScheduler` for optional recording of LR changes inside `net.history`. NOTE: Supported only in Pytorch>=1.4
 - Make it easier to add custom modules or optimizers to a neural net class by automatically registering them where necessary and by making them available to set_params
 - Added the `step_every` argument for `LRScheduler` to set whether the scheduler step should be taken on every epoch or on every batch.
+- Added a parameter `predict_nonlinearity` to `NeuralNet` which allows users to control the nonlinearity to be applied to the module output when calling `predict` and `predict_proba` (#637, #661)
 
 ### Changed
 
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Raise `FutureWarning` when using `CyclicLR` scheduler, because the default behavior has changed from taking a step every batch to taking a step every epoch. (#626)
 - Set train/validation on criterion if it's a PyTorch module (#621)
 - Don't pass `y=None` to `NeuralNet.train_split` to enable the direct use of split functions without positional `y` in their signatures. This is useful when working with unsupervised data (#605).
+- When using `CrossEntropyLoss`, softmax is now automatically applied to the output when calling `predict` or `predict_proba`
 
 ### Fixed
 

--- a/docs/user/neuralnet.rst
+++ b/docs/user/neuralnet.rst
@@ -346,13 +346,14 @@ from the ``module``. Alternatively, you may directly call
 ``net.module_(X)``.
 
 In case of :class:`.NeuralNetClassifier`, the
-:func:`~skorch.net.NeuralNetClassifier.predict` method tries to return
-the class labels by applying the argmax over the last axis of the
-result of :func:`~skorch.net.NeuralNetClassifier.predict_proba`.
+:func:`~skorch.classifier.NeuralNetClassifier.predict` method tries to
+return the class labels by applying the argmax over the last axis of
+the result of
+:func:`~skorch.classifier.NeuralNetClassifier.predict_proba`.
 Obviously, this only makes sense if
-:func:`~skorch.net.NeuralNetClassifier.predict_proba` returns class
-probabilities. If this is not true, you should just use
-:func:`~skorch.net.NeuralNetClassifier.predict_proba`.
+:func:`~skorch.classifier.NeuralNetClassifier.predict_proba` returns
+class probabilities. If this is not true, you should just use
+:func:`~skorch.classifier.NeuralNetClassifier.predict_proba`.
 
 score(X, y)
 ^^^^^^^^^^^

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -206,12 +206,7 @@ class NeuralNetClassifier(NeuralNet, ClassifierMixin):
         y_pred : numpy ndarray
 
         """
-        y_preds = []
-        for yp in self.forward_iter(X, training=False):
-            yp = yp[0] if isinstance(yp, tuple) else yp
-            y_preds.append(to_numpy(yp.max(-1)[-1]))
-        y_pred = np.concatenate(y_preds, 0)
-        return y_pred
+        return super().predict_proba(X).argmax(1)
 
 
 neural_net_binary_clf_doc_start = """NeuralNet for binary classification tasks
@@ -361,49 +356,3 @@ class NeuralNetBinaryClassifier(NeuralNet, ClassifierMixin):
         """
         y_proba = self.predict_proba(X)
         return (y_proba[:, 1] > self.threshold).astype('uint8')
-
-    # pylint: disable=missing-docstring
-    def predict_proba(self, X):
-        """Where applicable, return probability estimates for
-        samples.
-
-        If the module's forward method returns multiple outputs as a
-        tuple, it is assumed that the first output contains the
-        relevant information and the other values are ignored. If all
-        values are relevant, consider using
-        :func:`~skorch.NeuralNet.forward` instead.
-
-        Parameters
-        ----------
-        X : input data, compatible with skorch.dataset.Dataset
-          By default, you should be able to pass:
-
-            * numpy arrays
-            * torch tensors
-            * pandas DataFrame or Series
-            * scipy sparse CSR matrices
-            * a dictionary of the former three
-            * a list/tuple of the former three
-            * a Dataset
-
-          If this doesn't work with your data, you have to pass a
-          ``Dataset`` that can deal with the data.
-
-        Returns
-        -------
-        y_proba : numpy ndarray
-
-        """
-        y_probas = []
-        self.check_is_fitted(attributes=['criterion_'])
-        bce_logits_loss = isinstance(
-            self.criterion_, torch.nn.BCEWithLogitsLoss)
-
-        for yp in self.forward_iter(X, training=False):
-            yp = yp[0] if isinstance(yp, tuple) else yp
-            if bce_logits_loss:
-                yp = torch.sigmoid(yp)
-            y_probas.append(to_numpy(yp))
-        y_proba = np.concatenate(y_probas, 0)
-        y_proba = np.stack((1 - y_proba, y_proba), axis=1)
-        return y_proba

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -206,7 +206,7 @@ class NeuralNetClassifier(NeuralNet, ClassifierMixin):
         y_pred : numpy ndarray
 
         """
-        return super().predict_proba(X).argmax(1)
+        return super().predict_proba(X).argmax(axis=1)
 
 
 neural_net_binary_clf_doc_start = """NeuralNet for binary classification tasks

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1041,7 +1041,7 @@ class NeuralNet:
             return self.module_(**x_dict)
         return self.module_(x, **fit_params)
 
-    def get_predict_nonlinearity(self):
+    def _get_predict_nonlinearity(self):
         """Return the nonlinearity to be applied to the prediction
 
         This can be useful, e.g., when
@@ -1066,7 +1066,6 @@ class NeuralNet:
         Returns
         -------
         nonlin : callable
-
           A callable that takes a single argument, which is a PyTorch
           tensor, and returns a PyTorch tensor.
 
@@ -1112,7 +1111,7 @@ class NeuralNet:
         y_proba : numpy ndarray
 
         """
-        nonlin = self.get_predict_nonlinearity()
+        nonlin = self._get_predict_nonlinearity()
         y_probas = []
         for yp in self.forward_iter(X, training=False):
             yp = yp[0] if isinstance(yp, tuple) else yp

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -166,7 +166,7 @@ class NeuralNet:
       PyTorch tensor, and return the transformed PyTorch tensor.
 
       This can be useful, e.g., when
-      :func:`~skorch.classifier.NeuralNetClassifier.predict_proba`
+      :func:`~skorch.NeuralNetClassifier.predict_proba`
       should return probabilities but a criterion is used that does
       not expect probabilities. In that case, the module can return
       whatever is required by the criterion and the

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -152,6 +152,8 @@ class NeuralNet:
       ``net.set_params(callbacks__print_log__keys_ignored=['epoch',
       'train_loss'])``).
 
+    predict_nonlinearity : TODO
+
     warm_start : bool (default=False)
       Whether each fit call should lead to a re-initialization of the
       module (cold start) or whether the module should be trained
@@ -213,6 +215,7 @@ class NeuralNet:
             dataset=Dataset,
             train_split=CVSplit(5),
             callbacks=None,
+            predict_nonlinearity='auto',
             warm_start=False,
             verbose=1,
             device='cpu',
@@ -229,6 +232,7 @@ class NeuralNet:
         self.dataset = dataset
         self.train_split = train_split
         self.callbacks = callbacks
+        self.predict_nonlinearity = predict_nonlinearity
         self.warm_start = warm_start
         self.verbose = verbose
         self.device = device

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -22,6 +22,8 @@ from skorch.dataset import uses_placeholder_y
 from skorch.exceptions import DeviceWarning
 from skorch.history import History
 from skorch.setter import optimizer_setter
+from skorch.utils import _identity
+from skorch.utils import _infer_predict_nonlinearty
 from skorch.utils import FirstStepAccumulator
 from skorch.utils import TeeGenerator
 from skorch.utils import check_is_fitted
@@ -152,7 +154,30 @@ class NeuralNet:
       ``net.set_params(callbacks__print_log__keys_ignored=['epoch',
       'train_loss'])``).
 
-    predict_nonlinearity : TODO
+    predict_nonlinearity : callable, None, or 'auto' (default='auto')
+      The nonlinearity to be applied to the prediction. When set to
+      'auto', infers the correct nonlinearity based on the criterion
+      (softmax for :class:`~torch.nn.CrossEntropyLoss` and sigmoid for
+      :class:`~torch.nn.BCEWithLogitsLoss`). If it cannot be inferred
+      or if the parameter is None, just use the identity function.
+
+      In case a callable is passed, it should accept the output of the
+      module (the first output if there is more than one), which is a
+      PyTorch tensor, and return the transformed PyTorch tensor.
+
+      This can be useful, e.g., when
+      :func:`~skorch.classifier.NeuralNetClassifier.predict_proba`
+      should return probabilities but a criterion is used that does
+      not expect probabilities. In that case, the module can return
+      whatever is required by the criterion and the
+      ``predict_nonlinearity`` transforms this output into
+      probabilities.
+
+      The nonlinearity is applied only when calling
+      :func:`~skorch.classifier.NeuralNetClassifier.predict` or
+      :func:`~skorch.classifier.NeuralNetClassifier.predict_proba` but
+      not anywhere else -- notably, the loss is unaffected by this
+      nonlinearity.
 
     warm_start : bool (default=False)
       Whether each fit call should lead to a re-initialization of the
@@ -1014,6 +1039,46 @@ class NeuralNet:
             return self.module_(**x_dict)
         return self.module_(x, **fit_params)
 
+    def get_predict_nonlinearity(self):
+        """Return the nonlinearity to be applied to the prediction
+
+        This can be useful, e.g., when
+        :func:`~skorch.classifier.NeuralNetClassifier.predict_proba`
+        should return probabilities but a criterion is used that does
+        not expect probabilities. In that case, the module can return
+        whatever is required by the criterion and the
+        ``predict_nonlinearity`` transforms this output into
+        probabilities.
+
+        The nonlinearity is applied only when calling
+        :func:`~skorch.classifier.NeuralNetClassifier.predict` or
+        :func:`~skorch.classifier.NeuralNetClassifier.predict_proba`
+        but not anywhere else -- notably, the loss is unaffected by
+        this nonlinearity.
+
+        Raises
+        ------
+        TypeError
+          Raise a TypeError if the return value is not callable.
+
+        Returns
+        -------
+        nonlin : callable
+
+          A callable that takes a single argument, which is a PyTorch
+          tensor, and returns a PyTorch tensor.
+
+        """
+        self.check_is_fitted()
+        nonlin = self.predict_nonlinearity
+        if nonlin is None:
+            nonlin = _identity
+        elif nonlin == 'auto':
+            nonlin = _infer_predict_nonlinearty(self)
+        if not callable(nonlin):
+            raise TypeError("predict_nonlinearity has to be a callable, 'auto' or None")
+        return nonlin
+
     def predict_proba(self, X):
         """Return the output of the module's forward method as a numpy
         array.
@@ -1045,9 +1110,11 @@ class NeuralNet:
         y_proba : numpy ndarray
 
         """
+        nonlin = self.get_predict_nonlinearity()
         y_probas = []
         for yp in self.forward_iter(X, training=False):
             yp = yp[0] if isinstance(yp, tuple) else yp
+            yp = nonlin(yp)
             y_probas.append(to_numpy(yp))
         y_proba = np.concatenate(y_probas, 0)
         return y_proba

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -159,7 +159,9 @@ class NeuralNet:
       'auto', infers the correct nonlinearity based on the criterion
       (softmax for :class:`~torch.nn.CrossEntropyLoss` and sigmoid for
       :class:`~torch.nn.BCEWithLogitsLoss`). If it cannot be inferred
-      or if the parameter is None, just use the identity function.
+      or if the parameter is None, just use the identity
+      function. Don't pass a lambda function if you want the net to be
+      pickleable.
 
       In case a callable is passed, it should accept the output of the
       module (the first output if there is more than one), which is a

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -289,7 +289,9 @@ class TestNeuralNetBinaryClassifier:
         mock = Mock(side_effect=lambda x: x)
         monkeypatch.setattr(torch, "sigmoid", mock)
 
-        # we need to add a custom nonlinearity, otherwise the output won't be 2d
+        # add a custom nonlinearity - note that the output must return
+        # a 2d array from a 1d vector to conform to the required
+        # y_proba
         def nonlin(x):
             return torch.stack((1 - x, x), 1)
 

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -291,7 +291,7 @@ class TestNeuralNetBinaryClassifier:
 
         # we need to add a custom nonlinearity, otherwise the output won't be 2d
         def nonlin(x):
-            return torch.stack((1 - x, x), axis=1)
+            return torch.stack((1 - x, x), 1)
 
         net = net_cls(module_cls, max_epochs=1, lr=0.1, criterion=nn.MSELoss,
                       predict_nonlinearity=nonlin)

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -289,7 +289,12 @@ class TestNeuralNetBinaryClassifier:
         mock = Mock(side_effect=lambda x: x)
         monkeypatch.setattr(torch, "sigmoid", mock)
 
-        net = net_cls(module_cls, max_epochs=1, lr=0.1, criterion=nn.MSELoss)
+        # we need to add a custom nonlinearity, otherwise the output won't be 2d
+        def nonlin(x):
+            return torch.stack((1 - x, x), axis=1)
+
+        net = net_cls(module_cls, max_epochs=1, lr=0.1, criterion=nn.MSELoss,
+                      predict_nonlinearity=nonlin)
         X, y = data
         net.fit(X, y)
 

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2587,7 +2587,7 @@ class TestNeuralNet:
         assert len(side_effect) == 2
         assert side_effect[0].shape == (128, 2)
         assert side_effect[1].shape == (72, 2)
-        assert (y_proba == 0).all()
+        assert np.allclose(y_proba, 0)
 
         net.predict_proba(X)
         assert len(side_effect) == 4

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2608,7 +2608,7 @@ class TestNeuralNet:
         rv = np.random.random((20, 5))
         net.forward_iter = lambda *args, **kwargs: (torch.as_tensor(rv) for _ in range(2))
 
-        # 2 batches, mock return value hs shape 20,5 thus y_proba has
+        # 2 batches, mock return value has shape 20,5 thus y_proba has
         # shape 40,5
         y_proba = net.predict_proba(X)
         assert y_proba.shape == (40, 5)

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2595,7 +2595,7 @@ class TestNeuralNet:
     def test_predict_nonlinearity_none(
             self, net_cls, module_cls, data):
         # even though we have CrossEntropyLoss, we don't want the
-        # output from predict_proba to be modified, since we set
+        # output from predict_proba to be modified, thus we set
         # predict_nonlinearity to None
         X = data[0][:200]
         net = net_cls(

--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -669,3 +669,69 @@ class TestTeeGenerator:
 
         assert first_return == expected_list
         assert second_return == expected_list
+
+
+class TestInferPredictNonlinearity:
+    @pytest.fixture
+    def infer_predict_nonlinearity(self):
+        from skorch.utils import _infer_predict_nonlinearty
+        return _infer_predict_nonlinearty
+
+    @pytest.fixture
+    def net_clf_cls(self):
+        from skorch import NeuralNetClassifier
+        return NeuralNetClassifier
+
+    @pytest.fixture
+    def net_bin_clf_cls(self):
+        from skorch import NeuralNetBinaryClassifier
+        return NeuralNetBinaryClassifier
+
+    @pytest.fixture
+    def net_regr_cls(self):
+        from skorch import NeuralNetRegressor
+        return NeuralNetRegressor
+
+    def test_infer_neural_net_classifier_default(
+            self, infer_predict_nonlinearity, net_clf_cls, module_cls):
+        # default NeuralNetClassifier: no output nonlinearity
+        net = net_clf_cls(module_cls).initialize()
+        fn = infer_predict_nonlinearity(net)
+
+        X = np.random.random((20, 5))
+        out = fn(X)
+        assert out is X
+
+    def test_infer_neural_net_classifier_crossentropy_loss(
+            self, infer_predict_nonlinearity, net_clf_cls, module_cls):
+        # CrossEntropyLoss should return valid probabilities
+        net = net_clf_cls(module_cls, criterion=torch.nn.CrossEntropyLoss).initialize()
+        fn = infer_predict_nonlinearity(net)
+
+        X = torch.rand((20, 5))
+        out = fn(X).numpy()
+        assert np.allclose(out.sum(1), 1.0)
+        assert ((0 <= out) & (out <= 1.0)).all()
+
+    def test_infer_neural_binary_net_classifier_default(
+            self, infer_predict_nonlinearity, net_bin_clf_cls, module_cls):
+        # BCEWithLogitsLoss should return valid probabilities
+        net = net_bin_clf_cls(module_cls).initialize()
+        fn = infer_predict_nonlinearity(net)
+
+        X = torch.rand(20)  # binary classifier returns 1-dim output
+        X = 10 * X - 5.0  # random values from -5 to 5
+        out = fn(X).numpy()
+        assert out.shape == (20, 2)  # output should be 2-dim
+        assert np.allclose(out.sum(1), 1.0)
+        assert ((0 <= out) & (out <= 1.0)).all()
+
+    def test_infer_neural_net_regressor_default(
+            self, infer_predict_nonlinearity, net_regr_cls, module_cls):
+        # default NeuralNetRegressor: no output nonlinearity
+        net = net_regr_cls(module_cls).initialize()
+        fn = infer_predict_nonlinearity(net)
+
+        X = np.random.random((20, 5))
+        out = fn(X)
+        assert out is X

--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -710,7 +710,7 @@ class TestInferPredictNonlinearity:
 
         X = torch.rand((20, 5))
         out = fn(X).numpy()
-        assert np.allclose(out.sum(1), 1.0)
+        assert np.allclose(out.sum(axis=1), 1.0)
         assert ((0 <= out) & (out <= 1.0)).all()
 
     def test_infer_neural_binary_net_classifier_default(

--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -723,7 +723,7 @@ class TestInferPredictNonlinearity:
         X = 10 * X - 5.0  # random values from -5 to 5
         out = fn(X).numpy()
         assert out.shape == (20, 2)  # output should be 2-dim
-        assert np.allclose(out.sum(1), 1.0)
+        assert np.allclose(out.sum(axis=1), 1.0)
         assert ((0 <= out) & (out <= 1.0)).all()
 
     def test_infer_neural_net_regressor_default(

--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -838,7 +838,7 @@ class TestInferPredictNonlinearity:
 
     def test_infer_neural_net_classifier_crossentropy_loss(
             self, infer_predict_nonlinearity, net_clf_cls, module_cls):
-        # CrossEntropyLoss should return valid probabilities
+        # CrossEntropyLoss criteron: nonlinearity should return valid probabilities
         net = net_clf_cls(module_cls, criterion=torch.nn.CrossEntropyLoss).initialize()
         fn = infer_predict_nonlinearity(net)
 

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -564,7 +564,9 @@ def _sigmoid_then_2d(x):
 
     Sigmoid is applied to x to transform it to probabilities. Then
     concatenate the probabilities with 1 - these probabilities to
-    return a correctly formed ``y_proba``.
+    return a correctly formed ``y_proba``. This is required for
+    sklearn, which expects probabilities to be 2d arrays whose sum
+    along axis 1 is 1.0.
 
     Parameters
     ----------

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -565,7 +565,7 @@ def _sigmoid_then_2d(x):
 
     """
     prob = torch.sigmoid(x)
-    y_proba = torch.stack((1 - prob, prob), axis=1)
+    y_proba = torch.stack((1 - prob, prob), 1)
     return y_proba
 
 

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -538,6 +538,16 @@ def check_is_fitted(estimator, attributes, msg=None, all_or_any=all):
         raise NotInitializedError(msg % {'name': type(estimator).__name__})
 
 
+def _identity(x):
+    """Return input as is, the identity operation"""
+    return x
+
+
+def _infer_predict_nonlinearty(net):
+    """TODO"""
+    return _identity
+
+
 class TeeGenerator:
     """Stores a generator and calls ``tee`` on it to create new generators
     when ``TeeGenerator`` is iterated over to let you iterate over the given

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -17,6 +17,8 @@ import numpy as np
 from scipy import sparse
 import sklearn
 import torch
+from torch.nn import BCEWithLogitsLoss
+from torch.nn import CrossEntropyLoss
 from torch.nn.utils.rnn import PackedSequence
 from torch.utils.data.dataset import Subset
 
@@ -543,8 +545,50 @@ def _identity(x):
     return x
 
 
+def _sigmoid_then_2d(x):
+    """Transform 1-dim logits to valid y_proba
+
+    Sigmoid is applied to x to transform it to probabilities. Then
+    concatenate the probabilities with 1 - these probabilities to
+    return a correctly formed ``y_proba``.
+
+    Parameters
+    ----------
+    x : torch.tensor
+      A 1 dimensional float torch tensor containing raw logits.
+
+    Returns
+    -------
+    y_proba : torch.tensor
+      A 2 dimensional float tensor of probabilities that sum up to 1
+      on axis 1.
+
+    """
+    prob = torch.sigmoid(x)
+    y_proba = torch.stack((1 - prob, prob), axis=1)
+    return y_proba
+
+
 def _infer_predict_nonlinearty(net):
-    """TODO"""
+    """Infers the correct nonlinearity to apply for this net
+
+    The nonlinearity is applied only when calling
+    :func:`~skorch.classifier.NeuralNetClassifier.predict` or
+    :func:`~skorch.classifier.NeuralNetClassifier.predict_proba`.
+
+    """
+    # Implementation: At the moment, this function "dispatches" only
+    # based on the criterion, not the class of the net. We still pass
+    # the whole net as input in case we want to modify this at a
+    # future point in time.
+    criterion = net.criterion_
+
+    if isinstance(criterion, CrossEntropyLoss):
+        return partial(torch.softmax, dim=-1)
+
+    if isinstance(criterion, BCEWithLogitsLoss):
+        return _sigmoid_then_2d
+
     return _identity
 
 


### PR DESCRIPTION
Resolves #637, resolves #661

Supersedes #572 #580

Added a parameter `predict_nonlinearity` to `NeuralNet` which allows users to control the nonlinearity to be applied to the module output when calling `predict` and `predict_proba`. Also, when using `CrossEntropyLoss`, softmax is now automatically applied to the output.

This PR implements what was discussed in #661. Regarding the implementation, I used the most simple approach at the moment (no dispatching based on the net class, for instance). Also, I added a `get_predict_nonlinearity` method to `NeuralNet`, which handles the case of `'auto'` vs `None` vs `callable`.

Regarding the naming, I decided against `output_nonlinearity`. I believe `predict_nonlinearity` makes it much more obvious that this nonlinearity is **not** applied to the module output directly (which would affect loss etc.) but only when calling `predict` and `predict_proba`.

ping @qtux 