### PR TITLE
Facilitate integration with huggingface

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,4 +17,5 @@ sacred
 sphinx
 sphinx_rtd_theme
 tensorboard>=1.14.0
+transformers
 wandb<0.10.29

--- a/skorch/dataset.py
+++ b/skorch/dataset.py
@@ -70,11 +70,11 @@ def _len(x):
 
 
 def get_len(data):
-    if hasattr(data, 'convert_to_tensors'):
-        # this might be expensive but huggingface BatchEncodings are lists of
-        # lists and thus their length would be determined incorrectly otherwise,
-        # returning the sequence length instead of the number of samples.
-        data = data.convert_to_tensors('pt')
+    if isinstance(data, Mapping) and (data.get('input_ids') is not None):
+        # Special casing Huggingface BatchEncodings because they are lists of
+        # lists and thus their length would be determined incorrectly, returning
+        # the sequence length instead of the number of samples.
+        return len(data['input_ids'])
     lens = [_apply_to_data(data, _len, unpack_dict=True)]
     lens = list(flatten(lens))
     len_set = set(lens)

--- a/skorch/dataset.py
+++ b/skorch/dataset.py
@@ -1,5 +1,6 @@
 """Contains custom skorch Dataset and ValidSplit."""
 import warnings
+from collections.abc import Mapping
 from functools import partial
 from numbers import Number
 
@@ -40,7 +41,7 @@ def _apply_to_data(data, func, unpack_dict=False):
     """
     apply_ = partial(_apply_to_data, func=func, unpack_dict=unpack_dict)
 
-    if isinstance(data, dict):
+    if isinstance(data, Mapping):
         if unpack_dict:
             return [apply_(v) for v in data.values()]
         return {k: apply_(v) for k, v in data.items()}
@@ -69,6 +70,11 @@ def _len(x):
 
 
 def get_len(data):
+    if hasattr(data, 'convert_to_tensors'):
+        # this might be expensive but huggingface BatchEncodings are lists of
+        # lists and thus their length would be determined incorrectly otherwise,
+        # returning the sequence length instead of the number of samples.
+        data = data.convert_to_tensors('pt')
     lens = [_apply_to_data(data, _len, unpack_dict=True)]
     lens = list(flatten(lens))
     len_set = set(lens)

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -7,6 +7,7 @@ sklearn-conforming classes like NeuralNetClassifier.
 """
 
 import fnmatch
+from collections.abc import Mapping
 from functools import partial
 from itertools import chain
 from collections import OrderedDict
