### PR TITLE
Add a logging callback for Sacred

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `SacredLogger` callback for logging to Sacred (#725)
 - CLI helper function now also supports normal (i.e. non-skorch) sklearn estimators
 
 ### Changed

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ future>=0.17.1
 jupyter
 matplotlib>=2.0.2
 neptune-client>=0.4.103
+sacred
 numpydoc
 openpyxl
 pandas

--- a/skorch/callbacks/__init__.py
+++ b/skorch/callbacks/__init__.py
@@ -33,6 +33,7 @@ __all__ = [
     'ProgressBar',
     'TrainEndCheckpoint',
     'TensorBoard',
+    'SacredLogger',
     'Unfreezer',
     'WandbLogger',
     'WarmRestartLR',

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -835,14 +835,6 @@ class SacredLogger(Callback):
         self.log_on_epoch_end = log_on_epoch_end
         self.batch_suffix = batch_suffix
         self.epoch_suffix = epoch_suffix
-        if self.batch_suffix is None:
-            self.batch_suffix = (
-                "_batch" if log_on_batch_end and log_on_epoch_end else ""
-            )
-        if self.epoch_suffix is None:
-            self.epoch_suffix = (
-                "_epoch" if log_on_batch_end and log_on_epoch_end else ""
-            )
         self.keys_ignored = keys_ignored
 
     def initialize(self):
@@ -851,6 +843,17 @@ class SacredLogger(Callback):
             keys_ignored = [keys_ignored]
         self.keys_ignored_ = set(keys_ignored or [])
         self.keys_ignored_.add("batches")
+
+        self.batch_suffix_ = self.batch_suffix
+        self.epoch_suffix_ = self.epoch_suffix
+        if self.batch_suffix__ is None:
+            self.batch_suffix_ = (
+                "_batch" if log_on_batch_end and log_on_epoch_end else ""
+            )
+        if self.epoch_suffix_ is None:
+            self.epoch_suffix_ = (
+                "_epoch" if log_on_batch_end and log_on_epoch_end else ""
+            )
         return self
 
     def on_batch_end(self, net, **kwargs):
@@ -861,7 +864,7 @@ class SacredLogger(Callback):
         for key in filter_log_keys(batch_logs.keys(), self.keys_ignored_):
             # skorch does not keep a batch count, but sacred will
             # automatically associate the results with a counter.
-            self.experiment.log_scalar(key + self.batch_suffix, batch_logs[key])
+            self.experiment.log_scalar(key + self.batch_suffix_, batch_logs[key])
 
     def on_epoch_end(self, net, **kwargs):
         """Automatically log values from the last history step."""
@@ -871,4 +874,4 @@ class SacredLogger(Callback):
         epoch = epoch_logs["epoch"]
 
         for key in filter_log_keys(epoch_logs.keys(), self.keys_ignored_):
-            self.experiment.log_scalar(key + self.epoch_suffix, epoch_logs[key], epoch)
+            self.experiment.log_scalar(key + self.epoch_suffix_, epoch_logs[key], epoch)

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -744,6 +744,40 @@ class SacredLogger(Callback):
     more information. Alternatively you can subclass this callback and extend
     the ``on_*`` methods.
 
+    To use this logger, you first have to install Sacred:
+
+    >>> pip install sacred
+
+    You might also install pymongo to use a mongodb backend. See the upstream_
+    documentation for more details. Once you have installed it, you can set up
+    a simple experiment and pass this Logger as a callback to your skorch
+    estimator:
+
+    >>> from sacred import Experiment
+    >>> from sokrch.callbacks.logging import SacredLogger
+    >>> from sokrch.callbacks.scoring import EpochScoring
+    >>> ex = Experiment()
+
+    >>> @ex.config
+    >>> def my_config():
+    ...     max_epochs = 20
+    ...     lr = 0.01
+
+    >>> @ex.automain
+    >>> def main(_run, max_epochs, lr):
+    ...     # Take care to add additional scoring callbacks *before* the logger.
+    ...     net = NeuralNetClassifier(
+    ...         ClassifierModule,
+    ...         max_epochs=max_epochs,
+    ...         lr=0.01,
+    ...         callbacks=[EpochScoring("f1"), SacredLogger(_run)]
+    ...     )
+    ...     # now fit your estimator to your data
+    ...     net.fit(X, y)
+
+    You can then call this script and optionally pass a backend as a command
+    line parameter.
+
 
     Parameters
     ----------
@@ -757,6 +791,9 @@ class SacredLogger(Callback):
       Key or list of keys that should not be logged to Sacred. Note that in
       addition to the keys provided by the user, keys such as those starting
       with 'event_' or ending on '_best' are ignored by default.
+
+
+    .. _upstream: https://github.com/IDSIA/sacred#installing
     """
 
     def __init__(

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -848,11 +848,11 @@ class SacredLogger(Callback):
         self.epoch_suffix_ = self.epoch_suffix
         if self.batch_suffix_ is None:
             self.batch_suffix_ = (
-                "_batch" if log_on_batch_end and log_on_epoch_end else ""
+                "_batch" if self.log_on_batch_end and self.log_on_epoch_end else ""
             )
         if self.epoch_suffix_ is None:
             self.epoch_suffix_ = (
-                "_epoch" if log_on_batch_end and log_on_epoch_end else ""
+                "_epoch" if self.log_on_batch_end and self.log_on_epoch_end else ""
             )
         return self
 

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -787,8 +787,8 @@ class SacredLogger(Callback):
     Then call this from the command line, e.g. like this:
     ``python sacred-script.py with max_epochs=15``
 
-    You can then call this script and optionally pass a backend as a command
-    line parameter.
+    You can also change other options on the command line and optionally
+    specify a backend.
 
 
     Parameters

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -746,7 +746,7 @@ class SacredLogger(Callback):
 
     To use this logger, you first have to install Sacred:
 
-    >>> pip install sacred
+    $ pip install sacred
 
     You might also install pymongo to use a mongodb backend. See the upstream_
     documentation for more details. Once you have installed it, you can set up

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -734,7 +734,7 @@ class SacredLogger(Callback):
     """Logs results from history to Sacred.
 
     Sacred is a tool to help you configure, organize, log and reproduce
-    experiments developed at IDSIA. See https://github.com/IDSIA/sacred.
+    experiments. Developed at IDSIA. See https://github.com/IDSIA/sacred.
 
     Use this callback to automatically log all interesting values from
     your net's history to Sacred.

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -846,7 +846,7 @@ class SacredLogger(Callback):
 
         self.batch_suffix_ = self.batch_suffix
         self.epoch_suffix_ = self.epoch_suffix
-        if self.batch_suffix__ is None:
+        if self.batch_suffix_ is None:
             self.batch_suffix_ = (
                 "_batch" if log_on_batch_end and log_on_epoch_end else ""
             )

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -16,7 +16,7 @@ from skorch.dataset import get_len
 from skorch.callbacks import Callback
 
 __all__ = ['EpochTimer', 'NeptuneLogger', 'WandbLogger', 'PrintLog', 'ProgressBar',
-           'TensorBoard']
+           'TensorBoard', 'SacredLogger']
 
 
 def filter_log_keys(keys, keys_ignored=None):
@@ -728,3 +728,68 @@ class TensorBoard(Callback):
     def on_train_end(self, net, **kwargs):
         if self.close_after_train:
             self.writer.close()
+
+
+class SacredLogger(Callback):
+    """Logs results from history to Sacred.
+
+    Sacred is a tool to help you configure, organize, log and reproduce
+    experiments developed at IDSIA. See https://github.com/IDSIA/sacred.
+
+    Use this callback to automatically log all interesting values from
+    your net's history to Sacred.
+
+    If you want to log additional information, you can simply add it to
+    ``History``. See the documentation on ``Callbacks``, and ``Scoring`` for
+    more information. Alternatively you can subclass this callback and extend
+    the ``on_*`` methods.
+
+
+    Parameters
+    ----------
+    experiment : sacred.Experiment
+      Instantiated ``Experiment`` class.
+
+    log_on_batch_end : bool (default=False)
+      Whether to log loss and other metrics on batch level.
+
+    keys_ignored : str or list of str (default=None)
+      Key or list of keys that should not be logged to Sacred. Note that in
+      addition to the keys provided by the user, keys such as those starting
+      with 'event_' or ending on '_best' are ignored by default.
+    """
+
+    def __init__(
+        self,
+        experiment,
+        log_on_batch_end=False,
+        keys_ignored=None,
+    ):
+        self.experiment = experiment
+        self.log_on_batch_end = log_on_batch_end
+        self.keys_ignored = keys_ignored
+
+    def initialize(self):
+        keys_ignored = self.keys_ignored
+        if isinstance(keys_ignored, str):
+            keys_ignored = [keys_ignored]
+        self.keys_ignored_ = set(keys_ignored or [])
+        self.keys_ignored_.add('batches')
+        return self
+
+    def on_batch_end(self, net, **kwargs):
+        if self.log_on_batch_end:
+            batch_logs = net.history[-1]['batches'][-1]
+
+            for key in filter_log_keys(batch_logs.keys(), self.keys_ignored_):
+                # skorch does not keep a batch count, but sacred will
+                # automatically associate the results with a counter.
+                self.experiment.log_scalar(key, batch_logs[key])
+
+    def on_epoch_end(self, net, **kwargs):
+        """Automatically log values from the last history step."""
+        epoch_logs = net.history[-1]
+        epoch = epoch_logs['epoch']
+
+        for key in filter_log_keys(epoch_logs.keys(), self.keys_ignored_):
+            self.experiment.log_scalar(key, epoch_logs[key], epoch)

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -753,9 +753,15 @@ class SacredLogger(Callback):
     a simple experiment and pass this Logger as a callback to your skorch
     estimator:
 
+    # contents of sacred-experiment.py
+    >>> import numpy as np
     >>> from sacred import Experiment
-    >>> from sokrch.callbacks.logging import SacredLogger
-    >>> from sokrch.callbacks.scoring import EpochScoring
+    >>> from sklearn.datasets import make_classification
+    >>> from skorch.callbacks.logging import SacredLogger
+    >>> from skorch.callbacks.scoring import EpochScoring
+    >>> from skorch import NeuralNetClassifier
+    >>> from skorch.toy import make_classifier
+
     >>> ex = Experiment()
 
     >>> @ex.config
@@ -763,17 +769,23 @@ class SacredLogger(Callback):
     ...     max_epochs = 20
     ...     lr = 0.01
 
+    >>> X, y = make_classification()
+    >>> X, y = X.astype(np.float32), y.astype(np.int64)
+
     >>> @ex.automain
     >>> def main(_run, max_epochs, lr):
     ...     # Take care to add additional scoring callbacks *before* the logger.
     ...     net = NeuralNetClassifier(
-    ...         ClassifierModule,
+    ...         make_classifier(),
     ...         max_epochs=max_epochs,
     ...         lr=0.01,
     ...         callbacks=[EpochScoring("f1"), SacredLogger(_run)]
     ...     )
     ...     # now fit your estimator to your data
     ...     net.fit(X, y)
+    
+    Then call this from the command line, e.g. like this:
+    ``python sacred-script.py with max_epochs=15``
 
     You can then call this script and optionally pass a backend as a command
     line parameter.

--- a/skorch/tests/callbacks/test_logging.py
+++ b/skorch/tests/callbacks/test_logging.py
@@ -307,7 +307,13 @@ class TestSacred:
 
         # 5 epochs x (40/4 batches x 2 batch metrics + 2 epoch metrics) = 110 calls
         assert mock_experiment.log_scalar.call_count == 110
-        mock_experiment.log_scalar.assert_any_call('train_batch_size', 4)
+        mock_experiment.log_scalar.assert_any_call('train_batch_size_batch', 4)
+
+        logged_keys = [
+            call_args.args[0] for call_args in mock_experiment.log_scalar.call_args_list
+        ]
+        # This is a batch-only metric.
+        assert 'train_batch_size_epoch' not in logged_keys
 
     def test_log_on_batch_level_off(
             self,
@@ -329,7 +335,7 @@ class TestSacred:
         # 5 epochs x 2 epoch metrics = 10 calls
         assert mock_experiment.log_scalar.call_count == 10
         call_args_list = mock_experiment.log_scalar.call_args_list
-        assert call('train_batch_size', 4) not in call_args_list
+        assert call('train_batch_size_batch', 4) not in call_args_list
 
 @pytest.mark.skipif(
     not wandb_installed, reason='wandb is not installed')

--- a/skorch/tests/callbacks/test_logging.py
+++ b/skorch/tests/callbacks/test_logging.py
@@ -11,6 +11,7 @@ import torch
 from torch import nn
 
 from skorch.tests.conftest import neptune_installed
+from skorch.tests.conftest import sacred_installed
 from skorch.tests.conftest import wandb_installed
 from skorch.tests.conftest import tensorboard_installed
 
@@ -190,6 +191,139 @@ class TestNeptune:
 
         npt.on_batch_end(net)
         assert npt.first_batch_ is False
+
+@pytest.mark.skipif(
+    not sacred_installed, reason='Sacred is not installed')
+class TestSacred:
+    @pytest.fixture
+    def net_cls(self):
+        from skorch import NeuralNetClassifier
+        return NeuralNetClassifier
+
+    @pytest.fixture
+    def data(self, classifier_data):
+        X, y = classifier_data
+        # accelerate training since we don't care for the loss
+        X, y = X[:40], y[:40]
+        return X, y
+
+    @pytest.fixture
+    def sacred_logger_cls(self):
+        from skorch.callbacks import SacredLogger
+        return SacredLogger
+
+    @pytest.fixture
+    def sacred_experiment_cls(self):
+        from sacred import Experiment
+        return Experiment
+
+    @pytest.fixture
+    def mock_experiment(self, sacred_experiment_cls):
+        mock = Mock(spec=sacred_experiment_cls)
+        mock.log_scalar = Mock()
+        return mock
+
+    @pytest.fixture
+    def net_fitted(
+            self,
+            net_cls,
+            classifier_module,
+            data,
+            sacred_logger_cls,
+            mock_experiment,
+    ):
+        return net_cls(
+            classifier_module,
+            callbacks=[sacred_logger_cls(mock_experiment)],
+            max_epochs=3,
+        ).fit(*data)
+
+    def test_ignore_keys(
+            self,
+            net_cls,
+            classifier_module,
+            data,
+            sacred_logger_cls,
+            mock_experiment,
+    ):
+        # ignore 'dur' and 'valid_loss', 'unknown' doesn't exist but
+        # this should not cause a problem
+        npt = sacred_logger_cls(
+            mock_experiment, keys_ignored=['dur', 'valid_loss', 'unknown'])
+        net_cls(
+            classifier_module,
+            callbacks=[npt],
+            max_epochs=3,
+        ).fit(*data)
+
+        # 3 epochs x 2 epoch metrics = 6 calls
+        assert mock_experiment.log_scalar.call_count == 6
+        call_args = [args[0][0] for args in mock_experiment.log_scalar.call_args_list]
+        assert 'valid_loss' not in call_args
+
+    def test_keys_ignored_is_string(self, sacred_logger_cls, mock_experiment):
+        npt = sacred_logger_cls(
+            mock_experiment, keys_ignored='a-key').initialize()
+        expected = {'a-key', 'batches'}
+        assert npt.keys_ignored_ == expected
+
+    def test_fit_with_real_experiment(
+            self,
+            net_cls,
+            classifier_module,
+            data,
+            sacred_logger_cls,
+            sacred_experiment_cls,
+    ):
+        net = net_cls(
+            classifier_module,
+            callbacks=[sacred_logger_cls(sacred_experiment_cls())],
+            max_epochs=5,
+        )
+        net.fit(*data)
+
+    def test_log_on_batch_level_on(
+            self,
+            net_cls,
+            classifier_module,
+            data,
+            sacred_logger_cls,
+            mock_experiment,
+    ):
+        net = net_cls(
+            classifier_module,
+            callbacks=[sacred_logger_cls(mock_experiment, log_on_batch_end=True)],
+            max_epochs=5,
+            batch_size=4,
+            train_split=False
+        )
+        net.fit(*data)
+
+        # 5 epochs x (40/4 batches x 2 batch metrics + 2 epoch metrics) = 110 calls
+        assert mock_experiment.log_scalar.call_count == 110
+        mock_experiment.log_scalar.assert_any_call('train_batch_size', 4)
+
+    def test_log_on_batch_level_off(
+            self,
+            net_cls,
+            classifier_module,
+            data,
+            sacred_logger_cls,
+            mock_experiment,
+    ):
+        net = net_cls(
+            classifier_module,
+            callbacks=[sacred_logger_cls(mock_experiment, log_on_batch_end=False)],
+            max_epochs=5,
+            batch_size=4,
+            train_split=False
+        )
+        net.fit(*data)
+
+        # 5 epochs x 2 epoch metrics = 10 calls
+        assert mock_experiment.log_scalar.call_count == 10
+        call_args_list = mock_experiment.log_scalar.call_args_list
+        assert call('train_batch_size', 4) not in call_args_list
 
 @pytest.mark.skipif(
     not wandb_installed, reason='wandb is not installed')

--- a/skorch/tests/callbacks/test_logging.py
+++ b/skorch/tests/callbacks/test_logging.py
@@ -275,12 +275,18 @@ class TestSacred:
             sacred_logger_cls,
             sacred_experiment_cls,
     ):
-        net = net_cls(
-            classifier_module,
-            callbacks=[sacred_logger_cls(sacred_experiment_cls())],
-            max_epochs=5,
-        )
-        net.fit(*data)
+        experiment = sacred_experiment_cls()
+
+        @experiment.main
+        def experiment_main(_run):
+            net = net_cls(
+                classifier_module,
+                callbacks=[sacred_logger_cls(_run)],
+                max_epochs=5,
+            )
+            net.fit(*data)
+
+        experiment.run()
 
     def test_log_on_batch_level_on(
             self,

--- a/skorch/tests/callbacks/test_logging.py
+++ b/skorch/tests/callbacks/test_logging.py
@@ -265,7 +265,7 @@ class TestSacred:
         logger = sacred_logger_cls(
             mock_experiment, keys_ignored='a-key').initialize()
         expected = {'a-key', 'batches'}
-        assert npt.keys_ignored_ == expected
+        assert logger.keys_ignored_ == expected
 
     def test_fit_with_real_experiment(
             self,

--- a/skorch/tests/callbacks/test_logging.py
+++ b/skorch/tests/callbacks/test_logging.py
@@ -248,11 +248,11 @@ class TestSacred:
     ):
         # ignore 'dur' and 'valid_loss', 'unknown' doesn't exist but
         # this should not cause a problem
-        npt = sacred_logger_cls(
+        logger = sacred_logger_cls(
             mock_experiment, keys_ignored=['dur', 'valid_loss', 'unknown'])
         net_cls(
             classifier_module,
-            callbacks=[npt],
+            callbacks=[logger],
             max_epochs=3,
         ).fit(*data)
 
@@ -262,7 +262,7 @@ class TestSacred:
         assert 'valid_loss' not in call_args
 
     def test_keys_ignored_is_string(self, sacred_logger_cls, mock_experiment):
-        npt = sacred_logger_cls(
+        logger = sacred_logger_cls(
             mock_experiment, keys_ignored='a-key').initialize()
         expected = {'a-key', 'batches'}
         assert npt.keys_ignored_ == expected

--- a/skorch/tests/conftest.py
+++ b/skorch/tests/conftest.py
@@ -150,6 +150,15 @@ try:
 except ImportError:
     pass
 
+sacred_installed = False
+try:
+    # pylint: disable=unused-import
+    import sacred
+
+    sacred_installed = True
+except ImportError:
+    pass
+
 wandb_installed = False
 try:
     # pylint: disable=unused-import


### PR DESCRIPTION
Similar to the existing Neptune logger, just logging to [Sacred](https://github.com/IDSIA/sacred) instead
of Neptune. The main difference is the name of the logging function and
that an experiment does not have to be closed explicitly. I kept the
documentation and functionality similar, to make it easier to use one as
a drop-in replacement for the other.