### PR TITLE
Fix a bug that led to double-registration

### DIFF
--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1792,7 +1792,10 @@ class NeuralNet:
         # special treatment.
         params_cb = self._get_params_callbacks(deep=deep)
         params.update(params_cb)
-        return params
+
+        # don't include the following attributes
+        to_exclude = {'_modules', '_criteria', '_optimizers'}
+        return {key: val for key, val in params.items() if key not in to_exclude}
 
     def _check_kwargs(self, kwargs):
         """Check argument names passed at initialization.
@@ -2095,11 +2098,13 @@ class NeuralNet:
             self.cuda_dependent_attributes_ = (
                 self.cuda_dependent_attributes_[:] + [name + '_'])
 
-        if self.init_context_ == 'module':
+        # make sure to not double register -- this should never happen, but
+        # still better to check
+        if (self.init_context_ == 'module') and (name not in self._modules):
             self._modules = self._modules[:] + [name]
-        elif self.init_context_ == 'criterion':
+        elif (self.init_context_ == 'criterion') and (name not in self._criteria):
             self._criteria = self._criteria[:] + [name]
-        elif self.init_context_ == 'optimizer':
+        elif (self.init_context_ == 'optimizer') and (name not in self._optimizers):
             self._optimizers = self._optimizers[:] + [name]
 
     def _unregister_attribute(

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -574,6 +574,7 @@ class TestNeuralNet:
 
     def test_save_load_state_dict_no_duplicate_registration_after_initialize(
             self, net_cls, module_cls, net_fit, tmpdir):
+        # #781
         net = net_cls(module_cls).initialize()
 
         p = tmpdir.mkdir('skorch').join('testmodel.pkl')
@@ -592,6 +593,7 @@ class TestNeuralNet:
 
     def test_save_load_state_dict_no_duplicate_registration_after_clone(
             self, net_fit, tmpdir):
+        # #781
         net = clone(net_fit).initialize()
 
         p = tmpdir.mkdir('skorch').join('testmodel.pkl')
@@ -1461,6 +1463,15 @@ class TestNeuralNet:
         params = net.get_params(deep=True)
         # now initialized
         assert 'callbacks__myscore__scoring' in params
+
+    def test_get_params_no_unwanted_params(self, net, net_fit):
+        # #781
+        # make sure certain keys are not returned
+        keys_unwanted = {'_modules', '_criteria', '_optimizers'}
+        for net_ in (net, net_fit):
+            keys_found = set(net_.get_params())
+            overlap = keys_found & keys_unwanted
+            assert not overlap
 
     def test_get_params_with_uninit_callbacks(self, net_cls, module_cls):
         from skorch.callbacks import EpochTimer


### PR DESCRIPTION
This is a bug introduced by a last minute change in #751 

After `clone`ing a net, `_module`, `_criteria`, and `_optimizers` are already
populated. Then, when loading params, there is yet another registration,
i.e. a double registration. As a consequence, there would be two
`'modules'` etc. This is a fix for that.

The solution is a two-pronged: Don't return `_modules` etc. when cloning,
and make a safety check during registration. Either of those should be
sufficient, but it's probably better to be extra safe.