### PR TITLE
Implement loss scoring for #628

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the `event_name` argument for `LRScheduler` for optional recording of LR changes inside `net.history`. NOTE: Supported only in Pytorch>=1.4
 - Make it easier to add custom modules or optimizers to a neural net class by automatically registering them where necessary and by making them available to set_params
 - Added the `step_every` argument for `LRScheduler` to set whether the scheduler step should be taken on every epoch or on every batch.
+- Added the `scoring` module with `loss_scoring` function, which computes the net's loss (using `get_loss`) on provided input data.
 
 ### Changed
 

--- a/docs/scoring.rst
+++ b/docs/scoring.rst
@@ -1,0 +1,5 @@
+skorch.scoring
+==============
+
+.. automodule:: skorch.scoring
+    :members:

--- a/docs/skorch.rst
+++ b/docs/skorch.rst
@@ -12,5 +12,6 @@ skorch
    history
    net
    regressor
+   scoring
    toy
    utils

--- a/docs/user/FAQ.rst
+++ b/docs/user/FAQ.rst
@@ -357,3 +357,50 @@ layer, and that the number of features can be determined by
 ``X.shape[1]``. If those assumptions are not true for your case,
 adjust the code accordingly. A fully working example can be found
 on `stackoverflow <https://stackoverflow.com/a/60170023/1643939>`_.
+
+How do I implement a score method on the net that returns the loss?
+-------------------------------------------------------------------
+
+Sometimes, it is useful to be able to compute the loss of a net from within
+``skorch`` (*e.g.,* when a net is part of an ``sklearn`` pipeline). The function
+:func:`skorch.scoring.loss_scoring` achieves this. Two examples are provided
+below. The first demonstrates how to use :func:`skorch.scoring.loss_scoring` as
+a function on a trained ``net`` object.
+
+.. code:: python
+
+    from skorch.scoring import loss_scoring
+
+    X = np.random.randn(250, 25).astype('float32')
+    y = (X.dot(np.ones(25)) > 0).astype(int)
+
+    module = nn.Sequential(
+        nn.Linear(25, 25),
+        nn.ReLU(),
+        nn.Linear(25, 2),
+        nn.Softmax(dim=1)
+    )
+    net = skorch.NeuralNetClassifier(module).fit(X, y)
+    print(loss_scoring(net, X, y))
+
+The second example shows how to sub-class :class:`skorch.NeuralNetClassifier` to
+implement a ``score`` method. In this example, the ``score`` method returns the
+**negative** of the loss value, because we want
+:class:`sklearn.model_selection.GridSearchCV` to return the run with **least**
+loss and :class:`sklearn.model_selection.GridSearchCV` searches for the run with
+the **greatest** score.
+
+.. code:: python
+
+    class ScoredNet(skorch.NeuralNetClassifier):
+        def score(self, X, y=None):
+            loss_value = loss_scoring(self, X, y)
+            return -loss_value
+    
+    net = ScoredNet(module)
+    grid_searcher = GridSearchCV(
+        net, {'lr': [1e-2, 1e-3], 'batch_size': [8, 16]},
+    )
+    grid_searcher.fit(X, y)
+    best_net = grid_searcher.best_estimator_
+    print(best_net.score(X, y))

--- a/docs/user/FAQ.rst
+++ b/docs/user/FAQ.rst
@@ -383,7 +383,7 @@ a function on a trained ``net`` object.
     net = skorch.NeuralNetClassifier(module).fit(X, y)
     print(loss_scoring(net, X, y))
 
-The second example shows how to sub-class :class:`skorch.NeuralNetClassifier` to
+The second example shows how to sub-class :class:`skorch.classifier.NeuralNetClassifier` to
 implement a ``score`` method. In this example, the ``score`` method returns the
 **negative** of the loss value, because we want
 :class:`sklearn.model_selection.GridSearchCV` to return the run with **least**

--- a/docs/user/FAQ.rst
+++ b/docs/user/FAQ.rst
@@ -362,7 +362,7 @@ How do I implement a score method on the net that returns the loss?
 -------------------------------------------------------------------
 
 Sometimes, it is useful to be able to compute the loss of a net from within
-``skorch`` (*e.g.,* when a net is part of an ``sklearn`` pipeline). The function
+``skorch`` (e.g. when a net is part of an ``sklearn`` pipeline). The function
 :func:`skorch.scoring.loss_scoring` achieves this. Two examples are provided
 below. The first demonstrates how to use :func:`skorch.scoring.loss_scoring` as
 a function on a trained ``net`` object.

