### PR TITLE
Initialize iterator only once per fit call

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `load_best` attribute to `EarlyStopping` callback to automatically load module weights of the best result at the end of training
 
 ### Changed
-- Initialize data loaders for training and validation dataset once per fit call instead of once per epoch
+- Initialize data loaders for training and validation dataset once per fit call instead of once per epoch ([migration guide](https://skorch.readthedocs.io/en/stable/user/FAQ.html#migration-from-0-11-to-0-12))
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `load_best` attribute to `EarlyStopping` callback to automatically load module weights of the best result at the end of training
 
 ### Changed
+- Initialize data loaders for training and validation dataset once per fit call instead of once per epoch
 
 ### Fixed
 

--- a/docs/user/FAQ.rst
+++ b/docs/user/FAQ.rst
@@ -479,3 +479,7 @@ lines of code to accomplish this, as shown below:
 Your old code should still work for the time being but will give a
 ``DeprecationWarning``. Starting from skorch v0.13, old code will raise an error
 instead.
+
+If it is necessary to have access to the ``Dataset`` inside of
+``run_single_epoch``, you can access it on the ``DataLoader`` object using
+``iterator.dataset``.

--- a/docs/user/FAQ.rst
+++ b/docs/user/FAQ.rst
@@ -444,3 +444,38 @@ this is how to make the transition:
         ...
 
 The same goes for the other three methods.
+
+Migration from 0.11 to 0.12
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In skorch 0.12, we made a change regarding the training step. Now, we initialize
+the :class:`torch.utils.data.DataLoader` only once per fit call instead of once
+per epoch. This is accomplished by calling
+:py:meth:`skorch.net.NeuralNet.get_iterator` only once at the beginning of the
+training process. For the majority of the users, this should make no difference
+in practice.
+
+However, you might be affected if you wrote a custom
+:py:meth:`skorch.net.NeuralNet.run_single_epoch`. The first argument to this
+method is now the initialized ``DataLoader`` instead of a ``Dataset``.
+Therefore, this method should no longer call
+:py:meth:`skorch.net.NeuralNet.get_iterator`. You only need to change a few
+lines of code to accomplish this, as shown below:
+
+.. code:: python
+
+    # before
+    def run_single_epoch(self, dataset, ...):
+        ...
+        for batch in self.get_iterator(dataset, training=training):
+            ...
+
+    # after
+    def run_single_epoch(self, iterator, ...):
+        ...
+        for batch in iterator:
+            ...
+
+Your old code should still work for the time being but will give a
+``DeprecationWarning``. Starting from skorch v0.13, old code will raise an error
+instead.

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1637,6 +1637,19 @@ class NeuralNet:
           mini-batches.
 
         """
+        # TODO: remove in skorch v0.13, see #835
+        if isinstance(dataset, DataLoader):
+            msg = (
+                "get_iterator was called with a DataLoader instance but it should be "
+                "called with a Dataset instead. Probably, you implemented a custom "
+                "run_single_epoch method. Its first argument is now a DataLoader, "
+                "not a Dataset. For more information, look here: "
+                "https://skorch.readthedocs.io/en/latest/user/FAQ.html"
+                "#migration-from-0-11-to-0-12. This will raise an error in skorch v0.13"
+            )
+            warnings.warn(msg, DeprecationWarning)
+            return dataset
+
         if training:
             kwargs = self.get_params_for('iterator_train')
             iterator = self.iterator_train

--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -479,7 +479,7 @@ class TestEpochScoring:
         with pytest.raises(ValueError, match=msg):
                 net.fit(*data)
 
-    @pytest.mark.parametrize('use_caching, count', [(False, 1), (True, 0)])
+    @pytest.mark.parametrize('use_caching, count', [(False, 5), (True, 2)])
     def test_with_caching_get_iterator_not_called(
             self, net_cls, module_cls, train_split, caching_scoring_cls, data,
             use_caching, count,
@@ -499,10 +499,11 @@ class TestEpochScoring:
         net.fit(*data)
 
         # expected count should be:
-        # max_epochs * (1 (train) + 1 (valid) + 0 or 1 (from scoring,
-        # depending on caching))
-        count_expected = max_epochs * (1 + 1 + count)
-        assert net.get_iterator.call_count == count_expected
+        # fit loop: 1 (train) + 1 (valid) = 2
+        # scoring:
+        #   without cahching: 0
+        #   with caching: 1 per epoch = 3
+        assert net.get_iterator.call_count == count
 
     def test_subclassing_epoch_scoring(
             self, classifier_module, classifier_data):

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -3609,6 +3609,39 @@ class TestNeuralNet:
         y_pred = net.predict(X)
         assert y_pred.shape == (100, 2)
 
+    # TODO: remove in skorch v0.13
+    def test_net_with_custom_run_single_epoch(self, net_cls, module_cls, data):
+        # See #835. We changed the API to initialize the DataLoader only once
+        # per epoch. This test is to make sure that code that overrides
+        # run_single_epoch still works for the time being.
+        from skorch.dataset import get_len
+
+        class MyNet(net_cls):
+            def run_single_epoch(self, dataset, training, prefix, step_fn, **fit_params):
+                # code as in skorch<=0.11
+                # first argument is should now be an iterator, not a dataset
+                if dataset is None:
+                    return
+
+                batch_count = 0
+                for batch in self.get_iterator(dataset, training=training):
+                    self.notify("on_batch_begin", batch=batch, training=training)
+                    step = step_fn(batch, **fit_params)
+                    self.history.record_batch(prefix + "_loss", step["loss"].item())
+                    batch_size = (get_len(batch[0]) if isinstance(batch, (tuple, list))
+                                  else get_len(batch))
+                    self.history.record_batch(prefix + "_batch_size", batch_size)
+                    self.notify("on_batch_end", batch=batch, training=training, **step)
+                    batch_count += 1
+
+                self.history.record(prefix + "_batch_count", batch_count)
+
+        net = MyNet(module_cls, max_epochs=2)
+        X, y = data
+        with pytest.deprecated_call():
+            net.fit(X, y)
+        # does not raise
+        net.predict(X)
 
 class TestNetSparseInput:
     @pytest.fixture(scope='module')

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -3623,6 +3623,10 @@ class TestNeuralNet:
                 if dataset is None:
                     return
 
+                # make sure that the "dataset" (really the DataLoader) can still
+                # access the Dataset if needed
+                assert hasattr(dataset, 'dataset')
+
                 batch_count = 0
                 for batch in self.get_iterator(dataset, training=training):
                     self.notify("on_batch_begin", batch=batch, training=training)

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -3619,7 +3619,7 @@ class TestNeuralNet:
         class MyNet(net_cls):
             def run_single_epoch(self, dataset, training, prefix, step_fn, **fit_params):
                 # code as in skorch<=0.11
-                # first argument is should now be an iterator, not a dataset
+                # first argument should now be an iterator, not a dataset
                 if dataset is None:
                     return
 


### PR DESCRIPTION
## Description

At the moment, we initialize the iterators for the training and
validation datasets once per epoch. However, this is unnecessary and
creates an (ever so small) overhead.

With this PR, the iterators are created once per fit call only.

## Implementation

Theoretically, this could present a backwards compatibility issue, but I
think it will only affect very few, if any, users; those who are
affected should be able to fix the issue quickly.

I don't believe that anyone would rely on the iterators being
initialized once per epoch as a feature. If there is a good use case for
actually doing so, please tell me and we can discuss if this PR should
actually be rejected.

To test the change in terms of performance, I ran the MNIST benchmark.
(While doing so, I fixed a few issues with the script.). The difference
of this PR on this benchmark is not noticeable. I would only expect a
performance difference on very small datasets. Still, I believe the
benefits outweigh the costs.

## Side note

The [`test_pickle_load`](https://github.com/skorch-dev/skorch/blob/c58ae6712394e38155e276dc3b08aea656989ff6/skorch/tests/test_net.py#L418) failed for me locally when `cuda_available` was set
to False. I'm not exactly sure what the reason is, it could be that the
way we patch `torch.cuda.is_available` breaks with some recent changes in
PyTorch (tested on 1.8.1).