### PR TITLE
FIX Allows TrainEndCheckpoint to be unpickled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a few bugs in the `net.history` implementation (#776)
+- Fixed a bug in `TrainEndCheckpoint` that prevented it from being unpickled (#773)
 
 ## [0.10.0] - 2021-03-23
 

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -1,6 +1,7 @@
 """Tests for callbacks in training.py"""
 
 from functools import partial
+import pickle
 from unittest.mock import Mock
 from unittest.mock import patch
 from unittest.mock import call
@@ -1125,3 +1126,17 @@ class TestTrainEndCheckpoint:
 
         assert save_params_mock.call_count == 1
         save_params_mock.assert_has_calls([call(f_mymodule='train_end_mymodule.pt')])
+
+    def test_pickle_uninitialized_callback(self, trainendcheckpoint_cls):
+        # isuue 773
+        cp = trainendcheckpoint_cls()
+        # does not raise
+        s = pickle.dumps(cp)
+        pickle.loads(s)
+
+    def test_pickle_initialized_callback(self, trainendcheckpoint_cls):
+        # issue 773
+        cp = trainendcheckpoint_cls().initialize()
+        # does not raise
+        s = pickle.dumps(cp)
+        pickle.loads(s)


### PR DESCRIPTION
Fixes #773

Removes `__getattr__` from `TrainEndCheckpoint`. This should not be BC breaking because `Checkpoint` does not set attributes that is not already set in `TrainEndCheckpoint`.

Alternative to #774