### PR TITLE
Add PyTorch version 1.6.0 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 dist: xenial
 python:
-  - "3.7.5"
+  - "3.7"
   - "3.6"
   - "3.5"  # TODO: drop support in 0.10.0
 env:
@@ -11,6 +11,10 @@ env:
   - PYTORCH_VERSION="1.4.0"
   - PYTORCH_VERSION="1.5.0"
   - PYTORCH_VERSION="1.6.0"
+jobs:
+  exclude:
+  - python: "3.5"
+    env: PYTORCH_VERSION="1.6.0"
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ python:
   - "3.6"
   - "3.5"  # TODO: drop support in 0.10.0
 env:
-  - PYTORCH_VERSION="1.1.0"
-  - PYTORCH_VERSION="1.2.0"
   - PYTORCH_VERSION="1.3.1"
   - PYTORCH_VERSION="1.4.0"
-  - PYTORCH_VERSION="1.5.0"
+  - PYTORCH_VERSION="1.5.1"
   - PYTORCH_VERSION="1.6.0"
 jobs:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - PYTORCH_VERSION="1.3.1"
   - PYTORCH_VERSION="1.4.0"
   - PYTORCH_VERSION="1.5.0"
+  - PYTORCH_VERSION="1.6.0"
 
 cache:
   apt: true

--- a/README.rst
+++ b/README.rst
@@ -240,6 +240,7 @@ PyTorch versions:
 - 1.3.1
 - 1.4.0
 - 1.5.0
+- 1.6.0
 
 In general, this should work (assuming CUDA 9):
 

--- a/README.rst
+++ b/README.rst
@@ -232,22 +232,25 @@ PyTorch
 PyTorch is not covered by the dependencies, since the PyTorch version
 you need is dependent on your OS and device. For installation
 instructions for PyTorch, visit the `PyTorch website
-<http://pytorch.org/>`__. skorch officially supports the following
-PyTorch versions:
+<http://pytorch.org/>`__. skorch officially supports the last four
+minor PyTorch versions, which currently are:
 
-- 1.1.0
-- 1.2.0
 - 1.3.1
 - 1.4.0
-- 1.5.0
+- 1.5.1
 - 1.6.0
 
-In general, this should work (assuming CUDA 9):
+However, that doesn't mean that older versions don't work, just that
+they aren't tested. Since skorch mostly relies on the stable part of
+the PyTorch API, older PyTorch versions should work fine.
+
+In general, running this to install PyTorch should work (assuming CUDA
+10.2):
 
 .. code:: bash
 
     # using conda:
-    conda install pytorch cudatoolkit=9 -c pytorch
+    conda install pytorch cudatoolkit==10.2 -c pytorch
     # using pip
     pip install torch
 

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -94,6 +94,8 @@ PyTorch versions:
 - 1.2.0
 - 1.3.1
 - 1.4.0
+- 1.5.0
+- 1.6.0
 
 In general, this should work (assuming CUDA 9):
 

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -87,21 +87,24 @@ PyTorch
 PyTorch is not covered by the dependencies, since the PyTorch version
 you need is dependent on your OS and device. For installation
 instructions for PyTorch, visit the `PyTorch website
-<http://pytorch.org/>`__. skorch officially supports the following
-PyTorch versions:
+<http://pytorch.org/>`__. skorch officially supports the last four
+minor PyTorch versions, which currently are:
 
-- 1.1.0
-- 1.2.0
 - 1.3.1
 - 1.4.0
-- 1.5.0
+- 1.5.1
 - 1.6.0
 
-In general, this should work (assuming CUDA 9):
+However, that doesn't mean that older versions don't work, just that
+they aren't tested. Since skorch mostly relies on the stable part of
+the PyTorch API, older PyTorch versions should work fine.
+
+In general, running this to install PyTorch should work (assuming CUDA
+10.2):
 
 .. code:: bash
 
     # using conda:
-    conda install pytorch cudatoolkit=9 -c pytorch
+    conda install pytorch cudatoolkit==10.2 -c pytorch
     # using pip
     pip install torch

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -6,7 +6,6 @@ Only contains tests that are specific for classifier subclasses.
 
 from unittest.mock import Mock
 
-from flaky import flaky
 import numpy as np
 import pytest
 import torch
@@ -215,7 +214,6 @@ class TestNeuralNetBinaryClassifier:
                "before using this method.")
         assert exc.value.args[0] == msg
 
-    @flaky(max_runs=3)
     def test_net_learns(self, net_cls, module_cls, data):
         X, y = data
         net = net_cls(

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -292,7 +292,6 @@ class TestNeuralNet:
             args = check.call_args_list[0][0][1]
             assert args == attributes
 
-    @flaky(max_runs=3)
     def test_net_learns(self, net_cls, module_cls, data):
         X, y = data
         net = net_cls(
@@ -2755,7 +2754,6 @@ class TestNetSparseInput:
         return np.array(
             [1 if (' def ' in x) or (' assert ' in x) else 0 for x in X])
 
-    @flaky(max_runs=3)
     def test_fit_sparse_csr_learns(self, model, X, y):
         model.fit(X, y)
         net = model.steps[-1][1]

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -14,6 +14,7 @@ import pickle
 from unittest.mock import Mock
 from unittest.mock import patch
 import sys
+import time
 from contextlib import ExitStack
 
 from flaky import flaky
@@ -2208,8 +2209,11 @@ class TestNeuralNet:
         assert net.history[:, "train_batch_count"] == [train_batch_count]
         assert net.history[:, "valid_batch_count"] == [valid_batch_count]
 
-    @flaky(max_runs=3)
+    @flaky(max_runs=5)
     def test_fit_lbfgs_optimizer(self, net_cls, module_cls, data):
+        # need to randomize the seed, otherwise flaky always runs with
+        # the exact same seed
+        torch.manual_seed(time.time_ns())
         X, y = data
         net = net_cls(
             module_cls,
@@ -2763,7 +2767,6 @@ class TestNetSparseInput:
         assert score_start > 1.25 * score_end
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="no cuda device")
-    @flaky(max_runs=3)
     def test_fit_sparse_csr_learns_cuda(self, model, X, y):
         model.set_params(net__device='cuda')
         model.fit(X, y)

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2213,7 +2213,7 @@ class TestNeuralNet:
     def test_fit_lbfgs_optimizer(self, net_cls, module_cls, data):
         # need to randomize the seed, otherwise flaky always runs with
         # the exact same seed
-        torch.manual_seed(time.time_ns())
+        torch.manual_seed(int(time.time()))
         X, y = data
         net = net_cls(
             module_cls,

--- a/skorch/tests/test_regressor.py
+++ b/skorch/tests/test_regressor.py
@@ -4,11 +4,9 @@ Only contains tests that are specific for regressor subclasses.
 
 """
 
-from flaky import flaky
 import numpy as np
 import pytest
 from sklearn.base import clone
-import torch
 
 from skorch.tests.conftest import INFERENCE_METHODS
 
@@ -77,7 +75,6 @@ class TestNeuralNetRegressor:
                "before using this method.")
         assert exc.value.args[0] == msg
 
-    @flaky(max_runs=3)
     def test_net_learns(self, net, net_cls, data, module_cls):
         X, y = data
         net = net_cls(


### PR DESCRIPTION
Also document the support of that version.

@ottonemo tested PyTorch 1.6.0 with CUDA and it worked, so this should also work without further modification.

I wonder if we should start dropping support for older PyTorch versions. The main reason would be to accelerate CI. What are your thoughts?