### PR TITLE
Bugfix/loading set params kwargs without cuda

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix a bug in `SliceDataset` that prevented it to be used with `to_numpy` (#858)
+- Fix a bug that in some cases could prevent loading a net that was trained with CUDA without CUDA
 
 ## [0.11.0] - 2021-10-11
 

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -2121,6 +2121,7 @@ class NeuralNet:
 
     def __getstate__(self):
         state = self.__dict__.copy()
+        state['_kwargs'] = self._kwargs.copy()  # copy so as not to mutate
         cuda_attrs = {}
         for prefix in self.cuda_dependent_attributes_:
             for key in state:

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -2133,7 +2133,9 @@ class NeuralNet:
                         del state['_kwargs'][key]
 
         # remember cuda_dependent_attributes_ prefixes for __setstate__
-        state['__cuda_dependent_attributes_prefixes__'] = self.cuda_dependent_attributes_[:]
+        state['__cuda_dependent_attributes_prefixes__'] = (
+            self.cuda_dependent_attributes_[:]
+        )
 
         for k in cuda_attrs:
             state.pop(k)

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -434,11 +434,13 @@ class TestNeuralNet:
         )
         net_pickleable.fit(X, y)
 
+        kwarg_keys = net_pickleable._kwargs.keys()
+        # make sure that those keys are there
         cuda_dependent_kwargs = {'criterion__weight', 'optimizer'}
-        assert cuda_dependent_kwargs.issubset(net_pickleable._kwargs)
+        assert cuda_dependent_kwargs.issubset(kwarg_keys)
 
         net_loaded = pickle.loads(pickle.dumps(net_pickleable))
-        assert cuda_dependent_kwargs.issubset(net_loaded._kwargs)
+        assert kwarg_keys == net_loaded._kwargs.keys()
 
     @pytest.mark.parametrize('device', ['cpu', 'cuda'])
     def test_device_torch_device(self, net_cls, module_cls, device):


### PR DESCRIPTION
This bug occurs when trying to load a net that was trained on CUDA on a
CPU machine. However, it only occurred when there were CUDA-dependent
attribute set via `set_params`. This bug is now fixed.

## Details

The problem started occurring after PR #751, which introduced storing
parameters set via `set_params` in the private attribute `_kwargs`.
Normally, for attributes, we make sure that they can be loaded without
CUDA, but attributes within `_kwargs` were not checked. Thus, loading
those without CUDA failed. Unfortunately, this was not caught by CI
because CI is not CUDA-enabled.

The solution to this problem is that CUDA-dependent attributes are now
removed from `_kwargs` during `__getstate__` and re-added later during
`__setstate__` (a test was introduced for checking that). A little problem
occurring there was that the `cuda_dependent_attributes_` are not part of
`state`. Therefore, I add them to state during `__getstate__` and remove
them later in `__setstate__`.