### PR TITLE
Add torch 1.10.0 to CI, remove 1.6.0

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python_version: ['3.6', '3.7', '3.8', '3.9']
-        torch_version: ['1.6.0+cpu', '1.7.1+cpu', '1.8.1+cpu', '1.9.0+cpu']
+        torch_version: ['1.7.1+cpu', '1.8.1+cpu', '1.9.1+cpu', '1.10.0+cpu']
         os: [ubuntu-latest]
         exclude:
           - python_version: '3.9'

--- a/README.rst
+++ b/README.rst
@@ -236,10 +236,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.6.0
 - 1.7.1
 - 1.8.1
-- 1.9.0
+- 1.9.1
+- 1.10.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -90,10 +90,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.6.0
 - 1.7.1
 - 1.8.1
-- 1.9.0
+- 1.9.1
+- 1.10.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of


### PR DESCRIPTION
[PyTorch release notes](https://github.com/pytorch/pytorch/releases/tag/v1.10.0)

Update CI and documentation about officially supported PyTorch versions. It doesn't look like any other changes should be necessary.