### PR TITLE
Make binary classifier work with BCELoss

### DIFF
--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -88,7 +88,7 @@ class TestNeuralNet:
 
     # classifier-specific test
     def test_takes_no_log_without_nllloss(self, net_cls, module_cls, data):
-        net = net_cls(module_cls, criterion=nn.BCELoss, max_epochs=1)
+        net = net_cls(module_cls, criterion=nn.CrossEntropyLoss, max_epochs=1)
         net.initialize()
 
         mock_loss = Mock(side_effect=nn.NLLLoss())

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -256,8 +256,13 @@ class TestNeuralNetBinaryClassifier:
         y_pred_proba = net.predict_proba(X)
         assert y_pred_proba.shape == (X.shape[0], 2)
 
-        # the tests below check that we don't accidentally apply sigmoid twice,
-        # which would result in all probas being within [expit(-1), expit(1)]
+        # The tests below check that we don't accidentally apply sigmoid twice,
+        # which would result in probabilities constrained to [expit(-1),
+        # expit(1)]. The lower bound is not expit(0), as one may think at first,
+        # because we create the probabilities as:
+        # torch.stack((1 - prob, prob), 1)
+        # So the lowest value that could be achieved by applying sigmoid twice
+        # is 1 - expit(1), which is equal to expit(-1).
         prob_min, prob_max = expit(-1), expit(1)
         assert (y_pred_proba < prob_min).any()
         assert (y_pred_proba > prob_max).any()
@@ -385,8 +390,13 @@ class TestNeuralNetBinaryClassifier:
         assert (y_proba >= 0).all()
         assert (y_proba <= 1).all()
 
-        # the tests below check that we don't accidentally apply sigmoid twice,
-        # which would result in all probas being within [expit(-1), expit(1)]
+        # The tests below check that we don't accidentally apply sigmoid twice,
+        # which would result in probabilities constrained to [expit(-1),
+        # expit(1)]. The lower bound is not expit(0), as one may think at first,
+        # because we create the probabilities as:
+        # torch.stack((1 - prob, prob), 1)
+        # So the lowest value that could be achieved by applying sigmoid twice
+        # is 1 - expit(1), which is equal to expit(-1).
         prob_min, prob_max = expit(-1), expit(1)
         assert (y_proba < prob_min).any()
         assert (y_proba > prob_max).any()

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 import torch
+from scipy.special import expit
 from sklearn.base import clone
 from torch import nn
 
@@ -256,9 +257,10 @@ class TestNeuralNetBinaryClassifier:
         assert y_pred_proba.shape == (X.shape[0], 2)
 
         # the tests below check that we don't accidentally apply sigmoid twice,
-        # which would result in all probas being withiin [0.2689, 0.7311].
-        assert (y_pred_proba < 0.26).any()
-        assert (y_pred_proba > 0.74).any()
+        # which would result in all probas being within [expit(-1), expit(1)]
+        prob_min, prob_max = expit(-1), expit(1)
+        assert (y_pred_proba < prob_min).any()
+        assert (y_pred_proba > prob_max).any()
 
         y_pred_exp = (y_pred_proba[:, 1] > threshold).astype('uint8')
 
@@ -384,9 +386,10 @@ class TestNeuralNetBinaryClassifier:
         assert (y_proba <= 1).all()
 
         # the tests below check that we don't accidentally apply sigmoid twice,
-        # which would result in all probas being withiin [0.2689, 0.7311].
-        assert (y_proba < 0.26).any()
-        assert (y_proba > 0.74).any()
+        # which would result in all probas being within [expit(-1), expit(1)]
+        prob_min, prob_max = expit(-1), expit(1)
+        assert (y_proba < prob_min).any()
+        assert (y_proba > prob_max).any()
 
     def test_predict_with_bceloss(self, net_with_bceloss, data):
         X, _ = data

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -352,3 +352,19 @@ class TestNeuralNetBinaryClassifier:
         expected = ("Expected module output to have shape (n,) or "
                     "(n, 1), got (128, 2) instead")
         assert msg == expected
+
+    def test_binary_classification_with_bceloss(self, net_cls, module_cls, data):
+        # binary classification should also work with BCELoss
+        net = net_cls(
+            module_cls,
+            module__output_nonlin=torch.nn.Sigmoid(),
+            criterion=torch.nn.BCELoss,
+            lr=1,
+        )
+        X, y = data
+        net.fit(X, y)
+        net.predict_proba(X)
+        net.predict(X)
+
+        train_losses = net.history[:, 'train_loss']
+        assert train_losses[0] > 1.3 * train_losses[-1]

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -17,6 +17,7 @@ import numpy as np
 from scipy import sparse
 import sklearn
 import torch
+from torch.nn import BCELoss
 from torch.nn import BCEWithLogitsLoss
 from torch.nn import CrossEntropyLoss
 from torch.nn.utils.rnn import PackedSequence
@@ -632,7 +633,7 @@ def _infer_predict_nonlinearity(net):
     if isinstance(criterion, CrossEntropyLoss):
         return partial(torch.softmax, dim=-1)
 
-    if isinstance(criterion, BCEWithLogitsLoss):
+    if isinstance(criterion, (BCEWithLogitsLoss, BCELoss)):
         return _sigmoid_then_2d
 
     # TODO only needed if multiclass GP classfication is added

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -585,6 +585,18 @@ def _identity(x):
     return x
 
 
+def _make_2d_probs(prob):
+    """Create a 2d probability array from a 1d vector
+
+    This is needed because by convention, even for binary classification
+    problems, sklearn expects 2 probabilities to be returned per row, one for
+    class 0 and one for class 1.
+
+    """
+    y_proba = torch.stack((1 - prob, prob), 1)
+    return y_proba
+
+
 def _sigmoid_then_2d(x):
     """Transform 1-dim logits to valid y_proba
 
@@ -607,8 +619,7 @@ def _sigmoid_then_2d(x):
 
     """
     prob = torch.sigmoid(x)
-    y_proba = torch.stack((1 - prob, prob), 1)
-    return y_proba
+    return _make_2d_probs(prob)
 
 
 # TODO only needed if multiclass GP classfication is added
@@ -633,8 +644,11 @@ def _infer_predict_nonlinearity(net):
     if isinstance(criterion, CrossEntropyLoss):
         return partial(torch.softmax, dim=-1)
 
-    if isinstance(criterion, (BCEWithLogitsLoss, BCELoss)):
+    if isinstance(criterion, BCEWithLogitsLoss):
         return _sigmoid_then_2d
+
+    if isinstance(criterion, BCELoss):
+        return _make_2d_probs
 
     # TODO only needed if multiclass GP classfication is added
     # likelihood = getattr(net, 'likelihood_', None)


### PR DESCRIPTION
Until now, `NeuralNetBinaryClassifier` assumes that `BCEWithLogitLoss` is used. Now, `BCELoss` works as well.

Note: Unless there is a very good reason not to, it's still recommended to use `NeuralNetClassifier`, even when dealing with a binary classification problem.