### PR TITLE
Remove the deprecated LRScheduler epoch parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- We no longer pass teh `epoch` parameter to LR schedulers, since that parameter has been deprecated. We now rely on the scheduler to keep track of the epoch itself.
+- We no longer pass the `epoch` parameter to LR schedulers, since that parameter has been deprecated. We now rely on the scheduler to keep track of the epoch itself.
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- We no longer pass teh `epoch` parameter to LR schedulers, since that parameter has been deprecated. We now rely on the scheduler to keep track of the epoch itself.
+
 ### Fixed
 
 ## [0.9.0] - 2020-08-30

--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -167,14 +167,14 @@ class LRScheduler(Callback):
                 else:
                     score = net.history[-1, self.monitor]
 
-            self.lr_scheduler_.step(score, epoch)
+            self.lr_scheduler_.step(score)
             # ReduceLROnPlateau does not expose the current lr so it can't be recorded
         else:
             if self.event_name is not None and hasattr(
                     self.lr_scheduler_, "get_last_lr"):
                 net.history.record(self.event_name,
                                    self.lr_scheduler_.get_last_lr()[0])
-            self.lr_scheduler_.step(epoch)
+            self.lr_scheduler_.step()
 
     def on_batch_end(self, net, training, **kwargs):
         if not training or not self.step_every == 'batch':

--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -155,7 +155,6 @@ class LRScheduler(Callback):
     def on_epoch_end(self, net, **kwargs):
         if not self.step_every == 'epoch':
             return
-        epoch = len(net.history)
         if isinstance(self.lr_scheduler_, ReduceLROnPlateau):
             if callable(self.monitor):
                 score = self.monitor(net)


### PR DESCRIPTION
The parameter was deprecated, see [1].

[1] https://github.com/pytorch/pytorch/blob/dee82ef3ea1ed2cae4e891f071adff03cb4a6e0d/torch/optim/lr_scheduler.py#L13