### PR TITLE
The entry for the badge was missing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 
 ------------
 
-|build| |coverage| |docs| |powered|
+|build| |coverage| |docs| |huggingface| |powered|
 
 A scikit-learn compatible neural network library that wraps PyTorch.
 


### PR DESCRIPTION
A reference to the badge was added in #904 but for it to show, there needs to be an entry using that reference.