### PR TITLE
Update to PyTorch 1.12.0

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,11 +16,9 @@ jobs:
     strategy:
       matrix:
         python_version: ['3.7', '3.8', '3.9', '3.10']
-        torch_version: ['1.8.1+cpu', '1.9.1+cpu', '1.10.2+cpu', '1.11.0+cpu']
+        torch_version: ['1.9.1+cpu', '1.10.2+cpu', '1.11.0+cpu', '1.12.0+cpu']
         os: [ubuntu-latest]
         exclude:
-          - python_version: '3.10'
-            torch_version: '1.8.1+cpu'
           - python_version: '3.10'
             torch_version: '1.9.1+cpu'
           - python_version: '3.10'

--- a/README.rst
+++ b/README.rst
@@ -236,10 +236,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.8.1
 - 1.9.1
 - 1.10.2
 - 1.11.0
+- 1.12.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -90,10 +90,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.8.1
 - 1.9.1
 - 1.10.2
 - 1.11.0
+- 1.12.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of


### PR DESCRIPTION
- add PyTorch 1.12.0 to CI
- drop PyTorch 1.8.1 from CI

There is nothing in the [release notes](https://pytorch.org/blog/pytorch-1.12-released/) to suggest that any further changes are needed on our side.