### PR TITLE
Support for gradient accumulation with accelerate

### DIFF
--- a/skorch/helper.py
+++ b/skorch/helper.py
@@ -653,6 +653,17 @@ class AccelerateMixin:
 
         return self
 
+    def train_step(self, batch, **fit_params):
+        # Call training step within the accelerator context manager
+        with self.accelerator.accumulate(self.module_):
+            # Why are we passing only module_ here, even though there might be
+            # other modules as well? First of all, there is no possibility to
+            # pass multiple modules. Second, the module_ is only used to
+            # determine if Distributed Data Parallel is being used, not for
+            # anything else. Therefore, passing module_ should be sufficient
+            # most of the time.
+            return super().train_step(batch, **fit_params)
+
     def train_step_single(self, batch, **fit_params):
         self._set_training(True)
         Xi, yi = unpack_data(batch)

--- a/skorch/helper.py
+++ b/skorch/helper.py
@@ -12,6 +12,7 @@ from sklearn.base import TransformerMixin
 import torch
 
 from skorch.cli import parse_args  # pylint: disable=unused-import
+from skorch.callbacks import LRScheduler
 from skorch.dataset import unpack_data
 from skorch.utils import _make_split
 from skorch.utils import to_numpy
@@ -650,6 +651,15 @@ class AccelerateMixin:
                 optimizer = getattr(self, name + '_')
                 if isinstance(optimizer, torch.optim.Optimizer):
                     setattr(self, name + '_', self.accelerator.prepare(optimizer))
+
+        return self
+
+    def initialize_callbacks(self, *args, **kwargs):
+        super().initialize_callbacks(*args, **kwargs)
+
+        for _, callback in self.callbacks_:
+            if isinstance(callback, LRScheduler):
+                callback.policy_ = self.accelerator.prepare(callback.policy_)
 
         return self
 

--- a/skorch/tests/test_helper.py
+++ b/skorch/tests/test_helper.py
@@ -958,8 +958,8 @@ class TestAccelerate:
                 return super().infer(*args, **kwargs)
 
             def train_step_single(self, *args, **kwargs):
-                # check that all optimizers are prepared and that
-                # loss.backward() was called TODO
+                # check that all optimizers and the lr scheduler are prepared,
+                # and that loss.backward() was called,
                 assert self.optimizer_.is_prepared
                 assert self.optimizer2_.is_prepared
 

--- a/skorch/tests/test_helper.py
+++ b/skorch/tests/test_helper.py
@@ -1,5 +1,6 @@
 """Test for helper.py"""
 import pickle
+from contextlib import contextmanager
 from distutils.version import LooseVersion
 from functools import partial
 from unittest.mock import Mock
@@ -913,6 +914,10 @@ class TestAccelerate:
             def unwrap_model(self, model):
                 return model
 
+            @contextmanager
+            def accumulate(self, model):
+                yield
+
         # pylint: disable=missing-class-docstring
         class AcceleratedNet(AccelerateMixin, NeuralNetClassifier):
             def get_iterator(self, *args, **kwargs):
@@ -971,3 +976,51 @@ class TestAccelerate:
         # does not raise
         net.fit(X, y)
         net.predict(X)
+
+    def test_gradient_accumulation_with_accelerate(
+            self, module_cls, accelerator_cls, data
+    ):
+        # Check that using gradient accumulation provided by accelerate actually
+        # works. Testing this is not quite trivial. E.g. we cannot check haven
+        # often optimizer.step() is called because accelerate still calls it on
+        # each step but does not necessarily update the weights. Therefore, we
+        # check if there was an update step by comparing the weights before and
+        # after the train_step call. If the weights changed, then there was a
+        # step, otherwise not.
+        from skorch import NeuralNetClassifier
+        from skorch.helper import AccelerateMixin
+
+        def weight_sum(module):
+            return sum(weights.sum() for weights in module.parameters())
+
+        # Record for each training step if there was an update of the weights
+        updated = []
+
+        # pylint: disable=missing-docstring
+        class GradAccNet(AccelerateMixin, NeuralNetClassifier):
+            # pylint: disable=arguments-differ
+            def train_step(self, *args, **kwargs):
+                # Note: We use a very simplified way of checking if weights were
+                # updated by just comparing their sum. This way, we don't need
+                # to keep a copy around.
+                weight_sum_before = weight_sum(self.module_)
+                step = super().train_step(*args, **kwargs)
+                weight_sum_after = weight_sum(self.module_)
+                update_occurred = (weight_sum_before != weight_sum_after).item()
+                updated.append(update_occurred)
+                return step
+
+        max_epochs = 2
+        acc_steps = 3
+        accelerator = accelerator_cls(gradient_accumulation_steps=acc_steps)
+        net = GradAccNet(module_cls, accelerator=accelerator, max_epochs=max_epochs)
+        X, y = data
+        net.fit(X, y)
+
+        # Why we expect this outcome: Since acc_steps is 3, we expect that
+        # updated should be [False, False, True]. However, since we have 1000
+        # samples and a batch size of 128, every 7th batch is the last batch of
+        # the epoch, after which there should also be an update. Therefore,
+        # every 7th entry is also True.
+        updated_expected = [False, False, True, False, False, True, True] * max_epochs
+        assert updated == updated_expected


### PR DESCRIPTION
The latest accelerate release added gradient accumulation support. This
requires the AccelerateMixin to call the training loop within a context
manager. This is now done. Users can therefore use the gradient
accumulation feature of accelerate.