@@ -1358,7 +1359,7 @@ class NeuralNet:
 
         """
         x = to_tensor(x, device=self.device)
-        if isinstance(x, dict):
+        if isinstance(x, Mapping):
             x_dict = self._merge_x_and_fit_params(x, fit_params)
             return self.module_(**x_dict)
         return self.module_(x, **fit_params)

--- a/skorch/tests/test_dataset.py
+++ b/skorch/tests/test_dataset.py
@@ -459,6 +459,7 @@ class TestNetWithTokenizers:
         assert np.allclose(y_proba.sum(1), 1)
 
         train_losses = net.history[:, 'train_loss']
+        # make sure the network trained successfully with an arbitrary wide margin
         assert train_losses[0] > 5 * train_losses[-1]
 
 

--- a/skorch/tests/test_dataset.py
+++ b/skorch/tests/test_dataset.py
@@ -1,9 +1,11 @@
 """Tests for dataset.py."""
 
+import unittest
 from unittest.mock import Mock
 
 import numpy as np
 import pytest
+from scipy import sparse
 from sklearn.datasets import make_classification
 import torch
 import torch.utils.data
@@ -11,7 +13,6 @@ from torch import nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
-from scipy import sparse
 from skorch.utils import data_from_dataset
 from skorch.utils import is_torch_data_type
 from skorch.utils import to_tensor
@@ -64,6 +65,14 @@ class TestGetLen:
     def test_inconsistent_lengths(self, get_len, data):
         with pytest.raises(ValueError):
             get_len(data)
+
+    def test_get_len_transformers_tokenizer(self, get_len):
+        transformers = pytest.importorskip('transformers')
+
+        X = ['hello there'] * 10
+        tokenizer = transformers.AutoTokenizer.from_pretrained('bert-base-uncased')
+        tokens = tokenizer(X)
+        assert get_len(tokens) == 10
 
 
 class TestNetWithoutY:
@@ -379,6 +388,78 @@ class TestNetWithPandas:
         net.fit(X, y)
         y_proba = net.predict_proba(X)
         assert np.allclose(y_proba.sum(1), 1)
+
+
+class TestNetWithTokenizers:
+    """Huggingface tokenizers should work without special adjustments"""
+    @pytest.fixture(scope='session')
+    def tokenizer(self):
+        transformers = pytest.importorskip('transformers')
+        tokenizer = transformers.AutoTokenizer.from_pretrained('bert-base-uncased')
+        return tokenizer
+
+    @pytest.fixture(scope='session')
+    def data(self, tokenizer):
+        """A simple dataset that the model should be able to learn (or overfit)
+        on
+
+        """
+        X = [paragraph for paragraph in unittest.__doc__.split('\n') if paragraph]
+        Xt = tokenizer(
+            X,
+            max_length=12,
+            padding='max_length',
+            truncation=True,
+            return_token_type_ids=False,
+            return_tensors='pt',
+        )
+        y = np.array(['test' in x.lower() for x in X], dtype=np.int64)
+        return Xt, y
+
+    @pytest.fixture(scope='session')
+    def module_cls(self, tokenizer):
+        """Return a simple module using embedding + linear + softmax instead of
+        a full-fledged BERT module.
+
+        """
+        class MyModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.emb = nn.Embedding(tokenizer.vocab_size, 6)
+                self.dense = nn.Linear(6, 2)
+                self.sm = nn.Softmax(dim=-1)
+
+            # pylint: disable=arguments-differ
+            def forward(self, input_ids, attention_mask):
+                assert input_ids.shape == attention_mask.shape
+                X = self.emb(input_ids).mean(1)
+                return self.sm(self.dense(X))
+
+        return MyModule
+
+    @pytest.fixture(scope='session')
+    def net_cls(self):
+        from skorch import NeuralNetClassifier
+        return NeuralNetClassifier
+
+    @pytest.fixture(scope='module')
+    def net(self, net_cls, module_cls):
+        return net_cls(
+            module_cls,
+            optimizer=torch.optim.Adam,
+            max_epochs=5,
+            batch_size=8,
+            lr=0.1,
+        )
+
+    def test_fit_predict_proba(self, net, data):
+        X, y = data
+        net.fit(X, y)
+        y_proba = net.predict_proba(X)
+        assert np.allclose(y_proba.sum(1), 1)
+
+        train_losses = net.history[:, 'train_loss']
+        assert train_losses[0] > 5 * train_losses[-1]
 
 
 class TestDataset:

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -3647,6 +3647,7 @@ class TestNeuralNet:
         # does not raise
         net.predict(X)
 
+
 class TestNetSparseInput:
     @pytest.fixture(scope='module')
     def net_cls(self):

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -172,9 +172,6 @@ def to_device(X, device):
     if device is None:
         return X
 
-    if isinstance(X, dict):
-        return {key: to_device(val, device) for key, val in X.items()}
-
     if isinstance(X, Mapping):
         # dict-like but not a dict
         return type(X)({key: to_device(val, device) for key, val in X.items()})

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -91,7 +91,7 @@ def to_tensor(X, device, accept_sparse=False):
     if is_torch_data_type(X):
         return to_device(X, device)
     if hasattr(X, 'convert_to_tensors'):
-        # transformers BatchEncoding
+        # huggingface transformers BatchEncoding
         return X.convert_to_tensors('pt')
     if isinstance(X, Mapping):
         return {key: to_tensor_(val) for key, val in X.items()}

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -4,7 +4,7 @@ Should not have any dependency on other skorch packages.
 
 """
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from distutils.version import LooseVersion
 from enum import Enum
