### PR TITLE
Checkpoint dirname argument can also be a callable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `load_best` attribute to `EarlyStopping` callback to automatically load module weights of the best result at the end of training
 - Added a method, `trim_for_prediction`, on the net classes, which trims the net from everything not required for using it for prediction; call this after fitting to reduce the size of the net
 - Added experimental support for [huggingface accelerate](https://github.com/huggingface/accelerate); use the provided mixin class to add advanced training capabilities provided by the accelerate library to skorch
+- Added possibility for `dirname` argument of `Checkpoint` to be a callable that returns the actual directory name; this can be used for generating directory names dynamically, e.g. in case multiple checkpoints are being used in parallel training (#848)
 
 ### Changed
 - Initialize data loaders for training and validation dataset once per fit call instead of once per epoch ([migration guide](https://skorch.readthedocs.io/en/stable/user/FAQ.html#migration-from-0-11-to-0-12))


### PR DESCRIPTION
Solves #848

## Description

For `Checkpoint`, as of now, `dirname` can only be a string. With this
update, it can also be a callable with no arguments that returns a string.

What this solves is that the directory that a model is saved in can now
contain a dynamic element. This way, if you run, e.g., grid search with
`n_jobs>1` + checkpoint, each checkpoint instance can have its own
directory name (e.g. using a function that returns a random name), while
the files inside the directory still follow the same naming.

Without such a possibility, if a user runs grid search with `n_jobs>1` and
checkpoint with `load_best=True`, the loaded model would always be
whatever happens to be the latest one stored, which can result
in (silent) errors.

If anyone has a better idea how to solve the underlying problem, I'm
open to it.

## Implementation

As a consequence of the `dirname` now not being known at `__init__` time, I
removed the validation of the filenames from there. We still validate
them inside `initialize`, which is sufficient in my opinion.

In theory, we could call the `dirname` function inside `__init__` to
validate it, and then call it again inside `initialize` to actually set
it, but I don't like that. The reason is that we would call a
function that is possible non-deterministic or might have side effects
twice, with unknown consequences. This should be avoided if possible.

## Example

Before, code like this would fail:

```python
params = {
    'module__num_units': [10, 20, 30],
}

net = NeuralNetClassifier(
    ClassifierModule,
    callbacks=[Checkpoint(f_history=None, load_best=True)]
)
gs = GridSearchCV(net, params, refit=False, cv=3, scoring='accuracy', n_jobs=3)
gs.fit(X, y)

# error message:
# RuntimeError: Error(s) in loading state_dict for ClassifierModule:
#	size mismatch for dense0.weight: copying a param with shape torch.Size([20, 20]) from checkpoint, the shape in current model is torch.Size([10, 20]).
```

With this feature, we can do:

```python
import random
def make_dirname():
    return f"test-dir-{random.randint(0, 1_000_000)}"

net = NeuralNetClassifier(
    ClassifierModule,
    callbacks=[Checkpoint(f_history=None, load_best=True, dirname=make_dirname)]
)
gs = GridSearchCV(net, params, refit=False, cv=3, scoring='accuracy', n_jobs=3)
gs.fit(X, y)
```

and it works.