### PR TITLE
Drop official python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: xenial
+dist: focal
 python:
   - "3.8"
   - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,10 @@ python:
   - "3.7"
   - "3.6"
 env:
-  - PYTORCH_VERSION="1.3.1"
   - PYTORCH_VERSION="1.4.0"
   - PYTORCH_VERSION="1.5.1"
   - PYTORCH_VERSION="1.6.0"
-jobs:
-  exclude:
-  - python: "3.8"
-    env: PYTORCH_VERSION="1.3.1"
+  - PYTORCH_VERSION="1.7.0"
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ env:
   - PYTORCH_VERSION="1.4.0"
   - PYTORCH_VERSION="1.5.1"
   - PYTORCH_VERSION="1.6.0"
+jobs:
+  exclude:
+  - python: "3.8"
+    env: PYTORCH_VERSION="1.3.1"
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 language: python
 dist: xenial
 python:
+  - "3.8"
   - "3.7"
   - "3.6"
-  - "3.5"  # TODO: drop support in 0.10.0
 env:
   - PYTORCH_VERSION="1.3.1"
   - PYTORCH_VERSION="1.4.0"
   - PYTORCH_VERSION="1.5.1"
   - PYTORCH_VERSION="1.6.0"
-jobs:
-  exclude:
-  - python: "3.5"
-    env: PYTORCH_VERSION="1.6.0"
 
 cache:
   apt: true

--- a/README.rst
+++ b/README.rst
@@ -235,10 +235,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.3.1
 - 1.4.0
 - 1.5.1
 - 1.6.0
+- 1.7.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -90,10 +90,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.3.1
 - 1.4.0
 - 1.5.1
 - 1.6.0
+- 1.7.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of

--- a/skorch/__init__.py
+++ b/skorch/__init__.py
@@ -16,15 +16,6 @@ from . import callbacks
 
 MIN_TORCH_VERSION = '1.1.0'
 
-
-# TODO: remove in skorch 0.10.0
-if sys.version_info < (3, 6):
-    warnings.warn(
-        "Official support for Python 3.5 will be dropped starting from "
-        "skorch version 0.10.0",
-        FutureWarning,
-    )
-
 try:
     # pylint: disable=wrong-import-position
     import torch

--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -115,16 +115,6 @@ class LRScheduler(Callback):
         self.policy_ = self._get_policy_cls()
         self.lr_scheduler_ = None
         self.batch_idx_ = 0
-        # TODO: Remove this warning on 0.10 release
-        if (self.policy_ == TorchCyclicLR or self.policy_ == "TorchCyclicLR"
-                and self.step_every == 'epoch'):
-            warnings.warn(
-                "The LRScheduler now makes a step every epoch by default. "
-                "To have the cyclic lr scheduler update "
-                "every batch set step_every='batch'",
-                FutureWarning
-            )
-
         return self
 
     def _get_policy_cls(self):

--- a/skorch/tests/callbacks/test_lr_scheduler.py
+++ b/skorch/tests/callbacks/test_lr_scheduler.py
@@ -241,23 +241,6 @@ class TestLRCallbacks:
         )
         assert np.all(net.history[-1, 'batches', :, 'event_lr'] == new_lrs)
 
-    def test_cyclic_lr_with_epoch_step_warning(self,
-                                               classifier_module,
-                                               classifier_data):
-        msg = ("The LRScheduler now makes a step every epoch by default. "
-               "To have the cyclic lr scheduler update "
-               "every batch set step_every='batch'")
-        with pytest.warns(FutureWarning, match=msg) as record:
-            scheduler = LRScheduler(
-                TorchCyclicLR, base_lr=123, max_lr=999)
-            net = NeuralNetClassifier(
-                classifier_module,
-                max_epochs=0,
-                callbacks=[('scheduler', scheduler)],
-            )
-            net.initialize()
-        assert len(record) == 1
-
 
 class TestReduceLROnPlateau:
 


### PR DESCRIPTION
Comes down to no longer integrating it in CI. Add Python 3.8 though.

Also: Remove a FutureWarning in LRScheduler.