### PR TITLE
Fix FutureWarnings from numpy and torch

### DIFF
--- a/skorch/helper.py
+++ b/skorch/helper.py
@@ -242,7 +242,7 @@ class SliceDataset(Sequence):
                 raise IndexError("SliceDataset only supports slicing with 1 "
                                  "dimensional arrays, got {} dimensions instead."
                                  "".format(i.ndim))
-            if i.dtype == np.bool:
+            if i.dtype == bool:
                 i = np.flatnonzero(i)
 
         return cls(self.dataset, idx=self.idx, indices=self.indices_[i])

--- a/skorch/tests/test_helper.py
+++ b/skorch/tests/test_helper.py
@@ -389,7 +389,7 @@ class TestSliceDataset:
     @pytest.mark.parametrize('sl0, sl1, sl2', [
         (slice(0, 50), slice(10, 20), 5),
         ([0, 10, 3, -8, 3], [1, 2, 3], 2),
-        (np.ones(100, dtype=np.bool), np.arange(10, 40), 29),
+        (np.ones(100, dtype=bool), np.arange(10, 40), 29),
     ])
     def test_slice_three_times(self, slds_cls, custom_ds, X, y, sl0, sl1, sl2, n):
         data = y if n else X

--- a/skorch/tests/test_hf.py
+++ b/skorch/tests/test_hf.py
@@ -1050,7 +1050,7 @@ class TestHfHubStorage:
         for key, original in net_loaded.module_.state_dict().items():
             original = net.module_.state_dict()[key]
             loaded = net_loaded.module_.state_dict()[key]
-            torch.testing.assert_allclose(loaded, original)
+            torch.testing.assert_close(loaded, original)
 
     @pytest.mark.parametrize('storage', ['memory', 'str', 'path'])
     def test_saved_params_is_same(
@@ -1087,7 +1087,7 @@ class TestHfHubStorage:
         assert len(state_dict_before) == len(state_dict_after)
         for key, original in state_dict_before.items():
             loaded = state_dict_after[key]
-            torch.testing.assert_allclose(loaded, original)
+            torch.testing.assert_close(loaded, original)
 
     def test_latest_url_attribute(self, net, data, hf_hub_storer_cls):
         # Check that the URL returned by the HF API is stored as latest_url. In

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2293,11 +2293,13 @@ class TestNeuralNet:
         net.fit(X, y)
 
     def test_net_variable_label_lengths(self, net_cls, sequence_module_cls):
-        # neural net should work fine with varying y_true sequences.
+        # neural net should work fine with variable length y_true sequences.
         X = np.array([1, 5, 3, 6, 2])
-        y = np.array([[1], [1, 0, 1], [1, 1], [1, 1, 0], [1, 0]])
+        y = np.array([[1], [1, 0, 1], [1, 1], [1, 1, 0], [1, 0]], dtype=object)
         X = X[:, np.newaxis].astype('float32')
-        y = np.array([np.array(n, dtype='float32')[:, np.newaxis] for n in y])
+        y = np.array(
+            [np.array(n, dtype='float32')[:, np.newaxis] for n in y], dtype=object
+        )
 
         net = net_cls(
             sequence_module_cls,

--- a/skorch/tests/test_probabilistic.py
+++ b/skorch/tests/test_probabilistic.py
@@ -10,7 +10,6 @@ from sklearn.base import clone
 from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import Pipeline
 import torch
-from torch.testing import assert_allclose
 
 from skorch._version import Version
 from skorch.utils import is_torch_data_type
@@ -272,7 +271,7 @@ class BaseProbabilisticTests:
                 gp_fit.get_all_learnable_params(), gp2.get_all_learnable_params(),
         ):
             assert n0 == n1
-            assert_allclose(p0, p1)
+            torch.testing.assert_close(p0, p1)
 
     ##############
     # functional #


### PR DESCRIPTION
The following changes were made:

1. don't use `torch.testing.assert_allclose`, use `torch.testing.assert_close` instead
2. don't use `np.bool`, use `bool` instead
3. fix test that uses ragged numpy array

Regarding 2, `np.dtype('bool') == bool`, so replacing `np.bool` by `bool` should just work.

Regarding 3, numpy used to allow creation of ragged arrays, e.g. `np.array([[1], [2, 2], [3, 3, 3]])`

This does not work anymore with newer numpy versions (tested on 1.24.0rc2). To make it work, `dtype=object` has to be passed explicitly. This does not affect any skorch code directly, but it was necessary to fix a test.