### PR TITLE
history: Fix regressions in __getitem__

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a few bugs in the `net.history` implementation (#776)
+
 ## [0.10.0] - 2021-03-23
 
 ### Added


### PR DESCRIPTION
* Index epochs first so IndexError is always raised for bad epoch
  indices, and so jagged batch counts don't raise a false IndexError.

* Only filter epochs with non-matching keys once, and do it after
  indexing epochs to avoid returning values from the wrong epoch(s).

* Never compare arbitrary values to empty lists or tuples - instead,
  generate _none if no batches matched the keys to exclude the epoch.

* Don't raise KeyError if all batches are requested but there are no
  epochs - an empty list is probably more useful.

---

There are 8 new tests - 13 if you count all the parameterized variants.

Command used to run the new regression tests:
```
pytest --no-header --disable-warnings -c /dev/null skorch/tests/test_history_newtests.py
```

Tests included in test_history_newtests.py: test_history_key_in_other_epoch, test_history_no_epochs_index, test_history_jagged_batches

### Test Results

Selected tests before commit c50f3bb29571a2cfb2445815dae5c015fb5a708e:
```
============================= test session starts ==============================
collected 3 items                                                              

skorch/tests/test_history_newtests.py ...                                [100%]

======================= 3 passed, 3220 warnings in 0.01s =======================
```

Selected tests on commit c50f3bb29571a2cfb2445815dae5c015fb5a708e (PR #312):
```
============================= test session starts ==============================
collected 3 items                                                              

skorch/tests/test_history_newtests.py FFF                                [100%]

=================================== FAILURES ===================================
_________________ TestHistory.test_history_key_in_other_epoch __________________

self = <skorch.tests.test_history_newtests.TestHistory object at 0x7f95b3572460>

    def test_history_key_in_other_epoch(self):
        h = History()
        for has_valid in (True, False):
            h.new_epoch()
            h.new_batch()
            h.record_batch('train_loss', 1)
            if has_valid:
                h.new_batch()
                h.record_batch('valid_loss', 2)
    
        with pytest.raises(KeyError):
            # pylint: disable=pointless-statement
>           h[-1, 'batches', -1, 'valid_loss']
E           Failed: DID NOT RAISE <class 'KeyError'>

skorch/tests/test_history_newtests.py:43: Failed
___________________ TestHistory.test_history_no_epochs_index ___________________

self = <skorch.tests.test_history_newtests.TestHistory object at 0x7f95b354e580>

    def test_history_no_epochs_index(self):
        h = History()
        with pytest.raises(IndexError):
            # pylint: disable=pointless-statement
>           h[-1, 'batches']

skorch/tests/test_history_newtests.py:49: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = [], i = (-1, 'batches')

    def __getitem__(self, i):
        # This implementation resolves indexing backwards,
        # i.e. starting from the batches, then progressing to the
        # epochs.
        if isinstance(i, (int, slice)):
            i = (i,)
    
        # i_e: index epoch, k_e: key epoch
        # i_b: index batch, k_b: key batch
        i_e, k_e, i_b, k_b = _unpack_index(i)
        keyerror_msg = "Key '{}' was not found in history."
    
        if i_b is not None and k_e != 'batches':
            raise KeyError("History indexing beyond the 2nd level is "
                           "only possible if key 'batches' is used, "
                           "found key '{}'.".format(k_e))
    
        items = self.to_list()
    
        # extract indices of batches
        # handles: history[..., k_e, i_b]
        if i_b is not None:
            items = [row[k_e][i_b] for row in items]
    
        # extract keys of batches
        # handles: history[..., k_e, i_b][k_b]
        if k_b is not None:
            items = [
                _filter_none([_getitem(b, k_b) for b in batches])
                if isinstance(batches, (list, tuple))
                else _getitem(batches, k_b)
                for batches in items
            ]
            # get rid of empty batches
            items = [b for b in items if b not in (_none, [], ())]
            if not _filter_none(items):
                # all rows contained _none or were empty
                raise KeyError(keyerror_msg.format(k_b))
    
        # extract epoch-level values, but only if not already done
        # handles: history[..., k_e]
        if (k_e is not None) and (i_b is None):
            items = [_getitem(batches, k_e)
                     for batches in items]
            if not _filter_none(items):
>               raise KeyError(keyerror_msg.format(k_e))
E               KeyError: "Key 'batches' was not found in history."

skorch/history.py:210: KeyError
___________________ TestHistory.test_history_jagged_batches ____________________

self = <skorch.tests.test_history_newtests.TestHistory object at 0x7f95b34f3af0>

    def test_history_jagged_batches(self):
        h = History()
        for num_batch in (1, 2):
            h.new_epoch()
            for _ in range(num_batch):
                h.new_batch()
        # Make sure we can access this batch
>       assert h[-1, 'batches', 1] == {}

skorch/tests/test_history_newtests.py:58: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
skorch/history.py:187: in __getitem__
    items = [row[k_e][i_b] for row in items]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <list_iterator object at 0x7f95b34f3820>

>   items = [row[k_e][i_b] for row in items]
E   IndexError: list index out of range

skorch/history.py:187: IndexError
=========================== short test summary info ============================
FAILED skorch/tests/test_history_newtests.py::TestHistory::test_history_key_in_other_epoch
FAILED skorch/tests/test_history_newtests.py::TestHistory::test_history_no_epochs_index
FAILED skorch/tests/test_history_newtests.py::TestHistory::test_history_jagged_batches
======================= 3 failed, 3223 warnings in 0.12s =======================
```

Selected tests on master (commit 1d37ef3be97d0015463a4513006c970cc86c5ebe):
```
============================= test session starts ==============================
collected 3 items                                                              

skorch/tests/test_history_newtests.py FFF                                [100%]

=================================== FAILURES ===================================
[snip]
```

Selected tests on this PR:
```
============================= test session starts ==============================
collected 3 items                                                              

skorch/tests/test_history_newtests.py ...                                [100%]

======================= 3 passed, 3219 warnings in 0.01s =======================
```