### PR TITLE
Update CI to use PyTorch 1.13

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -37,6 +37,7 @@ jobs:
         python -m pip install -r requirements-dev.txt
         python -m pip install -r requirements.txt
         python -m pip install torch==${{ matrix.torch_version }} -f https://download.pytorch.org/whl/torch_stable.html
+        python -m pip list
     - name: Install skorch
       run: |
         python -m pip install .

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,13 +16,8 @@ jobs:
     strategy:
       matrix:
         python_version: ['3.7', '3.8', '3.9', '3.10']
-        torch_version: ['1.9.1+cpu', '1.10.2+cpu', '1.11.0+cpu', '1.12.0+cpu']
+        torch_version: ['1.10.2+cpu', '1.11.0+cpu', '1.12.1+cpu', '1.13.0+cpu']
         os: [ubuntu-latest]
-        exclude:
-          - python_version: '3.10'
-            torch_version: '1.9.1+cpu'
-          - python_version: '3.10'
-            torch_version: '1.10.2+cpu'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,6 +18,12 @@ jobs:
         python_version: ['3.7', '3.8', '3.9', '3.10']
         torch_version: ['1.10.2+cpu', '1.11.0+cpu', '1.12.1+cpu', '1.13.0+cpu']
         os: [ubuntu-latest]
+        exclude:
+          - python_version: '3.10'
+            torch_version: '1.9.1+cpu'
+          - python_version: '3.10'
+            torch_version: '1.10.2+cpu'
+        fail-fast: false  # don't cancel all jobs when one fails
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,6 +14,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false  # don't cancel all jobs when one fails
       matrix:
         python_version: ['3.7', '3.8', '3.9', '3.10']
         torch_version: ['1.10.2+cpu', '1.11.0+cpu', '1.12.1+cpu', '1.13.0+cpu']
@@ -23,7 +24,6 @@ jobs:
             torch_version: '1.9.1+cpu'
           - python_version: '3.10'
             torch_version: '1.10.2+cpu'
-        fail-fast: false  # don't cancel all jobs when one fails
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -241,22 +241,21 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.9.1
 - 1.10.2
 - 1.11.0
-- 1.12.0
+- 1.12.1
+- 1.13.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of
 the PyTorch API, older PyTorch versions should work fine.
 
-In general, running this to install PyTorch should work (assuming CUDA
-11.1):
+In general, running this to install PyTorch should work:
 
 .. code:: bash
 
     # using conda:
-    conda install pytorch cudatoolkit==11.1 -c pytorch
+    conda install pytorch cudatoolkit -c pytorch
     # using pip
     python -m pip install torch
 

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -90,10 +90,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.9.1
 - 1.10.2
 - 1.11.0
-- 1.12.0
+- 1.12.1
+- 1.13.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of

--- a/skorch/tests/test_helper.py
+++ b/skorch/tests/test_helper.py
@@ -334,9 +334,9 @@ class TestSliceDataset:
         [55],
         [-3],
         [0, 10, 3, -8, 3],
-        np.ones(100, dtype=np.bool),
+        np.ones(100, dtype=bool),
         # boolean mask array of length 100
-        np.array([0, 0, 1, 0] * 25, dtype=np.bool),
+        np.array([0, 0, 1, 0] * 25, dtype=bool),
     ])
     def test_len_and_shape_sliced(self, slds, y, sl):
         # torch tensors don't support negative steps, skip test
@@ -374,9 +374,9 @@ class TestSliceDataset:
         (slice(-1, None), 0),
         ([55], -1),
         ([0, 10, 3, -8, 3], 1),
-        (np.ones(100, dtype=np.bool), 5),
+        (np.ones(100, dtype=bool), 5),
         # boolean mask array of length 100
-        (np.array([0, 0, 1, 0] * 25, dtype=np.bool), 6),
+        (np.array([0, 0, 1, 0] * 25, dtype=bool), 6),
     ])
     def test_slice_twice(self, slds_cls, custom_ds, X, y, sl0, sl1, n):
         data = X if n == 0 else y

--- a/skorch/tests/test_hf.py
+++ b/skorch/tests/test_hf.py
@@ -569,6 +569,19 @@ class TestAccelerate:
     def test_mixed_precision_pickling(
             self, net_cls, accelerator_cls, data, mixed_precision
     ):
+        import accelerate
+        from skorch._version import Version
+
+        # https://github.com/huggingface/accelerate/issues/805
+        version_accelerate = Version(accelerate.__version__)
+        version_torch = Version(torch.__version__)
+        if (
+                (version_accelerate <= Version('0.13.2'))
+                and (version_torch >= Version('1.13.0'))
+        ):
+            reason = "skip because of a bug with accelerate <= 0.13.2 and torch >= 1.13"
+            pytest.skip(msg=reason)
+
         # Pickling currently doesn't work because the forward method on modules
         # is overwritten with a modified version of the method using autocast.
         # Pickle doesn't know how to restore those methods.


### PR DESCRIPTION
Remove 1.9.

Also, removed excluded combination from test matrix to check if they work now.

Locally, PyTorch 1.13 worked, and the change log also doesn't contain anything to suggest otherwise.