### PR TITLE
Docs: pin docutils to fix broken Sphinx build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+docutils<0.18
 numpy>=1.13.3
 https://download.pytorch.org/whl/cpu/torch-1.7.1%2Bcpu-cp37-cp37m-linux_x86_64.whl
 sphinx-rtd-theme==0.4.0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,8 +2,8 @@
 set -e
 
 PYTORCH_VERSION=${PYTORCH_VERSION:-""}
-PYTHON_VERSION="3.7"
-TWINE_VERSION="1.12.1"
+PYTHON_VERSION="3.9"
+TWINE_VERSION=">3,<4.0.0dev"
 CONDA_ENV="skorch-deploy"
 CONDA_ENV_YML="environment.yml"
 


### PR DESCRIPTION
Sphinx build is currently broken:

https://readthedocs.org/projects/skorch/builds/15141681/

I tried the fix of pinning docutils<0.18 suggested [here](https://github.yuuza.net/sphinx-doc/sphinx/issues/9727) and it works:

https://readthedocs.org/projects/skorch/builds/15141724/

The better long term solution would be to use a newer version of Sphinx but I haven't checked how to do that yet and I wouldn't be surprised if this surfaces some new problems, hence this short term solution for now.

(Please disregard the other commit in this PR.)