### PR TITLE
fetch_openml should return numpy arrays

### DIFF
--- a/examples/benchmarks/mnist.py
+++ b/examples/benchmarks/mnist.py
@@ -47,11 +47,11 @@ MAX_EPOCHS = 12
 
 
 def get_data(num_samples):
-    mnist = fetch_openml('mnist_784')
+    mnist = fetch_openml('mnist_784', as_frame=False)
     torch.manual_seed(0)
-    X = mnist.data.values.astype('float32').reshape(-1, 1, 28, 28)
-    y = mnist.target.values.astype('int64')
-    X, y = shuffle(X, y)
+    X = mnist.data.astype('float32').reshape(-1, 1, 28, 28)
+    y = mnist.target.astype('int64')
+    X, y = shuffle(X, y, random_state=0)
     X, y = X[:num_samples], y[:num_samples]
     X_train, X_test, y_train, y_test = train_test_split(X, y, stratify=y, random_state=0)
     X_train /= 255

--- a/notebooks/MNIST.ipynb
+++ b/notebooks/MNIST.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mnist = fetch_openml('mnist_784', cache=False)"
+    "mnist = fetch_openml('mnist_784', as_frame=False, cache=False)"
    ]
   },
   {


### PR DESCRIPTION
The default was changed from numpy arrays to pandas dataframes, which
broke a notebook. Use parameter to return numpy arrays again.

Additionally, set random seed for shuffling in mnist benchmark script.