### PR TITLE
Fix wrong error message in Checkpoint

### DIFF
--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -211,10 +211,10 @@ class Checkpoint(Callback):
             try:
                 do_checkpoint = net.history[-1, self.monitor]
             except KeyError as e:
-                raise SkorchException(
-                    "Monitor value '{}' cannot be found in history. "
-                    "Make sure you have validation data if you use "
-                    "validation scores for checkpointing.".format(e.args[0]))
+                msg = (
+                    f"{e.args[0]} Make sure you have validation data if you use "
+                    "validation scores for checkpointing.")
+                raise SkorchException(msg)
 
         if self.event_name is not None:
             net.history.record(self.event_name, bool(do_checkpoint))

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -185,15 +185,14 @@ class TestCheckpoint:
             train_split=None
         )
         from skorch.exceptions import SkorchException
-        with pytest.raises(SkorchException) as e:
+
+        msg_expected = (
+            r"Key 'valid_loss_best' was not found in history. "
+            r"Make sure you have validation data if you use "
+            r"validation scores for checkpointing."
+        )
+        with pytest.raises(SkorchException, match=msg_expected):
             net.fit(*data)
-            expected = (
-                "Monitor value '{}' cannot be found in history. "
-                "Make sure you have validation data if you use "
-                "validation scores for checkpointing.".format(
-                    'valid_loss_best')
-            )
-            assert str(e.value) == expected
 
     def test_string_monitor_and_formatting(
             self, save_params_mock, net_cls, checkpoint_cls, data):


### PR DESCRIPTION
When a key was monitored that was not found in history, the resulting
error message would be:

> skorch.exceptions.SkorchException: Monitor value 'Key
'valid_loss_best' was not found in history.' cannot be found in history.
Make sure you have validation data if you use validation scores for
checkpointing.

This bugfix now returns the correct error message.