### PR TITLE
Don't fail when gpytorch import fails

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix an error that could occur with specific combinations of gpytorch and PyTorch versions (#913)
+
 ## [0.12.0] - 2022-10-07
 
 ### Added

--- a/skorch/probabilistic.py
+++ b/skorch/probabilistic.py
@@ -8,7 +8,6 @@
 
 import pickle
 import re
-import warnings
 
 import gpytorch
 import numpy as np
@@ -21,16 +20,12 @@ from skorch.callbacks import EpochScoring
 from skorch.callbacks import EpochTimer
 from skorch.callbacks import PassthroughScoring
 from skorch.callbacks import PrintLog
-from skorch.exceptions import SkorchWarning
 from skorch.utils import check_is_fitted
 from skorch.utils import get_dim
 from skorch.utils import is_dataset
 from skorch.utils import to_numpy
 from skorch.utils import to_tensor
 
-
-warnings.warn("The API of the Gaussian Process estimators is experimental and may "
-              "change in the future", SkorchWarning)
 
 __all__ = ['ExactGPRegressor', 'GPRegressor', 'GPBinaryClassifier']
 

--- a/skorch/tests/test_probabilistic.py
+++ b/skorch/tests/test_probabilistic.py
@@ -17,7 +17,10 @@ from skorch.utils import is_torch_data_type
 from skorch.utils import to_numpy
 
 
-gpytorch = pytest.importorskip('gpytorch')
+try:
+    gpytorch = pytest.importorskip('gpytorch')
+except AttributeError:
+    pytest.skip("Incompatible gpytorch + torch version", allow_module_level=True)
 
 # check that torch version is sufficiently high for gpytorch, otherwise skip
 version_gpytorch = Version(gpytorch.__version__)

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -36,6 +36,14 @@ try:
     GPYTORCH_INSTALLED = True
 except ImportError:
     gpytorch = None
+except AttributeError:
+    msg = (
+        "Importing gpytorch failed. This is probably because its version is "
+        "incompatible with the installed torch version. Please visit "
+        "https://github.com/cornellius-gp/gpytorch#installation to check "
+        "which versions are compatible"
+    )
+    warnings.warn(msg)
 
 try:
     import torch_geometric

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -29,22 +29,6 @@ from torch.utils.data.dataset import Subset
 from skorch.exceptions import DeviceWarning
 from skorch.exceptions import NotInitializedError
 
-
-GPYTORCH_INSTALLED = False
-try:
-    import gpytorch
-    GPYTORCH_INSTALLED = True
-except ImportError:
-    gpytorch = None
-except AttributeError:
-    msg = (
-        "Importing gpytorch failed. This is probably because its version is "
-        "incompatible with the installed torch version. Please visit "
-        "https://github.com/cornellius-gp/gpytorch#installation to check "
-        "which versions are compatible"
-    )
-    warnings.warn(msg)
-
 try:
     import torch_geometric
     TORCH_GEOMETRIC_INSTALLED = True
@@ -673,17 +657,32 @@ def _infer_predict_nonlinearity(net):
     if isinstance(criterion, BCELoss):
         return _make_2d_probs
 
-    # TODO only needed if multiclass GP classfication is added
-    # likelihood = getattr(net, 'likelihood_', None)
-    # if (
-    #         likelihood
-    #         and GPYTORCH_INSTALLED
-    #         and isinstance(likelihood, gpytorch.likelihoods.SoftmaxLikelihood)
-    # ):
-    #     # SoftmaxLikelihood returns batch second order
-    #     return _transpose
-
     return _identity
+
+    # TODO: Add the code below to _infer_predict_nonlinearity if multiclass GP
+    # classfication is added.
+    # likelihood = getattr(net, 'likelihood_', None)
+    # if likelihood is None:
+    #     return _identity
+    # nonlin = _identity
+    # try:
+    #     import gpytorch
+    #     if isinstance(likelihood, gpytorch.likelihoods.SoftmaxLikelihood):
+    #         # SoftmaxLikelihood returns batch second order
+    #         nonlin = _transpose
+    # except ImportError:
+    #     # there is no gpytorch install
+    #     pass
+    # except AttributeError:
+    #     # gpytorch and pytorch are incompatible
+    #     msg = (
+    #         "Importing gpytorch failed. This is probably because its version is "
+    #         "incompatible with the installed torch version. Please visit "
+    #         "https://github.com/cornellius-gp/gpytorch#installation to check "
+    #         "which versions are compatible"
+    #     )
+    #     warnings.warn(msg)
+    # return nonlin
 
 
 class TeeGenerator:


### PR DESCRIPTION
This is mostly relevant for CI, as most users probably don't have gpytorch installed.

The problem is that some gpytorch versions now raise an `AttributeError` with some torch versions. Since we try to import gpytorch in `utils.py` and in `test_probabilistic.py` but only catch `ImportError`, the `AttributeError` will be raised. However, the presence of an incompatible gpytorch version should not preclude the usage of skorch.

In the gpytorch tests themselves, we already check for compatible versions and skip if they are not compatible. However, to check versions, we first need to successfully import gpytorch, which fails.

Here is an example of a job that currently fails because of this:

https://github.com/skorch-dev/skorch/actions/runs/3421070263/jobs/5696711066

The solution now is to catch `AttributeError`s during gpytorch imports. For `utils.py`, we then treat it as if gpytorch were not installed, for the tests we skip. A disadvantage of this indiscriminate skipping is that it could happen that all versions are skipped and we won't notice since CI is green. I don't have a good solution for this.