--- a/skorch/scoring.py
+++ b/skorch/scoring.py
@@ -3,71 +3,43 @@ from skorch.net import NeuralNet
 from skorch.dataset import unpack_data
 
 
-class _CriterionAccumulator:
-    def __init__(self, criterion):
-        """
-        _CriterionAccumulator(criterion)
-
-        Parameters
-        ----------
-        criterion: PyTorch loss function
-            e.g., nn.MSELoss or nn.NLLLoss
-        """
-        self.criterion = criterion
-        reduction = self._get_reduction()
-        assert reduction in ["mean", "sum", "none",], (
-            "Expected reduction to be one of 'mean', 'sum' "
-            + "or 'none' but got {reduction}.".format(reduction=reduction)
-        )
-        self.log = {"loss": [], "batch_size": []}
-        self._reduce = {
-            "sum": self._reduce_sum,
-            "mean": self._reduce_mean,
-            "none": self._reduce_none,
-        }
-
-    def __call__(self, input, target):
-        loss = self.criterion(input, target)
-
-        batch_size = target.size(0)
-        self.log["batch_size"].append(batch_size)
-
-        # If criterion.reduction is 'none', loss.item() can fail,
-        # because item method requires scalar input.
-        if self._get_reduction() == "none":
-            loss = loss.detach().cpu().numpy()
-            self.log["loss"].append(loss)
-        else:
-            self.log["loss"].append(loss.item())
-
-    def reduce(self):
-        reduction = self._get_reduction()
-        return self._reduce[reduction]()
-
-    def _get_reduction(self):
-        return self.criterion.reduction
-
-    def _reduce_sum(self):
-        return np.sum(self.log["loss"])
-
-    def _reduce_mean(self):
-        losses = np.array(self.log["loss"])
-        batch_sizes = np.array(self.log["batch_size"])
-        n_examples = batch_sizes.sum()
-        loss_value = np.sum(losses * batch_sizes) / n_examples
-        return loss_value
-
-    def _reduce_none(self):
-        return np.concatenate(self.log["loss"], 0)
-
-
 def loss_scoring(net: NeuralNet, X, y=None):
     """
     loss_scoring(net, X, y=None)
 
+    Computes the loss of ``net`` on data (``X``, ``y``).
+
+    This function can be used to implement the ``score`` method for a
+    :class:`.NeuralNet` through sub-classing. This is useful, for example, when
+    combining skorch models with sklearn objects that rely on the model's
+    ``score`` method. Below is an example using GridSearchCV.
+
+    >>> class ScoredNet(skorch.NeuralNetClassifier):
+    ...     def score(self, X, y=None, lower_is_better=False):
+    ...         loss_value = loss_scoring(self, X, y)
+    ...         if lower_is_better:
+    ...             return loss_value
+    ...         return -loss_value
+    ...
+    >>> X = np.random.randn(250, 25).astype('float32')
+    >>> y = (X.dot(np.ones(25)) > 0).astype(int)
+    >>> module = nn.Sequential(
+    ...     nn.Linear(25, 25),
+    ...     nn.ReLU(),
+    ...     nn.Linear(25,
+    ...     2),
+    ...     nn.Softmax(dim=1)
+    ... )
+    >>> net = ScoredNet(module)
+    >>> grid_searcher = GridSearchCV(
+    ...     net, {'lr': [1e-2, 1e-3], 'batch_size': [8, 16]}
+    ... )
+    >>> grid_searcher.fit(X, y)
+
     Parameters
     ----------
     net : skorch.NeuralNet
+        A fitted Skorch :class:`.NeuralNet` object.
     X : input data, compatible with skorch.dataset.Dataset
         By default, you should be able to pass:
             * numpy arrays
@@ -85,20 +57,32 @@ def loss_scoring(net: NeuralNet, X, y=None):
 
     Returns
     -------
-    loss_value : float32???? or np.ndarray
+    loss_value : float32 or np.ndarray
         Return type depends on net.criterion_.reduction, and will be a float if
         reduction is ``'sum'`` or ``'mean'``. If reduction is ``'none'`` then
         this function returns a ``np.ndarray`` object.
+
     """
     net.check_is_fitted()
 
-    criterion = _CriterionAccumulator(net.criterion_)
     dataset = net.get_dataset(X, y)
     iterator = net.get_iterator(dataset, training=False)
-
+    history = {"loss": [], "batch_size": []}
+    reduction = net.criterion_.reduction
     for data in iterator:
         Xi, yi = unpack_data(data)
         yp = net.evaluation_step(Xi, training=False)
