### PR TITLE
Test excluding Python 3.7 + PyTorch 1.8.1

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python_version: ['3.6', '3.7', '3.8', '3.9']
-        torch_version: ['1.7.1+cpu', '1.8.2+cpu', '1.9.1+cpu', '1.10.1+cpu']
+        torch_version: ['1.7.1+cpu', '1.8.1+cpu', '1.9.1+cpu', '1.10.1+cpu']
         os: [ubuntu-latest]
         exclude:
           - python_version: '3.9'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,8 +19,8 @@ jobs:
         torch_version: ['1.7.1+cpu', '1.8.1+cpu', '1.9.1+cpu', '1.10.0+cpu']
         os: [ubuntu-latest]
         exclude:
-          - python_version: '3.9'
-            torch_version: '1.5.1+cpu'
+          - python_version: '3.7'
+            torch_version: '1.8.1+cpu'
           - python_version: '3.9'
             torch_version: '1.6.0+cpu'
           - python_version: '3.9'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,11 +16,9 @@ jobs:
     strategy:
       matrix:
         python_version: ['3.6', '3.7', '3.8', '3.9']
-        torch_version: ['1.7.1+cpu', '1.8.1+cpu', '1.9.1+cpu', '1.10.0+cpu']
+        torch_version: ['1.7.1+cpu', '1.8.2+cpu', '1.9.1+cpu', '1.10.1+cpu']
         os: [ubuntu-latest]
         exclude:
-          - python_version: '3.7'
-            torch_version: '1.8.1+cpu'
           - python_version: '3.9'
             torch_version: '1.6.0+cpu'
           - python_version: '3.9'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,8 +20,6 @@ jobs:
         os: [ubuntu-latest]
         exclude:
           - python_version: '3.9'
-            torch_version: '1.6.0+cpu'
-          - python_version: '3.9'
             torch_version: '1.7.1+cpu'
 
     steps:

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -1756,10 +1756,9 @@ class TestNeuralNet:
     )
   ),
 )"""
-        if LooseVersion(torch.__version__) >= '1.2':
-            expected = expected.replace("Softmax()", "Softmax(dim=-1)")
-            expected = expected.replace("Dropout(p=0.5)",
-                                        "Dropout(p=0.5, inplace=False)")
+        expected = expected.replace("Softmax()", "Softmax(dim=-1)")
+        expected = expected.replace("Dropout(p=0.5)",
+                                    "Dropout(p=0.5, inplace=False)")
         assert result == expected
 
     def test_repr_fitted_works(self, net_cls, module_cls, data):

--- a/skorch/tests/test_probabilistic.py
+++ b/skorch/tests/test_probabilistic.py
@@ -21,8 +21,8 @@ gpytorch = pytest.importorskip('gpytorch')
 
 # extract pytorch version without possible '+something' suffix
 pytorch_version, _, _ = torch.__version__.partition('+')
-if LooseVersion(pytorch_version) == '1.7.1':
-    pytest.skip("gpytorch does not work with PyTorch 1.7.1", allow_module_level=True)
+if LooseVersion(pytorch_version) in ('1.7.1', '1.8.1'):
+    pytest.skip("gpytorch does not work with PyTorch 1.7.1 or 1.8.1", allow_module_level=True)
 
 
 def get_batch_size(dist):

--- a/skorch/tests/test_probabilistic.py
+++ b/skorch/tests/test_probabilistic.py
@@ -21,7 +21,9 @@ gpytorch = pytest.importorskip('gpytorch')
 
 # extract pytorch version without possible '+something' suffix
 pytorch_version, _, _ = torch.__version__.partition('+')
-if LooseVersion(pytorch_version) in ('1.7.1', '1.8.1'):
+# Keep up to date with the gpytorch's supported versions:
+# https://github.com/cornellius-gp/gpytorch#installation
+if LooseVersion(pytorch_version) >= "1.9":
     pytest.skip("gpytorch does not work with PyTorch 1.7.1 or 1.8.1", allow_module_level=True)
 
 

--- a/skorch/tests/test_probabilistic.py
+++ b/skorch/tests/test_probabilistic.py
@@ -23,8 +23,8 @@ gpytorch = pytest.importorskip('gpytorch')
 pytorch_version, _, _ = torch.__version__.partition('+')
 # Keep up to date with the gpytorch's supported versions:
 # https://github.com/cornellius-gp/gpytorch#installation
-if LooseVersion(pytorch_version) >= "1.9":
-    pytest.skip("gpytorch does not work with PyTorch 1.7.1 or 1.8.1", allow_module_level=True)
+if LooseVersion(pytorch_version) < '1.9':
+    pytest.skip("gpytorch does not support PyTorch versions < 1.9", allow_module_level=True)
 
 
 def get_batch_size(dist):


### PR DESCRIPTION
For some reason, gpytorch + PyTorch 1.8.1 now caused the following error:

> AttributeError: module 'torch.linalg' has no attribute 'cholesky_ex'

Thus, gpytorch tests are now skipped for that PyTorch version.

Also, no longer exclude 3.9 + 1.5.1, since 1.5.1 is no longer officially
supported and no longer tested.