### PR TITLE
Check Python 3.10 in CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,11 @@ jobs:
         os: [ubuntu-latest]
         exclude:
           - python_version: '3.10'
-            torch_version: ['1.8.1+cpu', '1.9.1+cpu', '1.10.2+cpu']
+            torch_version: '1.8.1+cpu'
+          - python_version: '3.10'
+            torch_version: '1.9.1+cpu'
+          - python_version: '3.10'
+            torch_version: '1.10.2+cpu'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,6 +18,7 @@ jobs:
         python_version: ['3.7', '3.8', '3.9', '3.10']
         torch_version: ['1.8.1+cpu', '1.9.1+cpu', '1.10.2+cpu', '1.11.0+cpu']
         os: [ubuntu-latest]
+        exclude:
           - python_version: '3.10'
             torch_version: ['1.8.1+cpu', '1.9.1+cpu', '1.10.2+cpu']
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,12 +15,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python_version: ['3.6', '3.7', '3.8', '3.9']
+        python_version: ['3.7', '3.8', '3.9', '3.10']
         torch_version: ['1.8.1+cpu', '1.9.1+cpu', '1.10.2+cpu', '1.11.0+cpu']
         os: [ubuntu-latest]
-        exclude:
-          - python_version: '3.6'
-            torch_version: '1.11.0+cpu'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,6 +18,8 @@ jobs:
         python_version: ['3.7', '3.8', '3.9', '3.10']
         torch_version: ['1.8.1+cpu', '1.9.1+cpu', '1.10.2+cpu', '1.11.0+cpu']
         os: [ubuntu-latest]
+          - python_version: '3.10'
+            torch_version: ['1.8.1+cpu', '1.9.1+cpu', '1.10.2+cpu']
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ numpydoc
 openpyxl
 pandas
 pillow
+protobuf>=3.12.0,<4.0dev
 pylint
 pytest>=3.4
 pytest-cov
@@ -18,4 +19,4 @@ sphinx
 sphinx_rtd_theme
 tensorboard>=1.14.0
 transformers
-wandb<0.10.29
+wandb>=0.12.17

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('requirements.txt') as f:
     install_requires = [l.strip() for l in f]
 
 
-python_requires = '>=3.6'
+python_requires = '>=3.7'
 
 tests_require = [
     'pytest',

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -976,12 +976,7 @@ class TestNeuralNet:
             self, net_cls, module_cls, net_fit, tmpdir, converter):
         # Test loading/saving with different kinds of path representations.
 
-        if converter is Path and sys.version < '3.6':
-            # `PosixPath` cannot be `open`ed in Python < 3.6
-            pytest.skip()
-
         net = net_cls(module_cls).initialize()
-
         history_before = net_fit.history
 
         p = tmpdir.mkdir('skorch').join('history.json')


### PR DESCRIPTION
No longer check Python 3.6 because it's been unsupported since the end of last year. Instead, add Python 3.10 to the CI. Unfortunately, the only PyTorch version supporting 3.10 right now is 1.11 (issue #66424), so all other versions are not being checked.

While working on this, an issue with wandb + protobuf came up, so I had to pin some versions there.

