### PR TITLE
Add logo variant for dark/light mode

### DIFF
--- a/assets/skorch_bordered.svg
+++ b/assets/skorch_bordered.svg
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="45.377293mm"
+   height="10.031023mm"
+   viewBox="0 0 45.377293 10.031023"
+   version="1.1"
+   id="svg8769"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="skorch_framed.svg">
+  <defs
+     id="defs8763" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9195959"
+     inkscape:cx="77.894717"
+     inkscape:cy="13.549026"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="3840"
+     inkscape:window-height="2032"
+     inkscape:window-x="0"
+     inkscape:window-y="54"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false" />
+  <metadata
+     id="metadata8766">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     style="display:inline"
+     transform="translate(0.3906939,-0.23600169)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path13291"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.52499962px;line-height:1.25;font-family:'Proxima Nova';-inkscape-font-specification:'Proxima Nova Bold';letter-spacing:1.60866666px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#d45500;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers"
+       d="m 23.084343,9.9670248 v -6.3531 h 2.97191 q 0.97669,0 1.55805,0.57206 0.58601,0.57206 0.58601,1.47433 0,0.39997 -0.12093,0.73949 -0.12092,0.33951 -0.32556,0.5674 -0.20464,0.22325 -0.44648,0.37207 -0.2372,0.14418 -0.50695,0.20929 l 1.43712,2.41846 h -1.56269 l -1.24644,-2.25568 h -0.99063 v 2.25568 z m 1.35341,-3.4463 h 1.42782 q 0.40927,0 0.67437,-0.23255 0.26975,-0.23719 0.26975,-0.63717 0,-0.38602 -0.26975,-0.61391 -0.2651,-0.23255 -0.67437,-0.23255 h -1.42782 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path13293"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.52499962px;line-height:1.25;font-family:'Proxima Nova';-inkscape-font-specification:'Proxima Nova Bold';letter-spacing:1.60866666px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:0.60000002;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers"
+       d="m 30.51126,6.6788548 q 0,-0.96273 0.44648,-1.71617 0.44649,-0.75345 1.21853,-1.16272 0.77205,-0.40928 1.72548,-0.40928 0.50229,0 0.93017,0.13022 0.43253,0.12558 0.74879,0.35347 0.32091,0.22324 0.55346,0.48834 0.23719,0.26045 0.41393,0.58136 l -1.16272,0.57206 q -0.20464,-0.39997 -0.60927,-0.66042 -0.40462,-0.26045 -0.87436,-0.26045 -0.86972,0 -1.43712,0.59066 -0.56276,0.59066 -0.56276,1.49293 0,0.90227 0.56276,1.49758 0.5674,0.59066 1.43712,0.59066 0.46974,0 0.87436,-0.26044 0.40463,-0.2651 0.60927,-0.66508 l 1.16272,0.56276 q -0.18139,0.32091 -0.41393,0.58601 -0.22789,0.26045 -0.5488,0.48834 -0.32092,0.22789 -0.75345,0.35812 -0.42788,0.13022 -0.93017,0.13022 -0.71159,0 -1.33946,-0.24184 -0.62321,-0.24185 -1.079,-0.66508 -0.45114,-0.42788 -0.71158,-1.0418 -0.26045,-0.61856 -0.26045,-1.33945 z" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path13295"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.52499962px;line-height:1.25;font-family:'Proxima Nova';-inkscape-font-specification:'Proxima Nova Bold';letter-spacing:1.60866666px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:0.60000002;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers"
+       d="m 38.97067,9.9670248 v -6.3531 h 1.3534 v 2.49752 h 2.99982 v -2.49752 h 1.36271 v 6.3531 h -1.36271 v -2.67426 h -2.99982 v 2.67426 z" />
+    <g
+       transform="translate(-130.35908,-125.62714)"
+       aria-label="S"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.52499962px;line-height:1.25;font-family:'Proxima Nova';-inkscape-font-specification:'Proxima Nova';letter-spacing:1.60866666px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:0.60000002;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers"
+       id="text9641">
+      <path
+         d="m 130.35908,134.58027 0.74414,-1.05575 q 0.36742,0.38602 0.88367,0.62787 0.5209,0.24185 1.13481,0.24185 0.53486,0 0.81856,-0.19999 0.2837,-0.20464 0.2837,-0.50695 0,-0.19534 -0.15813,-0.33486 -0.15813,-0.14418 -0.41393,-0.21859 -0.25579,-0.0791 -0.58601,-0.16278 -0.32556,-0.0884 -0.66972,-0.16278 -0.34417,-0.0791 -0.67438,-0.22325 -0.32556,-0.14882 -0.58136,-0.33951 -0.2558,-0.19534 -0.41393,-0.52555 -0.15813,-0.33021 -0.15813,-0.75809 0,-0.81856 0.65578,-1.37201 0.66042,-0.55811 1.75338,-0.55811 1.52548,0 2.47892,0.88367 l -0.75345,1.00924 q -0.37672,-0.34417 -0.86041,-0.51625 -0.48369,-0.17673 -0.98599,-0.17673 -0.42323,0 -0.66042,0.17208 -0.2372,0.16743 -0.2372,0.45579 0,0.17673 0.15348,0.30696 0.15813,0.13022 0.41393,0.20463 0.26045,0.0698 0.58601,0.15813 0.33021,0.0837 0.66973,0.16278 0.33951,0.0791 0.66507,0.23255 0.33022,0.14883 0.58602,0.34881 0.26044,0.19534 0.41392,0.52555 0.15813,0.33022 0.15813,0.75345 0,0.91157 -0.65577,1.47898 -0.65112,0.56275 -1.88361,0.56275 -1.69292,0 -2.70681,-1.01389 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.52499962px;font-family:'Proxima Nova';-inkscape-font-specification:'Proxima Nova Bold';letter-spacing:1.60866666px;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:0.60000002;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers"
+         id="path13288"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="translate(-130.35908,-125.51087)"
+       aria-label=" K"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:9.52499962px;line-height:1.25;font-family:'Proxima Nova';-inkscape-font-specification:'Proxima Nova';letter-spacing:1.60866666px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:0.60000002;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers"
+       id="text9645">
+      <path
+         d="m 138.0356,135.47789 v -6.3531 h 1.3534 v 2.82773 l 2.24638,-2.82773 h 1.66966 l -2.52542,2.98121 2.69751,3.37189 h -1.66967 l -1.92546,-2.55333 -0.493,0.59996 v 1.95337 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.52499962px;font-family:'Proxima Nova';-inkscape-font-specification:'Proxima Nova Bold';letter-spacing:1.60866666px;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:0.60000002;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers"
+         id="path13285"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       style="stroke:#ffffff;stroke-width:0.31057522;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers"
+       id="g1034"
+       transform="matrix(0.96594955,0,0,0.96594955,-125.27549,-121.58516)">
+      <path
+         id="path9627"
+         d="m 146.58431,132.73293 c -0.44379,0.44377 -0.51755,1.08948 -0.16474,1.44226 0.35277,0.35277 0.99846,0.27901 1.44222,-0.16472 0.44377,-0.44376 0.3154,-1.29157 0.16471,-1.44228 -0.12177,-0.12176 -0.99845,-0.279 -1.44219,0.16474 z"
+         inkscape:connector-curvature="0"
+         style="fill:#f89939;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.31057522;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers" />
+      <path
+         style="fill:#3499cd;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.31057522;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers"
+         inkscape:connector-curvature="0"
+         d="m 149.92045,132.73293 c 0.4438,0.44377 0.51756,1.08948 0.16474,1.44226 -0.35277,0.35277 -0.99845,0.27901 -1.44222,-0.16472 -0.44377,-0.44376 -0.31539,-1.29157 -0.16471,-1.44228 0.12177,-0.12176 0.99845,-0.279 1.44219,0.16474 z"
+         id="path9629" />
+      <path
+         style="fill:#3499cd;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.31057522;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers"
+         inkscape:connector-curvature="0"
+         d="m 146.58431,131.9626 c -0.44379,-0.44377 -0.51755,-1.08949 -0.16474,-1.44227 0.35277,-0.35274 0.99846,-0.279 1.44222,0.16475 0.44377,0.44374 0.3154,1.29155 0.16471,1.44226 -0.12177,0.12176 -0.99845,0.279 -1.44219,-0.16474 z"
+         id="path9631" />
+      <path
+         id="path9633"
+         d="m 149.92045,131.9626 c 0.4438,-0.44377 0.51756,-1.08949 0.16474,-1.44227 -0.35277,-0.35274 -0.99845,-0.279 -1.44222,0.16475 -0.44377,0.44374 -0.31539,1.29155 -0.16471,1.44226 0.12177,0.12176 0.99845,0.279 1.44219,-0.16474 z"
+         inkscape:connector-curvature="0"
+         style="fill:#f89939;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.31057522;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers" />
+    </g>
+    <g
+       id="g933"
+       transform="matrix(0.30531387,0,0,0.30531387,14.142937,0.77707744)"
+       style="stroke:#ffffff;stroke-width:1.96519077;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers">
+      <path
+         style="fill:#ee4c2c;stroke:#ffffff;stroke-width:1.96519077;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers"
+         inkscape:connector-curvature="0"
+         class="st0"
+         d="m 21,9.2 -2.2,2.2 c 3.6,3.6 3.6,9.4 0,12.9 -3.6,3.6 -9.4,3.6 -12.9,0 -3.6,-3.6 -3.6,-9.4 0,-12.9 v 0 l 5.7,-5.7 0.8,-0.8 v 0 -4.3 L 3.8,9.2 C -1,14 -1,21.7 3.8,26.5 8.6,31.3 16.3,31.3 21,26.5 25.8,21.7 25.8,14 21,9.2 Z"
+         id="path929" />
+      <circle
+         style="fill:#ee4c2c;stroke:#ffffff;stroke-width:1.96519077;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers"
+         class="st0"
+         cx="16.700001"
+         cy="7.0999999"
+         r="1.6"
+         id="circle931" />
+    </g>
+    <path
+       d="m 23.084343,9.9670248 v -6.3531 h 2.97191 q 0.97669,0 1.55805,0.57206 0.58601,0.57206 0.58601,1.47433 0,0.39997 -0.12093,0.73949 -0.12092,0.33951 -0.32556,0.5674 -0.20464,0.22325 -0.44648,0.37207 -0.2372,0.14418 -0.50695,0.20929 l 1.43712,2.41846 h -1.56269 l -1.24644,-2.25568 h -0.99063 v 2.25568 z m 1.35341,-3.4463 h 1.42782 q 0.40927,0 0.67437,-0.23255 0.26975,-0.23719 0.26975,-0.63717 0,-0.38602 -0.26975,-0.61391 -0.2651,-0.23255 -0.67437,-0.23255 h -1.42782 z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:9.52499962px;line-height:1.25;font-family:'Proxima Nova';-inkscape-font-specification:'Proxima Nova Bold';letter-spacing:1.60866666px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:0.60000002;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke fill markers"
+       id="path871"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-129.96839,-125.98862)"
+     style="display:inline" />
+  <style
+     id="style927"
+     type="text/css">
+	.st0{fill:#EE4C2C;}
+	.st1{fill:#FFFFFF;}
+</style>
+</svg>


### PR DESCRIPTION
Should be readable in both cases using a white border.

Resolves #800.