### PR TITLE
Maintenance: python and pytorch versions updated

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python_version: ['3.6', '3.7', '3.8']
-        torch_version: ['1.5.1+cpu', '1.6.0+cpu', '1.7.0+cpu']
+        torch_version: ['1.4.0+cpu', '1.5.1+cpu', '1.6.0+cpu', '1.7.1+cpu']
         os: [ubuntu-latest]
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -234,10 +234,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.3.1
 - 1.4.0
 - 1.5.1
 - 1.6.0
+- 1.7.1
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -90,10 +90,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.3.1
 - 1.4.0
 - 1.5.1
 - 1.6.0
+- 1.7.1
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of

--- a/skorch/__init__.py
+++ b/skorch/__init__.py
@@ -17,14 +17,6 @@ from . import callbacks
 MIN_TORCH_VERSION = '1.1.0'
 
 
-# TODO: remove in skorch 0.10.0
-if sys.version_info < (3, 6):
-    warnings.warn(
-        "Official support for Python 3.5 will be dropped starting from "
-        "skorch version 0.10.0",
-        FutureWarning,
-    )
-
 try:
     # pylint: disable=wrong-import-position
     import torch

--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -115,16 +115,6 @@ class LRScheduler(Callback):
         self.policy_ = self._get_policy_cls()
         self.lr_scheduler_ = None
         self.batch_idx_ = 0
-        # TODO: Remove this warning on 0.10 release
-        if (self.policy_ == TorchCyclicLR or self.policy_ == "TorchCyclicLR"
-                and self.step_every == 'epoch'):
-            warnings.warn(
-                "The LRScheduler now makes a step every epoch by default. "
-                "To have the cyclic lr scheduler update "
-                "every batch set step_every='batch'",
-                FutureWarning
-            )
-
         return self
 
     def _get_policy_cls(self):

--- a/skorch/tests/callbacks/test_lr_scheduler.py
+++ b/skorch/tests/callbacks/test_lr_scheduler.py
@@ -241,26 +241,8 @@ class TestLRCallbacks:
         )
         assert np.all(net.history[-1, 'batches', :, 'event_lr'] == new_lrs)
 
-    def test_cyclic_lr_with_epoch_step_warning(self,
-                                               classifier_module,
-                                               classifier_data):
-        msg = ("The LRScheduler now makes a step every epoch by default. "
-               "To have the cyclic lr scheduler update "
-               "every batch set step_every='batch'")
-        with pytest.warns(FutureWarning, match=msg) as record:
-            scheduler = LRScheduler(
-                TorchCyclicLR, base_lr=123, max_lr=999)
-            net = NeuralNetClassifier(
-                classifier_module,
-                max_epochs=0,
-                callbacks=[('scheduler', scheduler)],
-            )
-            net.initialize()
-        assert len(record) == 1
-
 
 class TestReduceLROnPlateau:
-
     def get_net_with_mock(
             self, classifier_data, classifier_module, monitor='train_loss'):
         """Returns a net with a mocked lr policy that allows to check what


### PR DESCRIPTION
Supersedes #686 

- use github actions instead of travis
- add CI for PyTorch 1.4.0 (since we want to support 4 versions)
- check PyTorch 1.7.1 instead of 1.7.0
- update docs
- remove warning about Python 3.5 support
- remove warning about change in CyclicLR step being per epoch