### PR TITLE
TST Fix test collection on cuda

### DIFF
--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -100,8 +100,8 @@ class TestToTensor:
                 ),
                 (torch.as_tensor(55), torch.as_tensor(55).to('cuda')),
                 (
-                    pack_padded_sequence(x, y),
-                    pack_padded_sequence(x, y).to('cuda')
+                    pack_padded_sequence(x, y.to('cpu')),
+                    pack_padded_sequence(x, y.to('cpu')).to('cuda')
                 ),
         ]:
             yield X, expected, device


### PR DESCRIPTION
This PR makes sure that CUDA tests can run. As stated in the [pack_padded_sequence](https://pytorch.org/docs/stable/generated/torch.nn.utils.rnn.pack_padded_sequence.html?highlight=pack_padded_sequence#torch.nn.utils.rnn.pack_padded_sequence) docs, the lengths must be on the cpu.

With this PR, cuda tests can run and two tests will fail:

<details>
 <summary>TestNeuralNet.test_pickle_load[False] </summary>

```
_________________________________________________ TestNeuralNet.test_pickle_load[False] __________________________________________________
                                                                                                                                          
self = <skorch.tests.test_net.TestNeuralNet object at 0x7f28a45b1970>, cuda_available = False                                             
pickled_cuda_net_path = 'skorch/tests/net_cuda.pkl'                                                                                       
                                                                     
    @pytest.mark.parametrize('cuda_available', {False, torch.cuda.is_available()})                                                        
    def test_pickle_load(self, cuda_available, pickled_cuda_net_path):                                                                            with patch('torch.cuda.is_available', lambda *_: cuda_available):                                                                 
            with open(pickled_cuda_net_path, 'rb') as f:                                                                                  
>               pickle.load(f)                                                                                                            
                                                                                                                                          
skorch/tests/test_net.py:421:                                                                                                             
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../miniconda3/envs/skorch/lib/python3.9/site-packages/torch/storage.py:161: in _load_from_bytes                                        
    return torch.load(io.BytesIO(b))                                                                                                      
../../miniconda3/envs/skorch/lib/python3.9/site-packages/torch/serialization.py:593: in load                                              
    return _legacy_load(opened_file, map_location, pickle_module, **pickle_load_args)                                                     
../../miniconda3/envs/skorch/lib/python3.9/site-packages/torch/serialization.py:772: in _legacy_load                                      
    result = unpickler.load()                                                                                                             ../../miniconda3/envs/skorch/lib/python3.9/site-packages/torch/serialization.py:728: in persistent_load                                   
    deserialized_objects[root_key] = restore_location(obj, location)                                                                      
../../miniconda3/envs/skorch/lib/python3.9/site-packages/torch/serialization.py:175: in default_restore_location                          
    result = fn(storage, location)                                                                                                        
../../miniconda3/envs/skorch/lib/python3.9/site-packages/torch/serialization.py:151: in _cuda_deserialize                                 
    device = validate_cuda_device(location)                                                                                               
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
                                                                                                                                          
location = 'cuda:0'                                                                                                                       
                                                                                                                                          
    def validate_cuda_device(location):                                                                                                   
        device = torch.cuda._utils._get_device_index(location, True)                                                                      
                                                                     
        if not torch.cuda.is_available():                                                                                                 
>           raise RuntimeError('Attempting to deserialize object on a CUDA '                                                              
                               'device but torch.cuda.is_available() is False. '                                                          
                               'If you are running on a CPU-only machine, '                                                               
                               'please use torch.load with map_location=torch.device(\'cpu\') '                                           
                               'to map your storages to the CPU.')                                                                        
E           RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on 
a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.                          

../../miniconda3/envs/skorch/lib/python3.9/site-packages/torch/serialization.py:135: RuntimeError
```

</details>

<details>
 <summary>TestProgressBar.test_pickle </summary>

```
______________________________________________________ TestProgressBar.test_pickle _______________________________________________________
                                                                                                                                          
self = <test_logging.TestProgressBar object at 0x7f28407c7940>                                                                            
net_cls = functools.partial(<class 'skorch.regressor.NeuralNetRegressor'>, module=functools.partial(<class 'skorch.toy.MLPModule'>, output
_units=1, input_units=1, num_hidden=0), train_split=None, max_epochs=2, batch_size=10)                                                    
progressbar_cls = <class 'skorch.callbacks.logging.ProgressBar'>                                                                          
data = (array([[0.],                                                                                                                      
       [0.],                                                                                                                                     [0.],                                                                                                                              
       [0.],                                                                                                                              
       [0.],                                                                                                                              
       [0.],                                                                                                                              
       [0.],                                                                                                                              
       [0.],                                                                                                                              
       [0.],                                                         
...      [0.],                                                                                                                            
       [0.],                                                                                                                              
       [0.],                                                                                                                              
       [0.],                                                                                                                              
       [0.],                                                                                                                              
       [0.],                                                         
       [0.],                                                                                                                              
       [0.]], dtype=float32))                                                                                                             
                                                                                                                                          
    def test_pickle(self, net_cls, progressbar_cls, data):                                                                                
        # pickling was an issue since TQDM progress bar instances cannot                                                                  
        # be pickled. Test pickling and restoration.                                                                                      
        import pickle                                                                                                                     
                                                                                                                                          
        net = net_cls(callbacks=[
            progressbar_cls(),
        ])
        net.fit(*data)
>       dump = pickle.dumps(net)

skorch/tests/callbacks/test_logging.py:704: 

        # Write the pickle data for `obj`
        data_buf = io.BytesIO()
        pickler = pickle_module.Pickler(data_buf, protocol=pickle_protocol)
        pickler.persistent_id = persistent_id
>       pickler.dump(obj)
E       AttributeError: Can't pickle local object 'TorchGraph.create_forward_hook.<locals>.after_forward_hook'

../../miniconda3/envs/skorch/lib/python3.9/site-packages/torch/serialization.py:476: AttributeError
```

</details>