### PR TITLE
Multiple small improvements to notebooks

### DIFF
--- a/examples/rnn_classifer/RNN_sentiment_classification.ipynb
+++ b/examples/rnn_classifer/RNN_sentiment_classification.ipynb
@@ -73,7 +73,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.random.seed(0)"
+    "np.random.seed(0)\n",
+    "torch.manual_seed(0)\n",
+    "torch.cuda.manual_seed(0)"
    ]
   },
   {
@@ -91,7 +93,7 @@
    "source": [
     "VOCAB_SIZE = 1000  # This is on the low end\n",
     "MAX_LEN = 50  # Texts are pretty long on average, this is on the low end\n",
-    "USE_CUDA = True  # Set this to False if you don't want to use CUDA\n",
+    "USE_CUDA = torch.cuda.is_available()  # Set this to False if you don't want to use CUDA\n",
     "NUM_CV_STEPS = 10  # Number of randomized search steps to perform"
    ]
   },
@@ -426,6 +428,7 @@
     "            num_units=128,\n",
     "            num_layers=2,\n",
     "            dropout=0,\n",
+    "            bidirectional=False,\n",
     "    ):\n",
     "        super().__init__()\n",
     "        self.embedding_dim = embedding_dim\n",
@@ -433,26 +436,39 @@
     "        self.num_units = num_units\n",
     "        self.num_layers = num_layers\n",
     "        self.dropout = dropout\n",
+    "        self.bidirectional = bidirectional\n",
     "\n",
+    "        self.reset_weights()\n",
+    "\n",
+    "    def reset_weights(self):\n",
     "        self.emb = nn.Embedding(VOCAB_SIZE + 1, embedding_dim=self.embedding_dim)\n",
     "        \n",
     "        rec_layer = {'lstm': nn.LSTM, 'gru': nn.GRU}[self.rec_layer_type]\n",
     "        # We have to make sure that the recurrent layer is batch_first,\n",
     "        # since sklearn assumes the batch dimension to be the first\n",
     "        self.rec = rec_layer(\n",
-    "            self.embedding_dim, self.num_units, num_layers=num_layers, batch_first=True)\n",
+    "            self.embedding_dim,\n",
+    "            self.num_units,\n",
+    "            num_layers=self.num_layers,\n",
+    "            dropout=self.dropout,\n",
+    "            bidirectional=self.bidirectional,\n",
+    "            batch_first=True,\n",
+    "        )\n",
     "\n",
+    "        self.drop = nn.Dropout(self.dropout)\n",
     "        self.output = nn.Linear(self.num_units, 2)\n",
     "\n",
     "    def forward(self, X):\n",
     "        embeddings = self.emb(X)\n",
+    "\n",
     "        # from the recurrent layer, only take the activities from the last sequence step\n",
     "        if self.rec_layer_type == 'gru':\n",
     "            _, rec_out = self.rec(embeddings)\n",
     "        else:\n",
     "            _, (rec_out, _) = self.rec(embeddings)\n",
     "        rec_out = rec_out[-1]  # take output of last RNN layer\n",
-    "        drop = F.dropout(rec_out, p=self.dropout)\n",
+    "\n",
+    "        drop = self.drop(rec_out)\n",
     "        # Remember that the final non-linearity should be softmax, so that our predict_proba\n",
     "        # method outputs actual probabilities!\n",
     "        out = F.softmax(self.output(drop), dim=-1)\n",
