### PR TITLE
Fix bug that could lead to duplicate params

### DIFF
--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2660,6 +2660,29 @@ class TestNeuralNet:
         # module is not re-initialized, since virtual parameter
         assert len(side_effects) == 1
 
+    def test_module_referencing_another_module_no_duplicate_params(
+            self, net_cls, module_cls
+    ):
+        # When a module references another module, it will yield that modules'
+        # parameters. Therefore, if we collect all paramters, we have to make
+        # sure that there are no duplicate parameters.
+        class MyCriterion(torch.nn.NLLLoss):
+            """Criterion that references net.module_"""
+            def __init__(self, *args, themodule, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.themodule = themodule
+
+        class MyNet(net_cls):
+            def initialize_criterion(self):
+                kwargs = self.get_params_for('criterion')
+                kwargs['themodule'] = self.module_
+                self.criterion_ = self.criterion(**kwargs)
+                return self
+
+        net = MyNet(module_cls, criterion=MyCriterion).initialize()
+        params = [p for _, p in net.get_all_learnable_params()]
+        assert len(params) == len(set(params))
+
     def test_custom_optimizer_lr_is_associated_with_optimizer(
             self, net_cls, module_cls,
     ):


### PR DESCRIPTION
When a net's module references another of that net's modules, the former
will yield the latter's parameters. Therefore, when all parameters are
collected, the latter's parameters appear twice.

This bugfix consists of remembering all yielded parameters in a set and
not yielding those that were already encountered.

This bug was introduced very recently (#751) and should occur very
rarely, since modules don't typically reference each other.