@@ -90,7 +90,10 @@ def to_tensor(X, device, accept_sparse=False):
 
     if is_torch_data_type(X):
         return to_device(X, device)
-    if isinstance(X, dict):
+    if hasattr(X, 'convert_to_tensors'):
+        # transformers BatchEncoding
+        return X.convert_to_tensors('pt')
+    if isinstance(X, Mapping):
         return {key: to_tensor_(val) for key, val in X.items()}
     if isinstance(X, (list, tuple)):
         return [to_tensor_(x) for x in X]
@@ -123,7 +126,7 @@ def to_numpy(X):
     if isinstance(X, np.ndarray):
         return X
 
-    if isinstance(X, dict):
+    if isinstance(X, Mapping):
         return {key: to_numpy(val) for key, val in X.items()}
 
     if is_pandas_ndframe(X):
@@ -172,6 +175,10 @@ def to_device(X, device):
     if isinstance(X, dict):
         return {key: to_device(val, device) for key, val in X.items()}
 
+    if isinstance(X, Mapping):
+        # dict-like but not a dict
+        return type(X)({key: to_device(val, device) for key, val in X.items()})
+
     # PackedSequence class inherits from a namedtuple
     if isinstance(X, (tuple, list)) and (type(X) != PackedSequence):
         return type(X)(to_device(x, device) for x in X)
@@ -200,7 +207,7 @@ def is_pandas_ndframe(x):
 
 def flatten(arr):
     for item in arr:
-        if isinstance(item, (tuple, list, dict)):
+        if isinstance(item, (tuple, list, Mapping)):
             yield from flatten(item)
         else:
             yield item
@@ -257,7 +264,7 @@ def check_indexing(data):
     if data is None:
         return _indexing_none
 
-    if isinstance(data, dict):
+    if isinstance(data, Mapping):
         # dictionary of containers
         return _indexing_dict
 


### PR DESCRIPTION
Solves #838

## Description

The Huggingface transformers library (or, more precisely, the tokenizers
library) currently is possibly the most popular library for state of the
art NLP models. Therefore, it would be good if skorch works well with
transformers.

One of the key steps is tokenization. For this, tokenizers implements
their own classes that return a special data type, which is currently
not understood by skorch. This PR makes it so that skorch understands
and thus correctly works with that data type. Without this adjustment,
users would need to write some (light) wrapper code to make skorch work
with these tokenizers.

## Implementation

The problem with this special data type, `BatchEncoding`, is that it's a
`Mapping` but not a `dict`. skorch already deals with `dict`s but since
`Mapping`s are not instances of `dict`s, skorch does not recognize the
`BatchEncoding` correctly. Therefore, some `isinstance` checks had to be
adjusted.

The second difficulty with `BatchEncoding` is that its values are lists
of lists (e.g. lists of lists of ints for the token ids). This clashes
with skorch, which, when encountering a list, believes that the list
contains the actual values. Therefore, when we determine the length of a
`BatchEncoding`, we don't get the length of the outer list, which is the
desired value (the sample size), but we get the length of the inner
list (the sequence length). This in turn leads to an error with our
`Dataset`, which believes that lengths are inconsistent.

To work around this issue, we could change how the `get_len`
implementation deals with lists of values. However, this would introduce
a backwards incompatibility. Thus I took a different, somewhat
inefficient approach: I call the `convert_to_tensors` method on
`BatchEncoding`, which converts the values from lists of lists to (padded)
tensors. For those, `get_len` returns the correct results.

This conversion is obviously inefficient. Hopefully, however, this makes
no big difference overall because the `Dataset` is initialized only once
per fit call.