### PR TITLE
Don't re-initialize uninitialized net after calling set_params

### DIFF
--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1654,11 +1654,12 @@ class NeuralNet:
             # callbacks need special treatmeant since they are list of tuples
             self.initialize_callbacks()
             self._set_params_callback(**cb_params)
-
-        # if the net is not initialized, just set the attributes on the net and
-        # exist early, no need to initialize any components
-        if not self.initialized_:
             vars(self).update(cb_params)
+
+        # if the net is not initialized, we can exit as this point, because the
+        # special_params have been set as attributes and will be applied by
+        # initialize() at a later point in time.
+        if not self.initialized_:
             return self
 
         # Below: Re-initialize parts of the net if necessary.

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1650,12 +1650,18 @@ class NeuralNet:
                     "caused this error.")
             setattr(self, key, val)
 
-        # Below: Re-initialize parts of the net if necessary.
-
         if cb_params:
             # callbacks need special treatmeant since they are list of tuples
             self.initialize_callbacks()
             self._set_params_callback(**cb_params)
+
+        # if the net is not initialized, just set the attributes on the net and
+        # exist early, no need to initialize any components
+        if not self.initialized_:
+            vars(self).update(cb_params)
+            return self
+
+        # Below: Re-initialize parts of the net if necessary.
 
         if any('criterion' in key.split('__', 1)[0] for key in special_params):
             self.initialize_criterion()

--- a/skorch/tests/test_cli.py
+++ b/skorch/tests/test_cli.py
@@ -351,10 +351,10 @@ class TestCli:
 
         # cmd line args have precedence over defaults
         assert net.batch_size == 123
-        assert net.module_.hidden_units == 55
-        assert isinstance(net.module_.nonlin, nn.Hardtanh)
-        assert net.module_.nonlin.min_val == 1
-        assert net.module_.nonlin.max_val == 2
+        assert net.module__hidden_units == 55
+        assert isinstance(net.module__nonlin, nn.Hardtanh)
+        assert net.module__nonlin.min_val == 1
+        assert net.module__nonlin.max_val == 2
 
     def test_parse_args_pipe_custom_defaults(self, parse_args, pipe):
         defaults = {'net__batch_size': 256, 'net__module__hidden_units': 55}
@@ -365,10 +365,10 @@ class TestCli:
 
         # cmd line args have precedence over defaults
         assert net.batch_size == 123
-        assert net.module_.hidden_units == 55
-        assert isinstance(net.module_.nonlin, nn.Hardtanh)
-        assert net.module_.nonlin.min_val == 1
-        assert net.module_.nonlin.max_val == 2
+        assert net.module__hidden_units == 55
+        assert isinstance(net.module__nonlin, nn.Hardtanh)
+        assert net.module__nonlin.min_val == 1
+        assert net.module__nonlin.max_val == 2
 
     def test_parse_args_sklearn_pipe_custom_defaults(self, parse_args, pipe_sklearn):
         defaults = {'features__scale__copy': 123, 'clf__fit_intercept': 456}


### PR DESCRIPTION
Previously, when a parameter on, say, the module was changed via
`set_params` (e.g. `net.set_params(module__hidden_units=123)`),
`set_params` would always trigger (re-)initialization of the module. However,
when the net was not initialized in the first place, this is unnecessary. It
is sufficient to set the new attribute and wait for the net to be
initialized later.

Fortunately, this change doesn't seem to have any further impact, i.e.
we didn't implicitly rely on this behavior anywhere. The only exceptions
are 2 tests in `test_cli.py`, but those can easily be adjusted and this
shouldn't have any user impact.