### PR TITLE
DOC: simplify sample_weight example

### DIFF
--- a/docs/user/FAQ.rst
+++ b/docs/user/FAQ.rst
@@ -104,23 +104,19 @@ dictionary. Below, there is example code on how to achieve this:
     # add sample_weight to the X dict
     X['sample_weight'] = sample_weight
 
-    class MyModule(nn.Module):
-        ...  # normal PyTorch module definition
-
     class MyNet(NeuralNet):
-        def __init__(self, *args, criterion__reduce=False, **kwargs):
+        def __init__(self, *args, **kwargs):
             # make sure to set reduce=False in your criterion, since we need the loss
             # for each sample so that it can be weighted
-            super().__init__(*args, criterion__reduce=criterion__reduce, **kwargs)
+            super().__init__(*args, criterion__reduce=False, **kwargs)
 
         def get_loss(self, y_pred, y_true, X, *args, **kwargs):
             # override get_loss to use the sample_weight from X
             loss_unreduced = super().get_loss(y_pred, y_true, X["data"], *args, **kwargs)
-            sample_weight = X['sample_weight']
-            loss_reduced = (sample_weight * loss_unreduced).mean()
+            loss_reduced = (X["sample_weight"] * loss_unreduced).mean()
             return loss_reduced
 
-    net = MyNet(MyModule, ...)
+    net = MyNet(nn.MSELoss, ...)
     net.fit(X, y)
 
 

--- a/docs/user/FAQ.rst
+++ b/docs/user/FAQ.rst
@@ -104,19 +104,24 @@ dictionary. Below, there is example code on how to achieve this:
     # add sample_weight to the X dict
     X['sample_weight'] = sample_weight
 
+    class MyModule(nn.Module):
+        ...  # normal PyTorch module
+
     class MyNet(NeuralNet):
         def __init__(self, *args, **kwargs):
-            # make sure to set reduce=False in your criterion, since we need the loss
-            # for each sample so that it can be weighted
+            # make sure to set reduce=False in your criterion
+            # (since we need the loss for each sample so that it can be weighted)
             super().__init__(*args, criterion__reduce=False, **kwargs)
 
         def get_loss(self, y_pred, y_true, X, *args, **kwargs):
-            # override get_loss to use the sample_weight from X
+            # Pass the data to get unnormalized loss
             loss_unreduced = super().get_loss(y_pred, y_true, X["data"], *args, **kwargs)
+
+            # Reweight the loss with sample_weight
             loss_reduced = (X["sample_weight"] * loss_unreduced).mean()
             return loss_reduced
 
-    net = MyNet(nn.MSELoss, ...)
+    net = MyNet(MyModule, ...)
     net.fit(X, y)
 
 

--- a/docs/user/FAQ.rst
+++ b/docs/user/FAQ.rst
@@ -105,12 +105,7 @@ dictionary. Below, there is example code on how to achieve this:
     X['sample_weight'] = sample_weight
 
     class MyModule(nn.Module):
-        ...
-        def forward(self, data, sample_weight):
-            # when X is a dict, its keys are passed as kwargs to forward, thus
-            # our forward has to have the arguments 'data' and 'sample_weight';
-            # usually, sample_weight can be ignored here
-            ...
+        ...  # normal PyTorch module definition
 
     class MyNet(NeuralNet):
         def __init__(self, *args, criterion__reduce=False, **kwargs):
@@ -120,7 +115,7 @@ dictionary. Below, there is example code on how to achieve this:
 
         def get_loss(self, y_pred, y_true, X, *args, **kwargs):
             # override get_loss to use the sample_weight from X
-            loss_unreduced = super().get_loss(y_pred, y_true, X, *args, **kwargs)
+            loss_unreduced = super().get_loss(y_pred, y_true, X["data"], *args, **kwargs)
             sample_weight = X['sample_weight']
             loss_reduced = (sample_weight * loss_unreduced).mean()
             return loss_reduced


### PR DESCRIPTION
**What does this PR implement?**
It simplifies the sample_weight example in the docs. In the previous example, `MyModule.forward` signature changed but  arguments were changed, but there was a comment saying "sample_weight can be ignored." I used that as motivation to do the following:

* Remove need to change signature of `MyModule.forward` to accept `sample_weight`
* Ensure `criterion__reduce` is always `False` (also, one less definition).

I've also added some comments explaining each step of the reweighting.

**Reference issues/PRs**
None.