### PR TITLE
Make NotInitializedError compatible with sklearn

### DIFF
--- a/skorch/exceptions.py
+++ b/skorch/exceptions.py
@@ -1,11 +1,13 @@
 """Contains skorch-specific exceptions and warnings."""
 
+from sklearn.exceptions import NotFittedError
+
 
 class SkorchException(BaseException):
     """Base skorch exception."""
 
 
-class NotInitializedError(SkorchException):
+class NotInitializedError(SkorchException, NotFittedError):
     """Module is not initialized, please call the ``.initialize``
     method or train the model by calling ``.fit(...)``.
 


### PR DESCRIPTION
This ensures that a user can catch the sklearn `NotFittedError`, just as
they can with regular sklearn estimators. As discussed in [1].

[1] https://github.com/skorch-dev/skorch/issues/859