### PR TITLE
Try to fix failing docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.13.3
 https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-linux_x86_64.whl
 sphinx-rtd-theme==0.4.0
 numpydoc==0.8.0
+Cython>=0.28.5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.13.3
 https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-linux_x86_64.whl
 sphinx-rtd-theme==0.4.0
 numpydoc==0.8.0
-Cython>=0.28.5
+scikit-learn>=0.19.1


### PR DESCRIPTION
Build fails with message that Cython>=0.28.5 needs to be installed to build sklearn. Let's add this dependency.