### PR TITLE
Adding code example to use python function for optimizer property

### DIFF
--- a/docs/user/neuralnet.rst
+++ b/docs/user/neuralnet.rst
@@ -135,6 +135,26 @@ support for wildcards (globbing):
         ('linear0.bias', {'lr': 1}),
     ]
 
+If your use case requires you to use a non-default PyTorch optimizer then
+you can create a method and assign it to optimizer property:
+
+.. code:: python
+
+    # custom optimizer to encapsulate Adam
+    def make_lookahead(parameters, optimizer_cls, k, alpha, **kwargs):
+        optimizer = optimizer_cls(parameters, **kwargs)
+        return Lookahead(optimizer=optimizer, k=k, alpha=alpha)
+
+
+    net = NeuralNetClassifier(
+            ...,
+            optimizer=make_lookahead,
+            optimizer__optimizer_cls=torch.optim.Adam,
+            optimizer__weight_decay=1e-2,
+            optimizer__k=5,
+            optimizer__alpha=0.5,
+            lr=1e-3
+
 lr
 ^^^
 

--- a/docs/user/neuralnet.rst
+++ b/docs/user/neuralnet.rst
@@ -135,8 +135,10 @@ support for wildcards (globbing):
         ('linear0.bias', {'lr': 1}),
     ]
 
-If your use case requires you to use a non-default PyTorch optimizer then
-you can create a method and assign it to optimizer property:
+Your use case may require an optimizer whose signature differs from a 
+default PyTorch optimizer's signature. In that case, you can define a 
+custom function that reroutes the arguments as needed and pass it to 
+the ``optimizer`` parameter:
 
 .. code:: python
 

--- a/docs/user/neuralnet.rst
+++ b/docs/user/neuralnet.rst
@@ -155,7 +155,7 @@ the ``optimizer`` parameter:
             optimizer__weight_decay=1e-2,
             optimizer__k=5,
             optimizer__alpha=0.5,
-            lr=1e-3
+            lr=1e-3)
 
 lr
 ^^^


### PR DESCRIPTION
**Issue reference**: 
This is in reference to documentation issue https://github.com/skorch-dev/skorch/issues/696:

**What does it implement/fix**
I have added an example of using Python function for optimizer property where a user may need to use non-default PyTorch optimizer