@@ -468,26 +484,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "steps.append(\n",
-    "    ('net', NeuralNetClassifier(\n",
-    "        RNNClassifier,\n",
-    "        device=('cuda' if USE_CUDA else 'cpu'),\n",
-    "        max_epochs=5,\n",
-    "        lr=0.01,\n",
-    "        optimizer=torch.optim.RMSprop,\n",
-    "    ))\n",
+    "net = NeuralNetClassifier(\n",
+    "    RNNClassifier,\n",
+    "    device=('cuda' if USE_CUDA else 'cpu'),\n",
+    "    max_epochs=5,\n",
+    "    lr=0.01,\n",
+    "    optimizer=torch.optim.RMSprop,\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we are good to go:"
    ]
   },
   {
@@ -496,7 +503,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pipe = Pipeline(steps)"
+    "pipe = Pipeline(steps + [('net', net)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we are good to go:"
    ]
   },
   {
@@ -616,6 +630,7 @@
     "    'net__module__num_units': stats.randint(32, 256 + 1),\n",
     "    'net__module__num_layers': [1, 2, 3],\n",
     "    'net__module__dropout': stats.uniform(0, 0.9),\n",
+    "    'net__module__bidirectional': [True, False],\n",
     "    'net__lr': [10**(-stats.uniform(1, 5).rvs()) for _ in range(NUM_CV_STEPS)],\n",
     "    'net__max_epochs': [5, 10],\n",
     "}"

--- a/notebooks/Advanced_Usage.ipynb
+++ b/notebooks/Advanced_Usage.ipynb
@@ -61,8 +61,17 @@
    "source": [
     "import torch\n",
     "from torch import nn\n",
-    "import torch.nn.functional as F\n",
-    "torch.manual_seed(0);"
+    "import torch.nn.functional as F"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torch.manual_seed(0)\n",
+    "torch.cuda.manual_seed(0)"
    ]
   },
   {
@@ -94,6 +103,15 @@
    "source": [
     "import numpy as np\n",
     "from sklearn.datasets import make_classification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.random.seed(0)"
    ]
   },
   {
@@ -663,7 +681,7 @@
    "outputs": [],
    "source": [
     "X, y = make_classification(1000, 20, n_informative=10, random_state=0)\n",
-    "X = X.astype(np.float32)\n",
+    "X, y = X.astype(np.float32), y.astype(np.int64)\n",
     "dataset = MyDataset(X, y)"
    ]
   },
@@ -803,7 +821,7 @@
    "outputs": [],
    "source": [
     "X, y = make_classification(1000, 20, n_informative=10, random_state=0)\n",
-    "X = X.astype(np.float32)\n",
+    "X, y = X.astype(np.float32), y.astype(np.int64)\n",
     "X0, X1 = X[:, :10], X[:, 10:]\n",
     "X_dict = {'X0': X0, 'X1': X1}"
    ]
@@ -902,7 +920,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Working with sklearn `FunctionTransformer` and `GridSearch`"
+    "#### Working with sklearn `Pipeline` and `GridSearchCV`"
    ]
   },
   {
@@ -922,7 +940,7 @@
    "source": [
     "sklearn makes the assumption that incoming data should be numpy/sparse arrays or something similar. This clashes with the use of dictionaries. Unfortunately, it is sometimes impossible to work around that for now (for instance using skorch with `BaggingClassifier`). Other times, there are possibilities.\n",
     "\n",
-    "When we have a preprocessing pipeline that involves `FunctionTransformer`, we have to pass the parameter `validate=False` so that sklearn allows the dictionary to pass through:"
+    "When we have a preprocessing pipeline that involves `FunctionTransformer`, we have to pass the parameter `validate=False` (which is the default value now) so that sklearn allows the dictionary to pass through. Everything else works:"
    ]
   },
   {
@@ -1097,7 +1115,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With this, we can call `GridSearch` just as expected:"
+    "With this, we can call `GridSearchCV` just as expected:"
    ]
   },
   {

--- a/notebooks/Basic_Usage.ipynb
+++ b/notebooks/Basic_Usage.ipynb
@@ -70,15 +70,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import torch\n",
     "from torch import nn\n",
-    "import torch.nn.functional as F\n",
-    "\n",
-    "torch.manual_seed(0);"
+    "import torch.nn.functional as F"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torch.manual_seed(0)\n",
+    "torch.cuda.manual_seed(0)"
    ]
   },
   {
@@ -1048,9 +1056,17 @@
     "    ClassifierModule,\n",
     "    max_epochs=20,\n",
     "    lr=0.1,\n",
-    "    verbose=0,\n",
     "    optimizer__momentum=0.9,\n",
+    "    verbose=0,\n",
+    "    train_split=False,\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Note*: We set the verbosity level to zero (`verbose=0`) to prevent too much print output from being shown. Also, we disable the skorch-internal train-validation split (`train_split=False`) because `GridSearchCV` already splits the training data for us. We only have to leave the skorch-internal split enabled for some specific uses, e.g. to perform `EarlyStopping`."
    ]
   },
   {


### PR DESCRIPTION
Make some improvements to a couple of notebooks. Fixes #599, fixes #691 

###  Improve Basic_Usage.ipynb

* For grid search, disable internal train-valid split. Add a comment
  to explain this.
* Set torch random seeds

### Improve Advanced_Usage.ipynb

* set torch manual seeds
* always cast y to int64
* FunctionTransformer's validate is now False by default
* minor text adjustments

### Improve RNN_sentiment_classification.ipynb

* set random seeds for torch (with cuda) and numpy
* add option for bidirectional RNNs
* add dropout to RNNs as well
* use dropout module instead of F.dropout (using the latter is a bug)