### PR TITLE
Add `restore_best_weights` argument to EarlyStopping callback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `load_best` attribute to `EarlyStopping` callback to automatically load module weights of the best result at the end of training
 
 ### Changed
 
@@ -18,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `load_best` attribute to `Checkpoint` callback to automatically load state of the best result at the end of training
-- Added `load_best` attribute to `EarlyStopping` callback to automatically load module weights of the best result at the end of training
 - Added a `get_all_learnable_params` method to retrieve the named parameters of all PyTorch modules defined on the net, including of criteria if applicable
 - Added `MlflowLogger` callback for logging to Mlflow (#769)
 - Added `InputShapeSetter` callback for automatically setting the input dimension of the PyTorch module

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `load_best` attribute to `Checkpoint` callback to automatically load state of the best result at the end of training
+- Added `load_best` attribute to `EarlyStopping` callback to automatically load module weights of the best result at the end of training
 - Added a `get_all_learnable_params` method to retrieve the named parameters of all PyTorch modules defined on the net, including of criteria if applicable
 - Added `MlflowLogger` callback for logging to Mlflow (#769)
 - Added `InputShapeSetter` callback for automatically setting the input dimension of the PyTorch module

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -398,7 +398,7 @@ class EarlyStopping(Callback):
 
     def __getstate__(self):
         # Avoids to save the module_ weights twice when pickling
-        state = self.__dict__
+        state = self.__dict__.copy()
         state['best_model_weights_'] = None
         return state
 

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -7,6 +7,7 @@ from contextlib import suppress
 from fnmatch import fnmatch
 from functools import partial
 from itertools import product
+from copy import deepcopy
 
 import numpy as np
 from skorch.callbacks import Callback
@@ -414,7 +415,7 @@ class EarlyStopping(Callback):
             self.dynamic_threshold_ = self._calc_new_threshold(current_score)
             self.best_epoch_ = net.history[-1, "epoch"]
             if self.load_best:
-                self.best_model_weights_ = net.module_.state_dict()
+                self.best_model_weights_ = deepcopy(net.module_.state_dict())
         if self.misses_ == self.patience:
             if net.verbose:
                 self._sink("Stopping since {} has not improved in the last "

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -358,9 +358,9 @@ class EarlyStopping(Callback):
       Ignore score improvements smaller than `threshold`.
 
     threshold_mode : str (default='rel')
-      One of `rel`, `abs`. Decides whether the `threshold` value is
-      interpreted in absolute terms or as a fraction of the best
-      score so far (relative)
+        One of `rel`, `abs`. Decides whether the `threshold` value is
+        interpreted in absolute terms or as a fraction of the best
+        score so far (relative)
 
     sink : callable (default=print)
       The target that the information about early stopping is
@@ -370,9 +370,9 @@ class EarlyStopping(Callback):
     load_best: bool (default=False)
       Whether to restore module weights from the epoch with the best value of
       the monitored quantity. If False, the module weights obtained at the
-      last step of training are used. Note that only the module is restored and
-      that the ``Checkpoint`` callback with the :attr:`~Checkpoint.load_best`
-      argument set to ``True``.
+      last step of training are used. Note that only the module is restored.
+      Use the ``Checkpoint`` callback with the :attr:`~Checkpoint.load_best`
+      argument set to ``True`` if you need to restore the whole object.
 
     """
     def __init__(
@@ -420,12 +420,14 @@ class EarlyStopping(Callback):
                 self._sink("Stopping since {} has not improved in the last "
                            "{} epochs.".format(self.monitor, self.patience),
                            verbose=net.verbose)
-                if self.load_best:
-                    net.module_.load_state_dict(self.best_model_weights_)
-                    self._sink("Restoring best model from epoch {}.".format(
-                        self.best_epoch_
-                    ), verbose=net.verbose)
             raise KeyboardInterrupt
+
+    def on_train_end(self, net, **kwargs):
+        if self.load_best:
+            net.module_.load_state_dict(self.best_model_weights_)
+            self._sink("Restoring best model from epoch {}.".format(
+                self.best_epoch_
+            ), verbose=net.verbose)
 
     def _is_score_improved(self, score):
         if self.lower_is_better:

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -371,7 +371,7 @@ class EarlyStopping(Callback):
       Whether to restore module weights from the epoch with the best value of
       the monitored quantity. If False, the module weights obtained at the
       last step of training are used. Note that only the module is restored and
-      that the ``Checkpoint`` callback with the :func:`~Checkpoint.load_best`
+      that the ``Checkpoint`` callback with the :attr:`~Checkpoint.load_best`
       argument set to ``True``.
 
     """

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -424,7 +424,7 @@ class EarlyStopping(Callback):
             raise KeyboardInterrupt
 
     def on_train_end(self, net, **kwargs):
-        if self.load_best:
+        if self.load_best and self.best_epoch_ != net.history[-1, "epoch"]:
             net.module_.load_state_dict(self.best_model_weights_)
             self._sink("Restoring best model from epoch {}.".format(
                 self.best_epoch_

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -398,7 +398,7 @@ class EarlyStopping(Callback):
 
     def __getstate__(self):
         # Avoids to save the module_ weights twice when pickling
-        state = super().__getstate__()
+        state = self.__dict__
         state['best_model_weights_'] = None
         return state
 

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -398,8 +398,9 @@ class EarlyStopping(Callback):
 
     def __getstate__(self):
         # Avoids to save the module_ weights twice when pickling
-        self.best_model_weights_ = None
-        return self.__dict__
+        state = super().__getstate__()
+        state['best_model_weights_'] = None
+        return state
 
     # pylint: disable=arguments-differ
     def on_train_begin(self, net, **kwargs):
@@ -430,8 +431,8 @@ class EarlyStopping(Callback):
 
     def on_train_end(self, net, **kwargs):
         if (
-            self.load_best and self.best_epoch_ != net.history[-1, "epoch"] and
-            self.best_model_weights_ is not None
+            self.load_best and (self.best_epoch_ != net.history[-1, "epoch"])
+            and (self.best_model_weights_ is not None)
         ):
             net.module_.load_state_dict(self.best_model_weights_)
             self._sink("Restoring best model from epoch {}.".format(

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -543,21 +543,18 @@ class TestEarlyStopping:
         assert msg == expected_msg
 
         msg = side_effect[1]
-        expected_msg = ("Restoring best model from epoch ")
+        expected_msg = "Restoring best model from epoch "
         assert expected_msg in msg
-
-        # Extract epoch reloaded by early stopping
-        loaded_epoch = int(msg.split()[-1][:-1])
 
         # Recompute validation loss and store it together with module weights
         y_proba = net.predict_proba(val_dataset)
         es_weights = deepcopy(net.module_.state_dict())
         es_loss = log_loss(y_val, y_proba)
 
-        # Retrain same classifier without ES, using the fetched epochs number
+        # Retrain same classifier without ES, using the best epochs number
         net = net_clf_cls(
             classifier_module,
-            max_epochs=loaded_epoch,
+            max_epochs=early_stopping_cb.best_epoch_,
             train_split=predefined_split(val_dataset),
         )
         torch.manual_seed(seed)

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -498,12 +498,13 @@ class TestEarlyStopping:
         assert len(net.history) == max_epochs
 
     def test_weights_restore(
-        self, net_clf_cls, broken_classifier_module, classifier_data,
+            self, net_clf_cls, broken_classifier_module, classifier_data,
             early_stopping_cls):
         patience = 5
         max_epochs = 8
 
         side_effect = []
+
         def sink(x):
             side_effect.append(x)
 
@@ -543,7 +544,7 @@ class TestEarlyStopping:
                 pre_fit_module_weights.values()
             )
         )
-    
+
     def test_typical_use_case_stopping(
             self, net_clf_cls, broken_classifier_module, classifier_data,
             early_stopping_cls):
@@ -554,10 +555,7 @@ class TestEarlyStopping:
         def sink(x):
             side_effect.append(x)
 
-        early_stopping_cb = early_stopping_cls(
-            patience=patience,
-            sink=sink,
-        )
+        early_stopping_cb = early_stopping_cls(patience=patience, sink=sink)
 
         net = net_clf_cls(
             broken_classifier_module,

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -6,7 +6,6 @@ from unittest.mock import Mock
 from unittest.mock import patch
 from unittest.mock import call
 from copy import deepcopy
-import tempfile
 
 import numpy as np
 import pytest
@@ -575,14 +574,12 @@ class TestEarlyStopping:
         assert es_loss == log_loss(y_val, y_proba_2)
 
         # Check best_model_weights_ is transformed into None when pickling
-        with tempfile.NamedTemporaryFile() as tmp_file:
-            del net1.callbacks[0].sink
-            pickle.dump(net1, tmp_file)
-            tmp_file.flush()
+        del net1.callbacks[0].sink
+        net1_pkl = pickle.dumps(net1)
 
-            reloaded_net1 = pickle.load(open(tmp_file.name, 'rb'))
-            assert reloaded_net1.callbacks[0].best_epoch_ == net1.callbacks[0].best_epoch_
-            assert reloaded_net1.callbacks[0].best_model_weights_ is None
+        reloaded_net1 = pickle.loads(net1_pkl)
+        assert reloaded_net1.callbacks[0].best_epoch_ == net1.callbacks[0].best_epoch_
+        assert reloaded_net1.callbacks[0].best_model_weights_ is None
 
     def test_typical_use_case_stopping(
             self, net_clf_cls, broken_classifier_module, classifier_data,

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 from unittest.mock import patch
 from unittest.mock import call
 from copy import deepcopy
+import tempfile
 
 import numpy as np
 import pytest
@@ -522,17 +523,17 @@ class TestEarlyStopping:
             torch.as_tensor(X_val).float(), torch.as_tensor(y_val))
 
         # Fix the network once with early stoppping and fixed seed
-        net = net_clf_cls(
+        net1 = net_clf_cls(
             classifier_module,
             callbacks=[early_stopping_cb],
             max_epochs=max_epochs,
             train_split=predefined_split(val_dataset),
         )
         torch.manual_seed(seed)
-        net.fit(tr_dataset, y=None)
+        net1.fit(tr_dataset, y=None)
 
         # Check training was stopped before the end
-        assert len(net.history) < max_epochs
+        assert len(net1.history) < max_epochs
 
         # check correct output messages
         assert len(side_effect) == 2
@@ -547,31 +548,41 @@ class TestEarlyStopping:
         assert expected_msg in msg
 
         # Recompute validation loss and store it together with module weights
-        y_proba = net.predict_proba(val_dataset)
-        es_weights = deepcopy(net.module_.state_dict())
+        y_proba = net1.predict_proba(val_dataset)
+        es_weights = deepcopy(net1.module_.state_dict())
         es_loss = log_loss(y_val, y_proba)
 
         # Retrain same classifier without ES, using the best epochs number
-        net = net_clf_cls(
+        net2 = net_clf_cls(
             classifier_module,
             max_epochs=early_stopping_cb.best_epoch_,
             train_split=predefined_split(val_dataset),
         )
         torch.manual_seed(seed)
-        net.fit(tr_dataset, y=None)
+        net2.fit(tr_dataset, y=None)
 
         # Check that weights obtained match
         assert all(
             torch.equal(wi, wj)
             for wi, wj in zip(
-                net.module_.state_dict().values(),
+                net2.module_.state_dict().values(),
                 es_weights.values()
             )
         )
 
         # Check validation loss obtained match
-        y_proba_2 = net.predict_proba(val_dataset)
+        y_proba_2 = net2.predict_proba(val_dataset)
         assert es_loss == log_loss(y_val, y_proba_2)
+
+        # Check best_model_weights_ is transformed into None when pickling
+        with tempfile.NamedTemporaryFile() as tmp_file:
+            del net1.callbacks[0].sink
+            pickle.dump(net1, tmp_file)
+            tmp_file.flush()
+
+            reloaded_net1 = pickle.load(open(tmp_file.name, 'rb'))
+            assert reloaded_net1.callbacks[0].best_epoch_ == net1.callbacks[0].best_epoch_
+            assert reloaded_net1.callbacks[0].best_model_weights_ is None
 
     def test_typical_use_case_stopping(
             self, net_clf_cls, broken_classifier_module, classifier_data,


### PR DESCRIPTION
This PR is a proposition to solve the issue https://github.com/skorch-dev/skorch/issues/808

It adds a new argument to the EarlyStopping callback allowing to retrieve the best model after stopping the training (from `patience` epochs before the end of the training). This useful for most situations in which EarlyStopping is used and at the same time makes the skorch API more coherent with other user-friendly deeplearning libraries which also implement EarlyStopping callbacks (e.g. Keras).