-        criterion(yp, yi)
-    loss_value = criterion.reduce()
+        loss = net.criterion_(yp, yi)
+        if reduction == "none":
+            loss_value = loss.detach().cpu().numpy()
+        else:
+            loss_value = loss.item()
+        history["loss"].append(loss_value)
+        history["batch_size"].append(yi.size(0))
+
+    if reduction == "none":
+        return np.concatenate(history["loss"], 0)
+    loss_value = np.average(history["loss"], weights=history["batch_size"])
+    if reduction == "sum":
+        loss_value *= len(history["batch_size"])
     return loss_value

--- a/skorch/scoring.py
+++ b/skorch/scoring.py
@@ -22,9 +22,9 @@ class _CriterionAccumulator:
         """
         self.criterion = criterion
         reduction = self._get_reduction()
-        assert reduction in ["mean", "sum", "none"], (
-            f"Expected reduction to be one of 'mean', 'sum' or "
-            f"'none' but got {reduction}."
+        assert reduction in ["mean", "sum", "none",], (
+            "Expected reduction to be one of 'mean', 'sum' "
+            + "or 'none' but got {reduction}.".format(reduction=reduction)
         )
         self.log = {"loss": [], "batch_size": []}
         self._reduce = {

--- a/skorch/scoring.py
+++ b/skorch/scoring.py
@@ -60,10 +60,11 @@ def loss_scoring(net: NeuralNet, X, y=None, sample_weight=None):
     iterator = net.get_iterator(dataset, training=False)
     history = {"loss": [], "batch_size": []}
     reduction = net.criterion_.reduction
-    assert reduction in ["mean", "sum", "none",], (
-        "Expected one of 'mean', 'sum' or 'none' "
-        "for reduction but got {reduction}.".format(reduction=reduction)
-    )
+    if reduction not in ["mean", "sum", "none"]:
+        raise ValueError(
+            "Expected one of 'mean', 'sum' or 'none' "
+            "for reduction but got {reduction}.".format(reduction=reduction)
+        )
     for data in iterator:
         Xi, yi = unpack_data(data)
         yp = net.evaluation_step(Xi, training=False)

--- a/skorch/scoring.py
+++ b/skorch/scoring.py
@@ -11,31 +11,11 @@ def loss_scoring(net: NeuralNet, X, y=None):
     This function can be used to implement the ``score`` method for a
     :class:`.NeuralNet` through sub-classing. This is useful, for example, when
     combining skorch models with sklearn objects that rely on the model's
-    ``score`` method. Below is an example using GridSearchCV.
+    ``score`` method. For example:
 
     >>> class ScoredNet(skorch.NeuralNetClassifier):
-    ...     def score(self, X, y=None, lower_is_better=False):
-    ...         loss_value = loss_scoring(self, X, y)
-    ...         if lower_is_better:
-    ...             return loss_value
-    ...         return -loss_value
-    ...
-    >>> X = np.random.randn(250, 25).astype('float32')
-    >>> y = (X.dot(np.ones(25)) > 0).astype(int)
-    >>> module = nn.Sequential(
-    ...     nn.Linear(25, 25),
-    ...     nn.ReLU(),
-    ...     nn.Linear(25,
-    ...     2),
-    ...     nn.Softmax(dim=1)
-    ... )
-    >>> net = ScoredNet(module)
-    >>> grid_searcher = GridSearchCV(
-    ...     net, {'lr': [1e-2, 1e-3], 'batch_size': [8, 16]}
-    ... )
-    >>> grid_searcher.fit(X, y)
-    >>> best_net = grid_searcher.best_estimator_
-    >>> print(best_net.score(X, y))
+    ...     def score(self, X, y=None):
+    ...         return loss_scoring(self, X, y)
 
     Parameters
     ----------

--- a/skorch/scoring.py
+++ b/skorch/scoring.py
@@ -42,6 +42,7 @@ def loss_scoring(net: NeuralNet, X, y=None):
     ----------
     net : skorch.NeuralNet
         A fitted Skorch :class:`.NeuralNet` object.
+
     X : input data, compatible with skorch.dataset.Dataset
         By default, you should be able to pass:
             * numpy arrays
@@ -53,6 +54,7 @@ def loss_scoring(net: NeuralNet, X, y=None):
             * a Dataset
         If this doesn't work with your data, you have to pass a
         ``Dataset`` that can deal with the data.
+
     y : target data, compatible with skorch.dataset.Dataset
         The same data types as for ``X`` are supported. If your X is a Dataset
         that contains the target, ``y`` may be set to None.

--- a/skorch/scoring.py
+++ b/skorch/scoring.py
@@ -55,7 +55,7 @@ def loss_scoring(net: NeuralNet, X, y=None):
     for data in iterator:
         Xi, yi = unpack_data(data)
         yp = net.evaluation_step(Xi, training=False)
-        loss = net.criterion_(yp, yi)
+        loss = net.get_loss(yp, yi)
         if reduction == "none":
             loss_value = loss.detach().cpu().numpy()
         else:

--- a/skorch/scoring.py
+++ b/skorch/scoring.py
@@ -24,13 +24,14 @@ def loss_scoring(net: NeuralNet, X, y=None, sample_weight=None):
 
     X : input data, compatible with skorch.dataset.Dataset
         By default, you should be able to pass:
-            * numpy arrays
-            * torch tensors
-            * pandas DataFrame or Series
-            * scipy sparse CSR matrices
-            * a dictionary of the former three
-            * a list/tuple of the former three
-            * a Dataset
+
+          * numpy arrays
+          * torch tensors
+          * pandas DataFrame or Series
+          * scipy sparse CSR matrices
+          * a dictionary of the former three
+          * a list/tuple of the former three
+          * a Dataset
         If this doesn't work with your data, you have to pass a
         ``Dataset`` that can deal with the data.
 
@@ -44,8 +45,8 @@ def loss_scoring(net: NeuralNet, X, y=None, sample_weight=None):
     Returns
     -------
     loss_value : float32 or np.ndarray
-        Return type depends on net.criterion_.reduction, and will be a float if
-        reduction is ``'sum'`` or ``'mean'``. If reduction is ``'none'`` then
+        Return type depends on ``net.criterion_.reduction``, and will be a float
+        if reduction is ``'sum'`` or ``'mean'``. If reduction is ``'none'`` then
         this function returns a ``np.ndarray`` object.
 
     """

