### PR TITLE
Feature/faster history getitem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed implementation of `net.history` access to make it faster; this should not have any noticeable effects, but if you encounter bugs, please create an issue
+
 ### Fixed
 
 ## [0.9.0] - 2020-08-30

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - We no longer pass the `epoch` parameter to LR schedulers, since that parameter has been deprecated. We now rely on the scheduler to keep track of the epoch itself.
-- Changed implementation of `net.history` access to make it faster; this should not have any noticeable effects, but if you encounter bugs, please create an issue
+- Changed implementation of `net.history` access to make it faster; this should result in a nice speedup when dealing with very small model/data but otherwise not have any noticeable effects; if you encounter bugs, though, please create an issue
 
 ### Fixed
 

--- a/skorch/history.py
+++ b/skorch/history.py
@@ -33,15 +33,14 @@ def _getitem_list_list(items, keys):
     filtered = []
     for item in items:
         row = []
-        do_append = True
         for key in keys:
             try:
                 row.append(item[key])
             except KeyError:
-                do_append = False
                 break
-        if row and do_append:
-            filtered.append(row)
+        else:  # no break
+            if row:
+                filtered.append(row)
     return filtered
 
 

--- a/skorch/history.py
+++ b/skorch/history.py
@@ -108,10 +108,6 @@ def _get_getitem_method(items, key):
     * history[0, 'foo', :, ('bar', 'baz')]: key is list/tuple of str
 
     """
-
-    if isinstance(items, tuple):
-        raise ZeroDivisionError
-
     if isinstance(items, list):
         if isinstance(key, list):
             return _getitem_list_list
@@ -119,7 +115,7 @@ def _get_getitem_method(items, key):
             return _getitem_list_tuple
         if isinstance(key, str):
             return _getitem_list_str
-        raise ZeroDivisionError
+        raise TypeError("History access with given types not supported")
 
     if isinstance(items, dict):
         if isinstance(key, list):
@@ -128,7 +124,7 @@ def _get_getitem_method(items, key):
             return _getitem_dict_tuple
         if isinstance(key, str):
             return _getitem_dict_str
-    raise ZeroDivisionError
+    raise TypeError("History access with given types not supported")
 
 
 def _unpack_index(i):

--- a/skorch/history.py
+++ b/skorch/history.py
@@ -39,7 +39,7 @@ def _getitem_list_list(items, keys):
                 row.append(item[key])
             except KeyError:
                 do_append = False
-                continue
+                break
         if row and do_append:
             filtered.append(row)
     return filtered

--- a/skorch/history.py
+++ b/skorch/history.py
@@ -23,17 +23,112 @@ def _filter_none(items):
     return type_(filter(_not_none, items))
 
 
-def _getitem(item, i):
-    """Extract value or values from dicts.
+def _getitem_list_list(items, keys):
+    """Ugly but efficient extraction of multiple values from a list of
+    items.
 
-    Covers the case of a single key or multiple keys. If not found,
-    return placeholders instead.
+    Keys are contained in a list.
 
     """
