### PR TITLE
API: allow disabling all callbacks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - CLI helper function now also supports normal (i.e. non-skorch) sklearn estimators
+- Disabling all callbacks is now supported (which allows reducing overhead,
+  which is especially relevant for small models).
 
 ### Changed
 

--- a/docs/user/callbacks.rst
+++ b/docs/user/callbacks.rst
@@ -138,7 +138,7 @@ use a callback for learning rate scheduling (e.g. via
 :class:`.LRScheduler`) and want to test its usefulness, you can
 compare the performance once with and once without the callback.
 
-To completely disable callbacks, set ``callbacks=False``.
+To completely disable all callbacks, set ``callbacks="diable"``.
 
 
 Scoring

--- a/docs/user/callbacks.rst
+++ b/docs/user/callbacks.rst
@@ -138,7 +138,8 @@ use a callback for learning rate scheduling (e.g. via
 :class:`.LRScheduler`) and want to test its usefulness, you can
 compare the performance once with and once without the callback.
 
-To completely disable all callbacks, set ``callbacks="diable"``.
+To completely disable all callbacks, including default callbacks, 
+set ``callbacks="disable"``.
 
 
 Scoring

--- a/docs/user/callbacks.rst
+++ b/docs/user/callbacks.rst
@@ -138,6 +138,8 @@ use a callback for learning rate scheduling (e.g. via
 :class:`.LRScheduler`) and want to test its usefulness, you can
 compare the performance once with and once without the callback.
 
+To completely disable callbacks, set ``callbacks=False``.
+
 
 Scoring
 -------

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -465,6 +465,9 @@ class NeuralNet:
             callbacks_.append((name, cb))
 
         self.callbacks_ = callbacks_
+        if self.callbacks is False:
+            self.callbacks_ = []
+
         return self
 
     def initialize_criterion(self):

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -141,11 +141,20 @@ class NeuralNet:
       data and should return the tuple ``dataset_train, dataset_valid``.
       The validation data may be None.
 
-    callbacks : None, False, or list of Callback instances (default=None)
-      More callbacks, in addition to those returned by
-      ``get_default_callbacks``. Each callback should inherit from
-      :class:`.Callback`. If not ``None``, a list of callbacks is
-      expected where the callback names are inferred from the class
+    callbacks : None, str, or list of Callback instances (default=None)
+      Which callbacks to enable. There are three possible values:
+
+      If ``callbacks=None``, only use default callbacks,
+      those returned by ``get_default_callbacks``.
+
+      If ``callbacks="disable"``, disable all callbacks, or, do not run
+      any of the callbacks.
+
+      If ``callbacks`` is a list of callbacks, use those callbacks in
+      addition to the default callbacks. Each callback should be an
+      instance of :class:`.Callback`.
+
+      Callback names are inferred from the class
       name. Name conflicts are resolved by appending a count suffix
       starting with 1, e.g. ``EpochScoring_1``. Alternatively,
       a tuple ``(name, callback)`` can be passed, where ``name``
@@ -154,9 +163,6 @@ class NeuralNet:
       callbacks (e.g., for the callback with name ``'print_log'``, use
       ``net.set_params(callbacks__print_log__keys_ignored=['epoch',
       'train_loss'])``).
-
-      If ``callbacks="disable"``, completely ignore all default
-      callbacks.
 
     predict_nonlinearity : callable, None, or 'auto' (default='auto')
       The nonlinearity to be applied to the prediction. When set to

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -141,7 +141,7 @@ class NeuralNet:
       data and should return the tuple ``dataset_train, dataset_valid``.
       The validation data may be None.
 
-    callbacks : None or list of Callback instances (default=None)
+    callbacks : None, False, or list of Callback instances (default=None)
       More callbacks, in addition to those returned by
       ``get_default_callbacks``. Each callback should inherit from
       :class:`.Callback`. If not ``None``, a list of callbacks is
@@ -154,6 +154,8 @@ class NeuralNet:
       callbacks (e.g., for the callback with name ``'print_log'``, use
       ``net.set_params(callbacks__print_log__keys_ignored=['epoch',
       'train_loss'])``).
+
+      If ``False``, completely disable callbacks.
 
     predict_nonlinearity : callable, None, or 'auto' (default='auto')
       The nonlinearity to be applied to the prediction. When set to

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -147,7 +147,7 @@ class NeuralNet:
       If ``callbacks=None``, only use default callbacks,
       those returned by ``get_default_callbacks``.
 
-      If ``callbacks="disable"``, disable all callbacks, or, do not run
+      If ``callbacks="disable"``, disable all callbacks, i.e. do not run
       any of the callbacks.
 
       If ``callbacks`` is a list of callbacks, use those callbacks in

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -155,7 +155,8 @@ class NeuralNet:
       ``net.set_params(callbacks__print_log__keys_ignored=['epoch',
       'train_loss'])``).
 
