### PR TITLE
Update to PyTorch 1.11.0

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python_version: ['3.6', '3.7', '3.8', '3.9']
-        torch_version: ['1.7.1+cpu', '1.8.1+cpu', '1.9.1+cpu', '1.10.1+cpu']
+        torch_version: ['1.8.2+cpu', '1.9.1+cpu', '1.10.2+cpu', '1.11.0+cpu']
         os: [ubuntu-latest]
         exclude:
           - python_version: '3.9'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,12 +31,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
-        pip install -r requirements.txt
-        pip install torch==${{ matrix.torch_version }} -f https://download.pytorch.org/whl/torch_stable.html
+        python -m pip install -r requirements-dev.txt
+        python -m pip install -r requirements.txt
+        python -m pip install torch==${{ matrix.torch_version }} -f https://download.pytorch.org/whl/torch_stable.html
     - name: Install skorch
       run: |
-        python setup.py install
+        python -m pip install .
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python_version: ['3.6', '3.7', '3.8', '3.9']
-        torch_version: ['1.8.2+cpu', '1.9.1+cpu', '1.10.2+cpu', '1.11.0+cpu']
+        torch_version: ['1.8.1+cpu', '1.9.1+cpu', '1.10.2+cpu', '1.11.0+cpu']
         os: [ubuntu-latest]
         exclude:
           - python_version: '3.9'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,11 +16,11 @@ jobs:
     strategy:
       matrix:
         python_version: ['3.6', '3.7', '3.8', '3.9']
-        torch_version: ['1.8.1+cpu', '1.9.1+cpu', '1.10.2+cpu']
+        torch_version: ['1.8.1+cpu', '1.9.1+cpu', '1.10.2+cpu', '1.11.0+cpu']
         os: [ubuntu-latest]
         exclude:
-          - python_version: '3.9'
-            torch_version: '1.7.1+cpu'
+          - python_version: '3.6'
+            torch_version: '1.11.0+cpu'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python_version: ['3.6', '3.7', '3.8', '3.9']
-        torch_version: ['1.8.1+cpu', '1.9.1+cpu', '1.10.2+cpu', '1.11.0+cpu']
+        torch_version: ['1.8.1+cpu', '1.9.1+cpu', '1.10.2+cpu']
         os: [ubuntu-latest]
         exclude:
           - python_version: '3.9'

--- a/README.rst
+++ b/README.rst
@@ -161,7 +161,7 @@ To install with pip, run:
 
 .. code:: bash
 
-    pip install -U skorch
+    python -m pip install -U skorch
 
 Again, we recommend to use a `virtual environment
 <https://docs.python.org/3/tutorial/venv.html>`_ for this.
@@ -183,7 +183,7 @@ To install skorch from source using conda, proceed as follows:
     cd skorch
     conda env create
     source activate skorch
-    pip install .
+    python -m pip install .
 
 If you want to help developing, run:
 
@@ -193,7 +193,7 @@ If you want to help developing, run:
     cd skorch
     conda env create
     source activate skorch
-    pip install -e .
+    python -m pip install -e .
 
     py.test  # unit tests
     pylint skorch  # static code checks
@@ -208,9 +208,9 @@ For pip, follow these instructions instead:
     git clone https://github.com/skorch-dev/skorch.git
     cd skorch
     # create and activate a virtual environment
-    pip install -r requirements.txt
+    python -m pip install -r requirements.txt
     # install pytorch version for your system (see below)
-    pip install .
+    python -m pip install .
 
 If you want to help developing, run:
 
@@ -219,10 +219,10 @@ If you want to help developing, run:
     git clone https://github.com/skorch-dev/skorch.git
     cd skorch
     # create and activate a virtual environment
-    pip install -r requirements.txt
+    python -m pip install -r requirements.txt
     # install pytorch version for your system (see below)
-    pip install -r requirements-dev.txt
-    pip install -e .
+    python -m pip install -r requirements-dev.txt
+    python -m pip install -e .
 
     py.test  # unit tests
     pylint skorch  # static code checks