-    if not isinstance(i, (tuple, list)):
-        return item.get(i, _none)
-    type_ = list if isinstance(item, list) else tuple
-    return type_(item.get(j, _none) for j in i)
+    filtered = []
+    for item in items:
+        row = []
+        do_append = True
+        for key in keys:
+            try:
+                row.append(item[key])
+            except KeyError:
+                do_append = False
+                continue
+        if row and do_append:
+            filtered.append(row)
+    return filtered
+
+
+def _getitem_list_tuple(items, keys):
+    """Ugly but efficient extraction of multiple values from a list of
+    items.
+
+    Keys are contained in a tuple.
+
+    """
+    filtered = []
+    for item in items:
+        row = ()
+        do_append = True
+        for key in keys:
+            try:
+                row += (item[key],)
+            except KeyError:
+                do_append = False
+                break
+        if row and do_append:
+            filtered.append(row)
+    return filtered
+
+
+def _getitem_list_str(items, key):
+    filtered = []
+    for item in items:
+        try:
+            filtered.append(item[key])
+        except KeyError:
+            continue
+    return filtered
+
+
+def _getitem_dict_list(item, keys):
+    return [item.get(key, _none) for key in keys]
+
+
+def _getitem_dict_tuple(item, keys):
+    return tuple(item.get(key, _none) for key in keys)
+
+
+def _getitem_dict_str(item, key):
+    return item.get(key, _none)
+
+
+def _get_getitem_method(items, key):
+    """Return method to extract values from items.
+
+    For the given type of items and type of keys, find the correct
+    method to extract the values. By calling this only once per items,
+    we can save a lot of type checking, which can be slow if there are
+    a lot of epochs and a lot of items. However, we now make the
+    assumption that the type of items doesn't change (we know that the
+    key doesn't change). This should always be true, except if
+    something really weird happens.
+
+    We are multi-dispatching based on the following possibilities:
+
+    * history[0, 'foo', :10]: get a list of items
+    * history[0, 'foo', 0]: get a dict
+    * history[0, 'foo', :, 'bar']: key is a str
+    * history[0, 'foo', :, ('bar', 'baz')]: key is list/tuple of str
+
+    """
+
+    if isinstance(items, tuple):
+        raise ZeroDivisionError
+
+    if isinstance(items, list):
+        if isinstance(key, list):
+            return _getitem_list_list
+        if isinstance(key, tuple):
+            return _getitem_list_tuple
+        if isinstance(key, str):
+            return _getitem_list_str
+        raise ZeroDivisionError
+
+    if isinstance(items, dict):
+        if isinstance(key, list):
+            return _getitem_dict_list
+        if isinstance(key, tuple):
+            return _getitem_dict_tuple
+        if isinstance(key, str):
+            return _getitem_dict_str
+    raise ZeroDivisionError
 
 
 def _unpack_index(i):
@@ -200,14 +295,9 @@ class History(list):
 
         # extract keys of batches
         # handles: history[..., k_e, i_b][k_b]
-        if k_b is not None:
-            items = [
-                _filter_none([_getitem(b, k_b) for b in batches])
-                if isinstance(batches, (list, tuple))
-                else _getitem(batches, k_b)
-                for batches in items
-            ]
-            # get rid of empty batches
+        if items and (k_b is not None):
+            extract = _get_getitem_method(items[0], k_b)
+            items = [extract(batches, k_b) for batches in items]
             items = [b for b in items if b not in (_none, [], ())]
             if not _filter_none(items):
                 # all rows contained _none or were empty
@@ -216,8 +306,11 @@ class History(list):
         # extract epoch-level values, but only if not already done
         # handles: history[..., k_e]
         if (k_e is not None) and (i_b is None):
-            items = [_getitem(batches, k_e)
-                     for batches in items]
+            if not items:
+                raise KeyError(keyerror_msg.format(k_e))
+
+            extract = _get_getitem_method(items[0], k_e)
+            items = [extract(item, k_e) for item in items]
             if not _filter_none(items):
                 raise KeyError(keyerror_msg.format(k_e))
 


### PR DESCRIPTION
Changes implementation of `History.__getitem__` so that the type of
items is only looked up once, not each time for each element. This
should be fine, as the types should not change between
elements (e.g. the rows in `'batches'`).

This can save a lot of time. In an example using 1000 samples, 500
epochs and a very small net, history access time goes down from 10 sec
to 2.5 sec.

Here is the code, provided by @stsievert in #719:

```python
import numpy as np
from sklearn.datasets import make_classification
from torch import nn
from skorch import NeuralNetClassifier

class MyModule(nn.Module):
    def __init__(self, n_targets=85):
        super(MyModule, self).__init__()

        self.lin1 = nn.Linear(3, n_targets)
        self.lin2 = nn.Linear(n_targets, 2)
        self.softmax = nn.Softmax(dim=-1)

    def forward(self, X, **kwargs):
        X = self.softmax(self.lin1(X))
        X = self.softmax(self.lin2(X))
        return X

X, y = make_classification(n_samples=1000, n_features=3, n_redundant=1, random_state=0)
X = X.astype(np.float32)
y = y.astype(np.int64)

net = NeuralNetClassifier(
    module=MyModule,
    max_epochs=500,
    lr=0.1,
    iterator_train__shuffle=True,
    verbose=0,
    train_split=False)

net.fit(X, y)
```

