### PR TITLE
Fix a TypeError that occurred when using predefined_split

### DIFF
--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2278,15 +2278,18 @@ class TestNeuralNet:
             flatten(net.history[:, 'batches', :, 'train_loss']))
         assert np.allclose(side_effect[2::3], expected_losses)
 
-    def test_predefined_split(self, net_cls, module_cls, data):
-        from skorch.dataset import Dataset
+    @pytest.fixture
+    def predefined_split(self):
         from skorch.helper import predefined_split
+        return predefined_split
 
+    def test_predefined_split(
+            self, net_cls, module_cls, data, predefined_split, dataset_cls):
         train_loader_mock = Mock(side_effect=torch.utils.data.DataLoader)
         valid_loader_mock = Mock(side_effect=torch.utils.data.DataLoader)
 
-        train_ds = Dataset(*data)
-        valid_ds = Dataset(*data)
+        train_ds = dataset_cls(*data)
+        valid_ds = dataset_cls(*data)
 
         net = net_cls(
             module_cls, max_epochs=1,
@@ -2302,6 +2305,22 @@ class TestNeuralNet:
 
         assert train_loader_ds == train_ds
         assert valid_loader_ds == valid_ds
+
+    def test_predefined_split_with_y(
+            self, net_cls, module_cls, data, predefined_split, dataset_cls):
+        # A change in the signature of utils._make_split in #646 led
+        # to a bug reported in #681, namely `TypeError: _make_split()
+        # got multiple values for argument 'valid_ds'`. This is a test
+        # for the bug.
+        X, y = data
+        X_train, y_train, X_valid, y_valid = X[:800], y[:800], X[800:], y[800:]
+        valid_ds = dataset_cls(X_valid, y_valid)
+        net = net_cls(
+            module_cls,
+            max_epochs=1,
+            train_split=predefined_split(valid_ds),
+        )
+        net.fit(X_train, y_train)
 
     def test_set_lr_at_runtime_doesnt_reinitialize(self, net_fit):
         with patch('skorch.NeuralNet.initialize_optimizer') as f:

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -491,7 +491,7 @@ class FirstStepAccumulator:
         return self.step
 
 
-def _make_split(X, valid_ds, **kwargs):
+def _make_split(X, y=None, valid_ds=None, **kwargs):
     """Used by ``predefined_split`` to allow for pickling"""
     return X, valid_ds
 


### PR DESCRIPTION
Fixes #681

This bug was introduced by PR #646 after a change in the function
signature of `utils._make_split`. Here the bug is fixed by returning to
the old signature but giving default values for `valid_ds` and `y`, so
that the desired behavior introduced by #646 is still possible.

A test is introduced to catch this bug.

As a cleanup, the unrelated test_predefined_split now uses the
already defined `dataset_cls` fixture instead of importing `Dataset` again.

@Dewald928 this should fix your bug. I tested your code example
and it worked.