--- a/skorch/scoring.py
+++ b/skorch/scoring.py
@@ -62,7 +62,7 @@ def loss_scoring(net: NeuralNet, X, y=None, sample_weight=None):
     reduction = net.criterion_.reduction
     assert reduction in ["mean", "sum", "none",], (
         "Expected one of 'mean', 'sum' or 'none' "
-        f"for reduction but got {reduction}."
+        "for reduction but got {reduction}.".format(reduction=reduction)
     )
     for data in iterator:
         Xi, yi = unpack_data(data)

--- a/skorch/scoring.py
+++ b/skorch/scoring.py
@@ -35,6 +35,8 @@ def loss_scoring(net: NeuralNet, X, y=None):
     ...     net, {'lr': [1e-2, 1e-3], 'batch_size': [8, 16]}
     ... )
     >>> grid_searcher.fit(X, y)
+    >>> best_net = grid_searcher.best_estimator_
+    >>> print(best_net.score(X, y))
 
     Parameters
     ----------

--- a/skorch/scoring.py
+++ b/skorch/scoring.py
@@ -34,10 +34,6 @@ class _CriterionAccumulator:
         }
 
     def __call__(self, input, target):
-        # if not isinstance(input, torch.Tensor):
-        #     input = to_tensor(input, "cpu")
-        # if not isinstance(target, torch.Tensor):
-        #     target = to_tensor(target, "cpu")
         loss = self.criterion(input, target)
 
         batch_size = target.size(0)

