### PR TITLE
Make cli helper work with normal sklearn estimators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- CLI helper function now also supports normal (i.e. non-skorch) sklearn estimators
+
 ### Changed
 
 ### Fixed

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -55,6 +55,10 @@ if __name__ == '__main__':
 
 ```
 
+Note: The function you pass to `fire.Fire` shouldn't have any
+positional arguments, otherwise the displayed help will not work
+correctly; this is a quirk of fire.
+
 This even works if your neural net is part of an sklearn pipeline, in
 which case the help extends to all other estimators of your pipeline.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,4 +14,4 @@ pytest-cov
 sphinx
 sphinx_rtd_theme
 tensorboard>=1.14.0
-wandb>=0.8.30
+wandb>=0.8.30,<0.10.0

--- a/skorch/cli.py
+++ b/skorch/cli.py
@@ -161,7 +161,8 @@ def _yield_preproc_steps(model):
     if not isinstance(model, Pipeline):
         return
 
-    for key, val in model.get_params().items():
+    preproc_pipe = Pipeline(model.steps[:-1])
+    for key, val in preproc_pipe.get_params().items():
         if isinstance(val, BaseEstimator):
             if not isinstance(val, (Pipeline, FeatureUnion)):
                 yield key, val
@@ -190,7 +191,12 @@ def _yield_estimators(model):
 
     yield '__'.join(net_prefixes), net
 
-    module = net.module
+    module = getattr(net, 'module', None)
+    if not module:
+        # There is no module attribute, we're dealing with a normal
+        # scikit-learn estimator, so no need to show further help.
+        return
+
     module_prefixes.append('module')
     yield '__'.join(module_prefixes), module
 
@@ -293,6 +299,13 @@ def parse_args(kwargs, defaults=None):
     >>>
     >>> if __name__ == '__main__':
     >>>     fire.Fire(main)
+
+
+    Note
+    ----
+    The function you pass to `fire.Fire` shouldn't have any positional
+    arguments, otherwise the displayed help will not correctly work;
+    this is a quirk of fire.
 
     Parameters
     ----------

--- a/skorch/tests/test_cli.py
+++ b/skorch/tests/test_cli.py
@@ -253,6 +253,57 @@ class TestCli:
             assert snippet in out
 
     @pytest.fixture
+    def clf_sklearn(self):
+        from sklearn.linear_model import LinearRegression
+        return LinearRegression()
+
+    @pytest.fixture
+    def pipe_sklearn(self, clf_sklearn):
+        return Pipeline([
+            ('features', FeatureUnion([
+                ('scale', MinMaxScaler()),
+            ])),
+            ('clf', clf_sklearn),
+        ])
+
+    def test_print_help_sklearn_estimator(self, print_help, clf_sklearn, capsys):
+        # Should also work with non-skorch sklearn estimator;
+        # need to assert that count==1 since there was a bug in my
+        # first implementation that resulted in the help for the final
+        # estimator appearing twice.
+        print_help(clf_sklearn)
+        out = capsys.readouterr()[0]
+
+        expected_snippets = [
+            '-- --help',
+            '--fit_intercept',
+            '--copy_X',
+            '--normalize',
+        ]
+        for snippet in expected_snippets:
+            assert snippet in out
+            assert out.count(snippet) == 1
+
+    def test_print_help_sklearn_pipeline(self, print_help, pipe_sklearn, capsys):
+        # Should also work with non-skorch sklearn pipelines;
+        # need to assert that count==1 since there was a bug in my
+        # first implementation that resulted in the help for the final
+        # estimator appearing twice.
+        print_help(pipe_sklearn)
+        out = capsys.readouterr()[0]
+
+        expected_snippets = [
+            '-- --help',
+            '<MinMaxScaler> options',
+            '--features__scale__feature_range',
+            '--clf__fit_intercept',
+            '--clf__normalize',
+        ]
+        for snippet in expected_snippets:
+            assert snippet in out
+            assert out.count(snippet) == 1
+
+    @pytest.fixture
     def parse_args(self):
         from skorch.cli import parse_args
         return parse_args
@@ -317,3 +368,16 @@ class TestCli:
         assert isinstance(net.module_.nonlin, nn.Hardtanh)
         assert net.module_.nonlin.min_val == 1
         assert net.module_.nonlin.max_val == 2
+
+    def test_parse_args_sklearn_pipe_custom_defaults(self, parse_args, pipe_sklearn):
+        defaults = {'features__scale__copy': 123, 'clf__fit_intercept': 456}
+        kwargs = {'features__scale__copy': 555, 'clf__normalize': 789}
+        parsed = parse_args(kwargs, defaults)
+        pipe = parsed(pipe_sklearn)
+        scaler = pipe.steps[0][1].transformer_list[0][1]
+        clf = pipe.steps[-1][1]
+
+        # cmd line args have precedence over defaults
+        assert scaler.copy == 555
+        assert clf.fit_intercept == 456
+        assert clf.normalize == 789


### PR DESCRIPTION
Change cli helper so that normal (i.e. non-skorch) sklearn estimators
also work. This mainly required to relax the assumption that the
estimator must have a `module` attribute.

On top, added a comment about not using positional arguments for
functions parsed by fire. The problem is that internally,
this (silently) breaks fire, so that `python foo.py --help` does not
work and instead returns the result of `python foo.py -- --help`.