### PR TITLE
ENH: set default parameters of module.__init__ to be model parameters

### DIFF
--- a/skorch/net.py
+++ b/skorch/net.py
@@ -32,6 +32,7 @@ from skorch.utils import params_for
 from skorch.utils import to_device
 from skorch.utils import to_numpy
 from skorch.utils import to_tensor
+from skorch.utils import get_default_args
 
 
 _PYTORCH_COMPONENTS = {'criterion', 'module', 'optimizer'}
@@ -219,6 +220,8 @@ class NeuralNet:
             **kwargs
     ):
         self.module = module
+        module_defaults = get_default_args(module.__init__)
+
         self.criterion = criterion
         self.optimizer = optimizer
         self.lr = lr
@@ -238,6 +241,12 @@ class NeuralNet:
         initialized = kwargs.pop('initialized_', False)
         virtual_params = kwargs.pop('virtual_params_', dict())
 
+        new_params = {
+            "module__" + k: v
+            for k, v in module_defaults.items()
+            if not hasattr(self, "module__" + k)
+        }
+        vars(self).update(new_params)
         kwargs = self._check_kwargs(kwargs)
         vars(self).update(kwargs)
 

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2644,7 +2644,6 @@ def test_gridsearch_defaults():
     params = {"module__hidden": [3, 4, 5]}
     search = GridSearchCV(model, params)
     X, y = make_classification(n_features=80)
-    X = X.astype("float32")
-    y = y.astype("float32")
+    X, y = X.astype("float32"), y.astype("float32")
     search.fit(X, y)
     assert search.best_score_ >= 0

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -4,6 +4,7 @@ Should not have any dependency on other skorch packages.
 
 """
 
+import inspect
 from collections.abc import Sequence
 from contextlib import contextmanager
 from distutils.version import LooseVersion
@@ -564,3 +565,12 @@ class TeeGenerator:
     def __iter__(self):
         self.gen, it = tee(self.gen)
         yield from it
+
+
+def get_default_args(func):
+    signature = inspect.signature(func)
+    return {
+        k: v.default
+        for k, v in signature.parameters.items()
+        if v.default is not inspect.Parameter.empty
+    }


### PR DESCRIPTION
**What does this PR implement?**
It sets the default arguments of `module.__init__` to be model parameters unless the user overrides them. This allows for parameters to be set even if they're not specified at initialization:



``` python
from skorch import NeuralNetClassifier
import torch.nn as nn

class Mod(torch.nn.Module):
    def __init__(self, features=80, hidden=3):
        super().__init__()
        self.l1 = torch.nn.Linear(features, hidden)
        self.l2 = torch.nn.Linear(hidden, 1)

    def forward(self, x):
        return torch.sign(self.l2(self.l1(x)))

model = NeuralNetClassifier(Mod)
model.set_params(module__hidden=5)
```

Before, `module__hidden` had to passed to `NeuralNetClassifier.__init__` to be recorded as a parameter. Now, it's included by default. This PR allows for a better searching:

``` python
from sklearn.model_selection import GridSearchCV
from sklearn.datasets import make_classification

model = NeuralNetClassifier(Mod, max_epochs=1, criterion=nn.MSELoss)
params = {"module__hidden": [3, 4, 5]}
search = GridSearchCV(model, params)
X, y = make_classification(n_features=80)
X, y = X.astype("float32"), y.astype("float32")
search.fit(X, y)
```

**References issues/PRs**
This PR resolves #667.