### PR TITLE
Fix false warning if iterator_valid__shuffle=False

### DIFF
--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1914,11 +1914,12 @@ class NeuralNet:
         # warn about usage of iterator_valid__shuffle=True, since this
         # is almost certainly not what the user wants
         if 'iterator_valid__shuffle' in self._params_to_validate:
-            warnings.warn(
-                "You set iterator_valid__shuffle=True; this is most likely not "
-                "what you want because the values returned by predict and "
-                "predict_proba will be shuffled.",
-                UserWarning)
+            if self.iterator_valid__shuffle:
+                warnings.warn(
+                    "You set iterator_valid__shuffle=True; this is most likely not "
+                    "what you want because the values returned by predict and "
+                    "predict_proba will be shuffled.",
+                    UserWarning)
 
         # check for wrong arguments
         unexpected_kwargs = []

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -263,19 +263,24 @@ class TestNeuralNet:
         # "optimizer_2".
         MyNet(module_cls, optimizer_2__lr=0.123)  # should not raise
 
-    def test_net_init_with_iterator_valid_shuffle_true(
+    def test_net_init_with_iterator_valid_shuffle_false_no_warning(
+            self, net_cls, module_cls, recwarn):
+        # If a user sets iterator_valid__shuffle=False, everything is good and
+        # no warning should be issued, see
+        # https://github.com/skorch-dev/skorch/issues/907
+        net_cls(module_cls, iterator_valid__shuffle=False).initialize()
+        assert not recwarn.list
+
+    def test_net_init_with_iterator_valid_shuffle_true_warns(
             self, net_cls, module_cls, recwarn):
         # If a user sets iterator_valid__shuffle=True, they might be
         # in for a surprise, since predict et al. will result in
         # shuffled predictions. It is best to warn about this, since
         # most of the times, this is not what users actually want.
         expected = (
-            "You set iterator_valid__shuffle=True; this is most likely not what you want "
-            "because the values returned by predict and predict_proba will be shuffled.")
-
-        # no warning expected here
-        net_cls(module_cls, iterator_valid__shuffle=False)
-        assert not recwarn.list
+            "You set iterator_valid__shuffle=True; this is most likely not what you "
+            "want because the values returned by predict and predict_proba will be "
+            "shuffled.")
 
         # warning expected here
         with pytest.warns(UserWarning, match=expected):


### PR DESCRIPTION
Resolves #907

The regression initially occurred because the we did not check for the value of `iterator_valid__shuffle`, just the presence of the key.

Even though there is a test for this, the test didn't detect the error. This is because during a refactor (#751), the parameter validation was moved to `initialize()` from `__init__()` but the test was not adjusted to take the change into account. For clarity, I moved the test to a separate function (it used to be a subtest of another test).