@@ -236,10 +236,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.7.1
 - 1.8.1
 - 1.9.1
-- 1.10.0
+- 1.10.2
+- 1.11.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of
@@ -253,7 +253,7 @@ In general, running this to install PyTorch should work (assuming CUDA
     # using conda:
     conda install pytorch cudatoolkit==11.1 -c pytorch
     # using pip
-    pip install torch
+    python -m pip install torch
 
 ==================
 External resources

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 docutils<0.18
 numpy>=1.13.3
-https://download.pytorch.org/whl/cpu/torch-1.7.1%2Bcpu-cp37-cp37m-linux_x86_64.whl
+torch>=1.11.0
 sphinx-rtd-theme==0.4.0
 numpydoc==0.8.0
 scikit-learn>=0.19.1

--- a/docs/user/helper.rst
+++ b/docs/user/helper.rst
@@ -179,7 +179,7 @@ thusly:
 
 .. code:: bash
 
-    pip install fire numpydoc
+    python -m pip install fire numpydoc
 
 Usage
 ^^^^^

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -13,7 +13,7 @@ To install with pip, run:
 
 .. code:: bash
 
-    pip install -U skorch
+    python -m pip install -U skorch
 
 We recommend to use a virtual environment for this.
 
@@ -37,7 +37,7 @@ If you just want to use skorch, use:
     cd skorch
     conda env create
     source activate skorch
-    pip install .
+    python -m pip install .
 
 If you want to help developing, run:
 
@@ -47,7 +47,7 @@ If you want to help developing, run:
     cd skorch
     conda env create
     source activate skorch
-    pip install -e .
+    python -m pip install -e .
 
     py.test  # unit tests
     pylint skorch  # static code checks
@@ -62,9 +62,9 @@ If you just want to use skorch, use:
     git clone https://github.com/skorch-dev/skorch.git
     cd skorch
     # create and activate a virtual environment
-    pip install -r requirements.txt
+    python -m pip install -r requirements.txt
     # install pytorch version for your system (see below)
-    pip install .
+    python -m pip install .
 
 If you want to help developing, run:
 
@@ -73,10 +73,10 @@ If you want to help developing, run:
     git clone https://github.com/skorch-dev/skorch.git
     cd skorch
     # create and activate a virtual environment
-    pip install -r requirements.txt
+    python -m pip install -r requirements.txt
     # install pytorch version for your system (see below)
-    pip install -r requirements-dev.txt
-    pip install -e .
+    python -m pip install -r requirements-dev.txt
+    python -m pip install -e .
 
     py.test  # unit tests
     pylint skorch  # static code checks
@@ -90,10 +90,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.7.1
 - 1.8.1
 - 1.9.1
-- 1.10.0
+- 1.10.2
+- 1.11.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of
@@ -107,4 +107,4 @@ In general, running this to install PyTorch should work (assuming CUDA
     # using conda:
     conda install pytorch cudatoolkit==11.1 -c pytorch
     # using pip
-    pip install torch
+    python -m pip install torch

--- a/docs/user/parallelism.rst
+++ b/docs/user/parallelism.rst
@@ -21,7 +21,7 @@ device to ``cuda`` when we initialize the :class:`.NeuralNet` class.
 
 Let's run through the steps.  First, install Dask and dask.distributed::
 
-  pip install dask distributed
+  python -m pip install dask distributed
 
 Next, assuming you have two GPUs on your machine, let's start up a
 Dask scheduler and two Dask workers.  Make sure the Dask workers are

--- a/docs/user/probabilistic.rst
+++ b/docs/user/probabilistic.rst
@@ -24,7 +24,7 @@ either pip or conda:
 .. code:: bash
 
     # using pip
-    pip install -U gpytorch
+    python -m pip install -U gpytorch
     # using conda
     conda install gpytorch -c gpytorch
 

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -18,7 +18,7 @@ To use this functionaliy, you need some further libraries that are not
 part of skorch, namely fire and numpydoc. You can install them thusly:
 
 ```bash
-pip install fire numpydoc
+python -m pip install fire numpydoc
 ```
 
 ## Usage

--- a/examples/nuclei_image_segmentation/README.md
+++ b/examples/nuclei_image_segmentation/README.md
@@ -6,7 +6,7 @@ This tutorial can be viewed at [nbviewer](https://nbviewer.jupyter.org/github/sk
 
 To run the notebook locally, please following the following setup procedure:
 
-1. Install dependencies: `pip install -r requirements.txt`
+1. Install dependencies: `python -m pip install -r requirements.txt`
 1. Follow [Kaggle's installation and configuration documentation](https://github.com/Kaggle/kaggle-api#installation) to install and configure the kaggle cli
 1. Go to Kaggle's [2018 Data Science Bowl Competition](https://www.kaggle.com/c/data-science-bowl-2018), click on "Late Submission" and accept the terms and conditions to get access to the data.
 1. Run `./dl_extract_prepare.sh` to download, extract and prepare the data.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -50,7 +50,7 @@ python setup.py install
 pytest -x
 
 # check if README can be rendered correctly on PyPI
-pip install readme-renderer
+python -m pip install readme-renderer
 python -m readme_renderer README.rst > /dev/null
 
 python setup.py sdist bdist_wheel

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -78,7 +78,7 @@ class NeptuneLogger(Callback):
 
     To monitor resource consumption install psutil
 
-    >>> pip install psutil
+    >>> python -m pip install psutil
 
     You can view example experiment logs here:
     https://ui.neptune.ai/o/shared/org/skorch-integration/e/SKOR-13/charts
@@ -86,7 +86,7 @@ class NeptuneLogger(Callback):
     Examples
     --------
     >>> # Install neptune
-    >>> pip install neptune-client
+    >>> python -m pip install neptune-client
     >>> # Create a neptune experiment object
     >>> import neptune
     ...
@@ -223,7 +223,7 @@ class WandbLogger(Callback):
     Examples
     --------
     >>> # Install wandb
-    ... pip install wandb
+    ... python -m pip install wandb
 
     >>> import wandb
     >>> from skorch.callbacks import WandbLogger
@@ -747,7 +747,7 @@ class SacredLogger(Callback):
 
     To use this logger, you first have to install Sacred:
 
-    $ pip install sacred
+    $ python -m pip install sacred
 
     You might also install pymongo to use a mongodb backend. See the upstream_
     documentation for more details. Once you have installed it, you can set up
@@ -894,7 +894,7 @@ class MlflowLogger(Callback):
 
     .. code-block::
 
-      $ pip install mlflow
+      $ python -m pip install mlflow
 
     Examples
     --------

--- a/skorch/cli.py
+++ b/skorch/cli.py
@@ -329,13 +329,17 @@ def parse_args(kwargs, defaults=None):
     try:
         import fire  # pylint: disable=unused-import
     except ImportError:
-        raise ImportError("Using skorch cli helpers requires the fire library,"
-                          " you can install it with pip: pip install fire.")
+        raise ImportError(
+            "Using skorch cli helpers requires the fire library,"
+            " you can install it with pip: python -m pip install fire."
+        )
     try:
         import numpydoc.docscrape  # pylint: disable=unused-import
     except ImportError:
-        raise ImportError("Using skorch cli helpers requires the numpydoc library,"
-                          " you can install it with pip: pip install numpydoc.")
+        raise ImportError(
+            "Using skorch cli helpers requires the numpydoc library,"
+            " you can install it with pip: python -m pip install numpydoc."
+        )
 
     defaults = defaults or {}
 


### PR DESCRIPTION
- Drop 1.7.1
- Update 1.10.0/1.10.1 to 1.10.2

Moreover, change all pip install instructions from `pip install` to
`python -m pip install`, which is the recommended way.