-      If ``False``, completely disable callbacks.
+      If ``callbacks="disable"``, completely ignore all default
+      callbacks.
 
     predict_nonlinearity : callable, None, or 'auto' (default='auto')
       The nonlinearity to be applied to the prediction. When set to
@@ -437,6 +438,10 @@ class NeuralNet:
         not unique, a ValueError is raised.
 
         """
+        if self.callbacks == "disable":
+            self.callbacks_ = []
+            return self
+
         callbacks_ = []
 
         class Dummy:
@@ -467,8 +472,6 @@ class NeuralNet:
             callbacks_.append((name, cb))
 
         self.callbacks_ = callbacks_
-        if self.callbacks is False:
-            self.callbacks_ = []
 
         return self
 

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -141,7 +141,7 @@ class NeuralNet:
       data and should return the tuple ``dataset_train, dataset_valid``.
       The validation data may be None.
 
-    callbacks : None, str, or list of Callback instances (default=None)
+    callbacks : None, "disable", or list of Callback instances (default=None)
       Which callbacks to enable. There are three possible values:
 
       If ``callbacks=None``, only use default callbacks,

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -1083,10 +1083,3 @@ class TestTrainEndCheckpoint:
 
         assert save_params_mock.call_count == 1
         save_params_mock.assert_has_calls([call(f_mymodule='train_end_mymodule.pt')])
-
-
-class TestNoCallbacks(TestCheckpoint):
-    def test_no_callbacks(self, net_cls, data):
-        net = net_cls(callbacks="disable")
-        net.initialize()
-        assert net.callbacks_ == []

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -1083,3 +1083,11 @@ class TestTrainEndCheckpoint:
 
         assert save_params_mock.call_count == 1
         save_params_mock.assert_has_calls([call(f_mymodule='train_end_mymodule.pt')])
+
+
+class TestNoCallbacks(TestCheckpoint):
+    def test_no_callbacks(self, net_cls, data):
+        net = net_cls(callbacks=False)
+        net.fit(*data)
+        assert net.callbacks is False
+        assert net.callbacks_ == []

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -1089,5 +1089,4 @@ class TestNoCallbacks(TestCheckpoint):
     def test_no_callbacks(self, net_cls, data):
         net = net_cls(callbacks="disable")
         net.fit(*data)
-        assert net.callbacks == "disable"
         assert net.callbacks_ == []

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -1088,5 +1088,5 @@ class TestTrainEndCheckpoint:
 class TestNoCallbacks(TestCheckpoint):
     def test_no_callbacks(self, net_cls, data):
         net = net_cls(callbacks="disable")
-        net.fit(*data)
+        net.initialize()
         assert net.callbacks_ == []

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -1087,7 +1087,7 @@ class TestTrainEndCheckpoint:
 
 class TestNoCallbacks(TestCheckpoint):
     def test_no_callbacks(self, net_cls, data):
-        net = net_cls(callbacks=False)
+        net = net_cls(callbacks="disable")
         net.fit(*data)
-        assert net.callbacks is False
+        assert net.callbacks == "disable"
         assert net.callbacks_ == []

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2811,3 +2811,8 @@ class TestNetSparseInput:
         score_end = net.history[-1]['train_loss']
 
         assert score_start > 1.25 * score_end
+
+    def test_no_callbacks(self, net_cls):
+        net = net_cls(callbacks="disable")
+        net.initialize()
+        assert net.callbacks_ == []

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -1421,6 +1421,11 @@ class TestNeuralNet:
         stdout = capsys.readouterr()[0]
         assert "Re-initializing module!" not in stdout
 
+    def test_no_callbacks(self, net_cls, module_cls):
+        net = net_cls(module_cls, callbacks="disable")
+        net.initialize()
+        assert net.callbacks_ == []
+
     def test_message_fit_with_initialized_net(
             self, net_cls, module_cls, data, capsys):
         net = net_cls(module_cls).initialize()
@@ -2811,8 +2816,3 @@ class TestNetSparseInput:
         score_end = net.history[-1]['train_loss']
 
         assert score_start > 1.25 * score_end
-
-    def test_no_callbacks(self, net_cls, module_cls):
-        net = net_cls(module_cls, callbacks="disable")
-        net.initialize()
-        assert net.callbacks_ == []

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2812,7 +2812,7 @@ class TestNetSparseInput:
 
         assert score_start > 1.25 * score_end
 
-    def test_no_callbacks(self, net_cls):
-        net = net_cls(callbacks="disable")
+    def test_no_callbacks(self, net_cls, module_cls):
+        net = net_cls(module_cls, callbacks="disable")
         net.initialize()
         assert net.callbacks_ == []


### PR DESCRIPTION
**What does this PR implement?**
It allows disabling all callbacks with `callbacks=False`.

I ran into a use case that uselessly spent 97% of the training time in various callbacks with the default `callbacks=None`. After this PR with `callbacks=False`, it only spends 5% of the total training time in various callbacks, a rather drastic speedup.