### PR TITLE
Update MNIST.ipynb

### DIFF
--- a/notebooks/MNIST.ipynb
+++ b/notebooks/MNIST.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mnist = fetch_openml('mnist_784', as_frame=False, cache=False)"
+    "mnist = fetch_openml('mnist_784')"
    ]
   },
   {


### PR DESCRIPTION
threw an error as written; should work w/o the added arguments

error:


```---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-19c8d440ea79> in <module>
----> 1 mnist = fetch_openml('mnist_784', as_frame=False, cache=False)

TypeError: fetch_openml() got an unexpected keyword argument 'as_frame'```