### PR TITLE
Unwrap accelerated model on train end

### DIFF
--- a/skorch/helper.py
+++ b/skorch/helper.py
@@ -669,3 +669,8 @@ class AccelerateMixin:
         for name in self._optimizers:
             optimizer = getattr(self, name + '_')
             optimizer.step()
+
+    # pylint: disable=unused-argument
+    def on_train_end(self, net, X=None, y=None, **kwargs):
+        super().on_train_end(net, X=X, y=y, **kwargs)
+        self.module_ = self.accelerator.unwrap_model(self.module_)

--- a/skorch/tests/test_helper.py
+++ b/skorch/tests/test_helper.py
@@ -835,6 +835,9 @@ class TestAccelerate:
                 loss.backward(**kwargs)
                 loss.backward_was_called = True
 
+            def unwrap_model(self, model):
+                return model
+
         # pylint: disable=missing-class-docstring
         class AcceleratedNet(AccelerateMixin, NeuralNetClassifier):
             def get_iterator(self, *args, **kwargs):


### PR DESCRIPTION
It is apparently recommended to "unwrap" the model after training ends:

https://github.com/huggingface/accelerate/blob/6ffab178accebda485295bddf8eb6bf436ff698f/src/accelerate/accelerator.py#L542-L551

https://github.com/huggingface/accelerate/blob/e549cea65ced232131d2d028717b6a0057274add/docs/source/quicktour.rst#savingloading-a-model