### PR TITLE
Nets now can be loaded even if device=None

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,10 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initialize data loaders for training and validation dataset once per fit call instead of once per epoch ([migration guide](https://skorch.readthedocs.io/en/stable/user/FAQ.html#migration-from-0-11-to-0-12))
 - It is now possible to call `np.asarray` with `SliceDataset`s (#858)
 - Add integration for Huggingface tokenizers; use `skorch.hf.HuggingfaceTokenizer` to train a Huggingface tokenizer on your custom data; use `skorch.hf.HuggingfacePretrainedTokenizer` to load a pre-trained Huggingface tokenizer
-- Fix a bug that occurred when loading a net that has device set to None
 
 ### Fixed
 - Fix a bug in `SliceDataset` that prevented it to be used with `to_numpy` (#858)
+- Fix a bug that occurred when loading a net that has device set to None
 
 ## [0.11.0] - 2021-10-11
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initialize data loaders for training and validation dataset once per fit call instead of once per epoch ([migration guide](https://skorch.readthedocs.io/en/stable/user/FAQ.html#migration-from-0-11-to-0-12))
 - It is now possible to call `np.asarray` with `SliceDataset`s (#858)
 - Add integration for Huggingface tokenizers; use `skorch.hf.HuggingfaceTokenizer` to train a Huggingface tokenizer on your custom data; use `skorch.hf.HuggingfacePretrainedTokenizer` to load a pre-trained Huggingface tokenizer
+- Fix a bug that occurred when loading a net that has device set to None
 
 ### Fixed
 - Fix a bug in `SliceDataset` that prevented it to be used with `to_numpy` (#858)

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -2413,6 +2413,15 @@ class NeuralNet:
         return the map device if it differs from the requested device
         along with a warning.
         """
+        if requested_device is None:
+            # user has set net.device=None, we don't know the type, use fallback
+            msg = (
+                f"Setting self.device = {map_device} since the requested device "
+                f"was not specified"
+            )
+            warnings.warn(msg, DeviceWarning)
+            return map_device
+
         type_1 = torch.device(requested_device)
         type_2 = torch.device(map_device)
         if type_1 != type_2:


### PR DESCRIPTION
## Description

In #600, we introduced the option to set `device=None`, which means that
skorch should not move any data to any device. However, this setting
introduced a bug when trying to load the net, as that code didn't
explicitly deal with `device=None.` With this PR, the bug is fixed.

## Implementation

If `device=None`, we really have no way of knowing what device to map the
parameters to. The most reasonable thing to do is to use the fallback,
which is 'cpu'.