--- a/skorch/scoring.py
+++ b/skorch/scoring.py
@@ -7,9 +7,6 @@ def loss_scoring(net: NeuralNet, X, y=None):
     """Calculate score using the criterion of the net
     
     Use the exact same logic as during model training to calculate the score.
-    loss_scoring(net, X, y=None)
-
-    Computes the loss of ``net`` on data (``X``, ``y``).
 
     This function can be used to implement the ``score`` method for a
     :class:`.NeuralNet` through sub-classing. This is useful, for example, when

--- a/skorch/scoring.py
+++ b/skorch/scoring.py
@@ -1,13 +1,6 @@
-from collections import defaultdict
 import numpy as np
-import torch
-from torch import nn, optim
-from torch.utils.data import DataLoader, TensorDataset
-
 from skorch.net import NeuralNet
-from skorch.callbacks import PassthroughScoring
 from skorch.dataset import unpack_data
-from skorch.utils import to_tensor
 
 
 class _CriterionAccumulator:

--- a/skorch/scoring.py
+++ b/skorch/scoring.py
@@ -4,7 +4,9 @@ from skorch.dataset import unpack_data
 
 
 def loss_scoring(net: NeuralNet, X, y=None):
-    """
+    """Calculate score using the criterion of the net
+    
+    Use the exact same logic as during model training to calculate the score.
     loss_scoring(net, X, y=None)
 
     Computes the loss of ``net`` on data (``X``, ``y``).

--- a/skorch/scoring.py
+++ b/skorch/scoring.py
@@ -1,0 +1,115 @@
+from collections import defaultdict
+import numpy as np
+import torch
+from torch import nn, optim
+from torch.utils.data import DataLoader, TensorDataset
+
+from skorch.net import NeuralNet
+from skorch.callbacks import PassthroughScoring
+from skorch.dataset import unpack_data
+from skorch.utils import to_tensor
+
+
+class _CriterionAccumulator:
+    def __init__(self, criterion):
+        """
+        _CriterionAccumulator(criterion)
+
+        Parameters
+        ----------
+        criterion: PyTorch loss function
+            e.g., nn.MSELoss or nn.NLLLoss
+        """
+        self.criterion = criterion
+        reduction = self._get_reduction()
+        assert reduction in ["mean", "sum", "none"], (
+            f"Expected reduction to be one of 'mean', 'sum' or "
+            f"'none' but got {reduction}."
+        )
+        self.log = {"loss": [], "batch_size": []}
+        self._reduce = {
+            "sum": self._reduce_sum,
+            "mean": self._reduce_mean,
+            "none": self._reduce_none,
+        }
+
+    def __call__(self, input, target):
+        # if not isinstance(input, torch.Tensor):
+        #     input = to_tensor(input, "cpu")
+        # if not isinstance(target, torch.Tensor):
+        #     target = to_tensor(target, "cpu")
+        loss = self.criterion(input, target)
+
+        batch_size = target.size(0)
+        self.log["batch_size"].append(batch_size)
+
+        # If criterion.reduction is 'none', loss.item() can fail,
+        # because item method requires scalar input.
+        if self._get_reduction() == "none":
+            loss = loss.detach().cpu().numpy()
+            self.log["loss"].append(loss)
+        else:
+            self.log["loss"].append(loss.item())
+
+    def reduce(self):
+        reduction = self._get_reduction()
+        return self._reduce[reduction]()
+
+    def _get_reduction(self):
+        return self.criterion.reduction
+
+    def _reduce_sum(self):
+        return np.sum(self.log["loss"])
+
+    def _reduce_mean(self):
+        losses = np.array(self.log["loss"])
+        batch_sizes = np.array(self.log["batch_size"])
+        n_examples = batch_sizes.sum()
+        loss_value = np.sum(losses * batch_sizes) / n_examples
+        return loss_value
+
+    def _reduce_none(self):
+        return np.concatenate(self.log["loss"], 0)
+
+
+def loss_scoring(net: NeuralNet, X, y=None):
+    """
+    loss_scoring(net, X, y=None)
+
+    Parameters
+    ----------
+    net : skorch.NeuralNet
+    X : input data, compatible with skorch.dataset.Dataset
+        By default, you should be able to pass:
+            * numpy arrays
+            * torch tensors
+            * pandas DataFrame or Series
+            * scipy sparse CSR matrices
+            * a dictionary of the former three
+            * a list/tuple of the former three
+            * a Dataset
+        If this doesn't work with your data, you have to pass a
+        ``Dataset`` that can deal with the data.
+    y : target data, compatible with skorch.dataset.Dataset
+        The same data types as for ``X`` are supported. If your X is a Dataset
+        that contains the target, ``y`` may be set to None.
+
+    Returns
+    -------
+    loss_value : float32???? or np.ndarray
+        Return type depends on net.criterion_.reduction, and will be a float if
+        reduction is ``'sum'`` or ``'mean'``. If reduction is ``'none'`` then
+        this function returns a ``np.ndarray`` object.
+    """
+    net.check_is_fitted()
+
+    criterion = _CriterionAccumulator(net.criterion_)
+    dataset = net.get_dataset(X, y)
+    iterator = net.get_iterator(dataset, training=False)
+
+    for data in iterator:
+        Xi, yi = unpack_data(data)
+        yp = net.evaluation_step(Xi, training=False)
+        criterion(yp, yi)
+    loss_value = criterion.reduce()
+    return loss_value

--- a/skorch/tests/test_scoring.py
+++ b/skorch/tests/test_scoring.py
@@ -1,0 +1,130 @@
+import pytest
+import numpy as np
+import torch
+from sklearn.base import clone
+from torch import nn
+
+# from skorch.scoring import _CriterionAccumulator, loss_scoring
+
+
+class Test_ScoreAccumulator:
+    @pytest.fixture(scope="module", params=["rgr", "clf"])
+    def data_type(self, request):
+        return request.param
+
+    @pytest.fixture(scope="module")
+    def output_data(self, data_type):
+        if data_type == "clf":
+            pred = torch.softmax(torch.randn(50, 2), dim=1)
+            target = torch.randint(2, size=(50,))
+            return pred, target
+        if data_type == "rgr":
+            target = torch.arange(15) + torch.randn(15)
+            pred = target + torch.randn(target.size(0))
+            return pred, target
+        raise ValueError("Unrecognized data type")
+
+    @pytest.fixture(scope="module", params=["mean", "sum", "none"])
+    def reduction(self, request):
+        return request.param
+
+    @pytest.fixture(scope="module")
+    def criterion_fn(self, data_type):
+        if data_type == "clf":
+            return nn.CrossEntropyLoss
+        if data_type == "rgr":
+            return nn.MSELoss
+        raise ValueError(f"data_type not recognized: {data_type}.")
+
+    @pytest.fixture(scope="module")
+    def accumulator(self, criterion_fn, reduction):
+        from skorch.scoring import _CriterionAccumulator
+
+        criterion = criterion_fn(reduction=reduction)
+        return _CriterionAccumulator(criterion)
+
+    def test_accumulate(self, accumulator, output_data):
+        pred, target = output_data
+        accumulator(pred, target)
+
+    def test_reduce(self, accumulator, output_data):
+        pred, target = output_data
+        accumulator(pred, target)
+        accumulator(pred, target)
+        output = accumulator.reduce()
+        if accumulator._get_reduction() == "none":
+            assert isinstance(output, np.ndarray)
+        else:
+            assert np.isscalar(output)
+
+
+class TestLossScoring:
+    @pytest.fixture(scope="module")
+    def data(self, classifier_data):
+        return classifier_data
+
+    @pytest.fixture(scope="module")
+    def net_cls(self):
+        from skorch import NeuralNetClassifier
+
+        return NeuralNetClassifier
+
+    @pytest.fixture(scope="module")
+    def module_cls(self, classifier_module):
+        return classifier_module
+
+    @pytest.fixture(scope="module")
+    def net(self, net_cls, module_cls):
+        return net_cls(module_cls, lr=0.1)
+
+    @pytest.fixture(scope="module")
+    def net_fit(self, net, data):
+        X, y = data
+        return net.fit(X, y)
+
+    @pytest.fixture(scope="module")
+    def loss_scoring_fn(self):
+        from skorch.scoring import loss_scoring
+
+        return loss_scoring
+
+    @pytest.fixture(scope="module")
+    def scored_net_cls(self, net_cls, loss_scoring_fn):
+        class ScoredNet(net_cls):
+            def score(self, X, y=None):
+                return loss_scoring_fn(self, X, y)
+
+        return ScoredNet
+
+    @pytest.fixture(scope="module")
+    def scored_net(self, scored_net_cls, module_cls):
+        return scored_net_cls(module_cls, lr=0.1)
+
+    @pytest.fixture(scope="module")
+    def scored_net_fit(self, scored_net, data):
+        X, y = data
+        return scored_net.fit(X, y)
+
+    def test_score_unfit_net_raises(self, loss_scoring_fn, net, data):
+        from skorch.exceptions import NotInitializedError
+
+        X, y = data
+        with pytest.raises(NotInitializedError):
+            loss_scoring_fn(net, X, y)
+
+    def test_score_unfit_scored_net_raises(self, scored_net, data):
+        from skorch.exceptions import NotInitializedError
+
+        X, y = data
+        with pytest.raises(NotInitializedError):
+            scored_net.score(X, y)
+
+    def test_scored_net_output_type(self, scored_net_fit, data):
+        X, y = data
+        score_value = scored_net_fit.score(X, y)
+        assert np.isscalar(score_value)
+
+    def test_score_on_net_fit(self, loss_scoring_fn, net_fit, data):
+        X, y = data
+        score_value = loss_scoring_fn(net_fit, X, y)
+        assert np.isscalar(score_value)

--- a/skorch/tests/test_scoring.py
+++ b/skorch/tests/test_scoring.py
@@ -34,7 +34,9 @@ class Test_ScoreAccumulator:
             return nn.CrossEntropyLoss
         if data_type == "rgr":
             return nn.MSELoss
-        raise ValueError(f"data_type not recognized: {data_type}.")
+        raise ValueError(
+            "data_type not recognized: {data_type}.".format(data_type=data_type)
+        )
 
     @pytest.fixture(scope="module")
     def accumulator(self, criterion_fn, reduction):

--- a/skorch/tests/test_scoring.py
+++ b/skorch/tests/test_scoring.py
@@ -9,13 +9,6 @@ class TestLossScoring:
         return classifier_data
 
     @pytest.fixture(scope="module")
-    def val_data(self, classifier_data):
-        X_train, y_train = classifier_data
-        X_val = np.random.randn(3, X_train.shape[1]).astype("float32")
-        y_val = np.random.randint(2, size=(3,))
-        return X_val, y_val
-
-    @pytest.fixture(scope="module")
     def net_cls(self):
         from skorch import NeuralNetClassifier
 
@@ -81,11 +74,11 @@ class TestLossScoring:
         score_value = loss_scoring_fn(net_fit, X, y)
         assert np.isscalar(score_value)
 
-    def test_scored_net_matches_criterion_value(self, scored_net_fit, val_data):
-        X_val, y_val = val_data
-        score_value = scored_net_fit.score(X_val, y_val)
+    def test_scored_net_matches_criterion_value(self, scored_net_fit, data):
+        X, y = data
+        score_value = scored_net_fit.score(X, y)
         criterion = scored_net_fit.criterion_
-        y_val = torch.as_tensor(y_val).long()
-        y_val_proba = torch.as_tensor(scored_net_fit.predict_proba(X_val))
-        loss_value = criterion(y_val_proba, y_val)
+        y = torch.as_tensor(y).long()
+        y_val_proba = torch.as_tensor(scored_net_fit.predict_proba(X))
+        loss_value = criterion(y_val_proba, y)
         assert score_value == loss_value.item()

--- a/skorch/tests/test_scoring.py
+++ b/skorch/tests/test_scoring.py
@@ -101,9 +101,12 @@ class TestLossScoring:
         net = scored_net_cls(
             module_cls, lr=0.01, criterion__reduction=reduction
         ).fit(X, y)
+        net.set_params(criterion__reduction="sum")
+        loss_value = net.score(X, y)
         net.set_params(criterion__reduction="none")
         output = net.score(X, y)
         assert output.shape[0] == X.shape[0]
+        assert np.allclose(output.sum(), loss_value)
 
     def test_score_unknown_reduction_raises(
         self, loss_scoring_fn, net_fit, data

--- a/skorch/tests/test_scoring.py
+++ b/skorch/tests/test_scoring.py
@@ -8,6 +8,10 @@ class TestLossScoring:
     def data(self, classifier_data):
         return classifier_data
 
+    @pytest.fixture(scope="module", params=["mean", "sum"])
+    def reduction(self, request):
+        return request.param
+
     @pytest.fixture(scope="module")
     def net_cls(self):
         from skorch import NeuralNetClassifier
@@ -19,8 +23,8 @@ class TestLossScoring:
         return classifier_module
 
     @pytest.fixture(scope="module")
-    def net(self, net_cls, module_cls):
-        return net_cls(module_cls, lr=0.1)
+    def net(self, net_cls, module_cls, reduction):
+        return net_cls(module_cls, lr=0.1, criterion__reduction=reduction)
 
     @pytest.fixture(scope="module")
     def net_fit(self, net, data):
@@ -42,8 +46,10 @@ class TestLossScoring:
         return ScoredNet
 
     @pytest.fixture(scope="module")
-    def scored_net(self, scored_net_cls, module_cls):
-        return scored_net_cls(module_cls, lr=0.01)
+    def scored_net(self, scored_net_cls, module_cls, reduction):
+        return scored_net_cls(
+            module_cls, lr=0.01, criterion__reduction=reduction
+        )
 
     @pytest.fixture(scope="module")
     def scored_net_fit(self, scored_net, data):
@@ -64,6 +70,13 @@ class TestLossScoring:
         with pytest.raises(NotInitializedError):
             scored_net.score(X, y)
 
+    def test_nonnull_sample_weight_raises(self, loss_scoring_fn, net_fit, data):
+        X, y = data
+        with pytest.raises(NotImplementedError):
+            loss_scoring_fn(
+                net_fit, X, y, sample_weight=np.random.rand(X.shape[0])
+            )
+
     def test_scored_net_output_type(self, scored_net_fit, data):
         X, y = data
         score_value = scored_net_fit.score(X, y)
@@ -76,9 +89,26 @@ class TestLossScoring:
 
     def test_scored_net_matches_criterion_value(self, scored_net_fit, data):
         X, y = data
-        score_value = scored_net_fit.score(X, y)
-        criterion = scored_net_fit.criterion_
-        y = torch.as_tensor(y).long()
         y_val_proba = torch.as_tensor(scored_net_fit.predict_proba(X))
-        loss_value = criterion(y_val_proba, y)
-        assert score_value == loss_value.item()
+        loss_value = scored_net_fit.get_loss(y_val_proba, y)
+        score_value = scored_net_fit.score(X, y)
+        assert np.allclose(score_value, loss_value.item())
+
+    def test_scored_net_with_reduction_none(
+        self, scored_net_cls, module_cls, reduction, data
+    ):
+        X, y = data
+        net = scored_net_cls(
+            module_cls, lr=0.01, criterion__reduction=reduction
+        ).fit(X, y)
+        net.set_params(criterion__reduction="none")
+        output = net.score(X, y)
+        assert output.shape[0] == X.shape[0]
+
+    def test_score_unknown_reduction_raises(
+        self, loss_scoring_fn, net_fit, data
+    ):
+        X, y = data
+        net_fit.set_params(criterion__reduction="unk")
+        with pytest.raises(AssertionError):
+            loss_scoring_fn(net_fit, X, y)

--- a/skorch/tests/test_scoring.py
+++ b/skorch/tests/test_scoring.py
@@ -110,5 +110,5 @@ class TestLossScoring:
     ):
         X, y = data
         net_fit.set_params(criterion__reduction="unk")
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError, match="for reduction but got"):
             loss_scoring_fn(net_fit, X, y)

--- a/skorch/tests/test_scoring.py
+++ b/skorch/tests/test_scoring.py
@@ -1,10 +1,7 @@
 import pytest
 import numpy as np
 import torch
-from sklearn.base import clone
 from torch import nn
-
-# from skorch.scoring import _CriterionAccumulator, loss_scoring
 
 
 class Test_ScoreAccumulator:

--- a/skorch/tests/test_scoring.py
+++ b/skorch/tests/test_scoring.py
@@ -19,7 +19,7 @@ class Test_ScoreAccumulator:
             target = torch.randint(2, size=(50,))
             return pred, target
         if data_type == "rgr":
-            target = torch.arange(15) + torch.randn(15)
+            target = torch.rand(15)
             pred = target + torch.randn(target.size(0))
             return pred, target
         raise ValueError("Unrecognized data type")

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -544,29 +544,10 @@ class TeeGenerator:
     generator more than once.
 
     """
