### PR TITLE
Docs: Fix class path in predefined_split example

### DIFF
--- a/skorch/helper.py
+++ b/skorch/helper.py
@@ -251,7 +251,7 @@ def predefined_split(dataset):
 
     Examples
     --------
-    >>> valid_ds = skorch.Dataset(X, y)
+    >>> valid_ds = skorch.dataset.Dataset(X, y)
     >>> net = NeuralNet(..., train_split=predefined_split(valid_ds))
 
     Parameters


### PR DESCRIPTION
**What does this PR implement?**
It fixes the class path in the example of predefined_split, using `skorch.dataset.Dataset` instead of `skorch.Dataset`

**Reference issues/PRs**
None