### PR TITLE
Update deploy.sh, openssl, use pip

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -46,6 +46,8 @@ source activate $CONDA_ENV
 echo "installing dependencies"
 conda install -c pytorch -y "pytorch==${PYTORCH_VERSION}"
 python -m pip install "twine${TWINE_VERSION}"
+# Workaround for error `AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'`
+# due to outdated system pyOpenSSL - see also: https://askubuntu.com/q/1428181
 python -m pip install pyOpenSSL --upgrade
 python -m pip install -r requirements.txt
 python -m pip install -r requirements-dev.txt

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,7 +26,7 @@ set +e
 conda env remove -y -n $CONDA_ENV
 set -e
 
-echo "creating conda env"
+echo "creating empty conda env"
 conda env create -q -n $CONDA_ENV
 
 remove_env() {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,7 +5,6 @@ PYTORCH_VERSION=${PYTORCH_VERSION:-""}
 PYTHON_VERSION="3.9"
 TWINE_VERSION=">3,<4.0.0dev"
 CONDA_ENV="skorch-deploy"
-CONDA_ENV_YML="environment.yml"
 
 if [[ $# -gt 1 ]] || [[ $1 != "live" && $1 != "stage" ]]; then
 	echo "Usage $0 [live|stage]" >&2
@@ -27,7 +26,8 @@ set +e
 conda env remove -y -n $CONDA_ENV
 set -e
 
-conda env create -q -n $CONDA_ENV -f $CONDA_ENV_YML "python=${PYTHON_VERSION}"
+echo "creating conda env"
+conda env create -q -n $CONDA_ENV
 
 remove_env() {
     source deactivate
@@ -43,10 +43,14 @@ remove_env() {
 trap remove_env EXIT
 
 source activate $CONDA_ENV
-conda install -q -y "twine==${TWINE_VERSION}"
+echo "installing dependencies"
 conda install -c pytorch -y "pytorch==${PYTORCH_VERSION}"
+python -m pip install "twine${TWINE_VERSION}"
+python -m pip install pyOpenSSL --upgrade
+python -m pip install -r requirements.txt
 python -m pip install -r requirements-dev.txt
 python -m pip install .
+python -m pip list
 
 pytest -x
 


### PR DESCRIPTION
I ran into this issue when trying to deploy:

https://askubuntu.com/questions/1428181/module-lib-has-no-attribute-x509-v-flag-cb-issuer-check

Therefore, I adjusted the script to update pyopenssl. On top of that, I was frustrated with the very slow testing cycle, since the script always creates a new environment from scratch. To accelerate this, I removed the reliance on the (outdated) `environment.yml` and used pip for the `requirements.txt`, which is faster and also more in line with our CI.

I tested this locally except for the last step (the upload) and it worked.