+
     def __init__(self, gen):
         self.gen = gen
 
     def __iter__(self):
         self.gen, it = tee(self.gen)
         yield from it
-
-
-def loss_scoring(net: skorch.NeuralNet, X, y=None, **fit_params):
-    from skorch.history import History
-    from skorch.dataset import get_len, unpack_data, uses_placeholder_y
-
-    net.check_data(X, y)
-    dataset = net.get_dataset(X, y)
-    history = History()
-    is_placeholder_y = uses_placeholder_y(dataset)
-    batch_count = 0
-    for data in net.get_iterator(dataset, training=False):
-        Xi, yi = unpack_data(data)
-        yi_res = yi if not is_placeholder_y else None
-        step = net.validation_step(Xi, yi, **fit_params)
-        history.record_batch("score" + "_loss", step["loss"].item())
-        history.record_batch("score" + "_batch_size", get_len(Xi))
-        batch_count += 1
-    history.record("score" + "_batch_count", batch_count)
-    return history

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -544,7 +544,6 @@ class TeeGenerator:
     generator more than once.
 
     """
-
     def __init__(self, gen):
         self.gen = gen
 

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -550,3 +550,23 @@ class TeeGenerator:
     def __iter__(self):
         self.gen, it = tee(self.gen)
         yield from it
+
+
+def loss_scoring(net: skorch.NeuralNet, X, y=None, **fit_params):
+    from skorch.history import History
+    from skorch.dataset import get_len, unpack_data, uses_placeholder_y
+
+    net.check_data(X, y)
+    dataset = net.get_dataset(X, y)
+    history = History()
+    is_placeholder_y = uses_placeholder_y(dataset)
+    batch_count = 0
+    for data in net.get_iterator(dataset, training=False):
+        Xi, yi = unpack_data(data)
+        yi_res = yi if not is_placeholder_y else None
+        step = net.validation_step(Xi, yi, **fit_params)
+        history.record_batch("score" + "_loss", step["loss"].item())
+        history.record_batch("score" + "_batch_size", get_len(Xi))
+        batch_count += 1
+    history.record("score" + "_batch_count", batch_count)
+    return history


### PR DESCRIPTION
This addresses issue #628 . Tests could probably be more complete. @BenjaminBossan , please let me know if/how they could be fleshed out to be more comprehensive. 

As a side note, I have limited familiarity with `PassThroughScoring`, but it seemed, in a way, like overkill. This could be because I'm not properly understanding some edge cases. Anyway, at the time, I thought it was sensible to write an accumulator class that handles the reduction of the batch-level statistics for `criterion`. In case this isn't ideal, is there an easy way to convert the current code to something that uses Skorch tools (*e.g.,* `PassThroughScoring`)?