### PR TITLE
Remove outdated version checks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added experimental support for [huggingface accelerate](https://github.com/huggingface/accelerate); use the provided mixin class to add advanced training capabilities provided by the accelerate library to skorch
 
 ### Changed
-- The minimum required scikit-learn version has been bumped to 1.0.0
+- The minimum required scikit-learn version has been bumped to 0.22.0
 - Initialize data loaders for training and validation dataset once per fit call instead of once per epoch ([migration guide](https://skorch.readthedocs.io/en/stable/user/FAQ.html#migration-from-0-11-to-0-12))
 - It is now possible to call `np.asarray` with `SliceDataset`s (#858)
 - Add integration for Huggingface tokenizers; use `skorch.hf.HuggingfaceTokenizer` to train a Huggingface tokenizer on your custom data; use `skorch.hf.HuggingfacePretrainedTokenizer` to load a pre-trained Huggingface tokenizer

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added experimental support for [huggingface accelerate](https://github.com/huggingface/accelerate); use the provided mixin class to add advanced training capabilities provided by the accelerate library to skorch
 
 ### Changed
+- The minimum required scikit-learn version has been bumped to 1.0.0
 - Initialize data loaders for training and validation dataset once per fit call instead of once per epoch ([migration guide](https://skorch.readthedocs.io/en/stable/user/FAQ.html#migration-from-0-11-to-0-12))
 - It is now possible to call `np.asarray` with `SliceDataset`s (#858)
 - Add integration for Huggingface tokenizers; use `skorch.hf.HuggingfaceTokenizer` to train a Huggingface tokenizer on your custom data; use `skorch.hf.HuggingfacePretrainedTokenizer` to load a pre-trained Huggingface tokenizer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.13.3
-scikit-learn>=1.0.0
+scikit-learn>=0.22.0
 scipy>=1.1.0
 tabulate>=0.7.7
 tqdm>=4.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.13.3
-scikit-learn>=0.19.1
+scikit-learn>=1.0.0
 scipy>=1.1.0
 tabulate>=0.7.7
 tqdm>=4.14.0

--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -2,7 +2,6 @@
 
 from contextlib import contextmanager
 from contextlib import suppress
-from distutils.version import LooseVersion
 from functools import partial
 import warnings
 
@@ -10,13 +9,9 @@ import numpy as np
 import sklearn
 from sklearn.metrics import make_scorer, check_scoring
 
-if LooseVersion(sklearn.__version__) >= '0.22':
-    from sklearn.metrics._scorer import _BaseScorer
-else:
-    from sklearn.metrics.scorer import _BaseScorer
-
 from skorch.callbacks import Callback
 from skorch.dataset import unpack_data
+from sklearn.metrics._scorer import _BaseScorer
 from skorch.utils import data_from_dataset
 from skorch.utils import is_skorch_dataset
 from skorch.utils import to_numpy

--- a/skorch/tests/callbacks/test_lr_scheduler.py
+++ b/skorch/tests/callbacks/test_lr_scheduler.py
@@ -1,5 +1,4 @@
 """Tests for lr_scheduler.py"""
-from distutils.version import LooseVersion
 from unittest.mock import Mock
 
 import numpy as np
@@ -191,10 +190,6 @@ class TestLRCallbacks:
     @pytest.mark.parametrize('policy,kwargs', [
         (StepLR, {'gamma': 0.9, 'step_size': 1})
     ])
-    @pytest.mark.skipif(
-        LooseVersion(torch.__version__) < '1.4',
-        reason="Feature isn't supported with this torch version."
-    )
     def test_lr_scheduler_record_epoch_step(self,
                                             classifier_module,
                                             classifier_data,
@@ -212,10 +207,6 @@ class TestLRCallbacks:
         net.fit(*classifier_data)
         assert np.all(net.history[:, 'event_lr'] == lrs)
 
-    @pytest.mark.skipif(
-        LooseVersion(torch.__version__) < '1.4',
-        reason="Feature isn't supported with this torch version."
-    )
     def test_lr_scheduler_record_batch_step(self, classifier_module, classifier_data):
         X, y = classifier_data
         batch_size = 128

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -6,7 +6,6 @@ that is general to NeuralNet class.
 """
 
 import copy
-from distutils.version import LooseVersion
 from functools import partial
 import os
 from pathlib import Path
@@ -1784,23 +1783,19 @@ class TestNeuralNet:
         expected = """<class 'skorch.classifier.NeuralNetClassifier'>[initialized](
   module_=MLPModule(
     (nonlin): PReLU(num_parameters=1)
-    (output_nonlin): Softmax()
+    (output_nonlin): Softmax(dim=-1)
     (sequential): Sequential(
       (0): Linear(in_features=20, out_features=11, bias=True)
       (1): PReLU(num_parameters=1)
-      (2): Dropout(p=0.5)
+      (2): Dropout(p=0.5, inplace=False)
       (3): Linear(in_features=11, out_features=11, bias=True)
       (4): PReLU(num_parameters=1)
-      (5): Dropout(p=0.5)
+      (5): Dropout(p=0.5, inplace=False)
       (6): Linear(in_features=11, out_features=2, bias=True)
-      (7): Softmax()
+      (7): Softmax(dim=-1)
     )
   ),
 )"""
-        if LooseVersion(torch.__version__) >= '1.2':
-            expected = expected.replace("Softmax()", "Softmax(dim=-1)")
-            expected = expected.replace("Dropout(p=0.5)",
-                                        "Dropout(p=0.5, inplace=False)")
         assert result == expected
 
     def test_fit_params_passed_to_module(self, net_cls, data):

--- a/skorch/tests/test_probabilistic.py
+++ b/skorch/tests/test_probabilistic.py
@@ -3,7 +3,6 @@
 import copy
 import pickle
 import re
-from distutils.version import LooseVersion
 
 import numpy as np
 import pytest
@@ -18,13 +17,6 @@ from skorch.utils import to_numpy
 
 
 gpytorch = pytest.importorskip('gpytorch')
-
-# extract pytorch version without possible '+something' suffix
-pytorch_version, _, _ = torch.__version__.partition('+')
-# Keep up to date with the gpytorch's supported versions:
-# https://github.com/cornellius-gp/gpytorch#installation
-if LooseVersion(pytorch_version) < '1.9':
-    pytest.skip("gpytorch does not support PyTorch versions < 1.9", allow_module_level=True)
 
 
 def get_batch_size(dist):

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -6,7 +6,6 @@ Should not have any dependency on other skorch packages.
 
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
-from distutils.version import LooseVersion
 from enum import Enum
 from functools import partial
 from itertools import tee
@@ -17,6 +16,7 @@ import numpy as np
 from scipy import sparse
 import sklearn
 from sklearn.exceptions import NotFittedError
+from sklearn.utils import _safe_indexing as safe_indexing
 from sklearn.utils.validation import check_is_fitted as sk_check_is_fitted
 import torch
 from torch.nn import BCELoss
@@ -28,10 +28,6 @@ from torch.utils.data.dataset import Subset
 from skorch.exceptions import DeviceWarning
 from skorch.exceptions import NotInitializedError
 
-if LooseVersion(sklearn.__version__) >= '0.22.0':
-    from sklearn.utils import _safe_indexing as safe_indexing
-else:
-    from sklearn.utils import safe_indexing
 
 GPYTORCH_INSTALLED = False
 try:


### PR DESCRIPTION
Remove version checks that are no longer required because we don't
support the min versions anymore.

I was working on the proposed solution in #887 when I noticed that none
of the version checks we do is actually required anymore. After removing
them, we thus no longer depend on distutils's `LooseVersion`.

If we ever need to do a version check in the future, I would still go
with the [scipy Version class](https://github.com/scipy/scipy/blob/main/scipy/_lib/_pep440.py).

Also, in the future, we should ensure to add `# TODO` comments to all
version checks so that we can easily find them.

One change I introduced here is to require scikit-learn>=1.0.0. I think
this should be fine because it's been out for some time now and it still
supports Python 3.7.

We could go to 0.24 instead and would still not need a version check,
let me know if you prefer that.