### PR TITLE
Bugfix: tests that fail in sklearn 1.2

### DIFF
--- a/skorch/tests/test_cli.py
+++ b/skorch/tests/test_cli.py
@@ -278,7 +278,6 @@ class TestCli:
             '-- --help',
             '--fit_intercept',
             '--copy_X',
-            '--normalize',
         ]
         for snippet in expected_snippets:
             assert snippet in out
@@ -297,7 +296,6 @@ class TestCli:
             '<MinMaxScaler> options',
             '--features__scale__feature_range',
             '--clf__fit_intercept',
-            '--clf__normalize',
         ]
         for snippet in expected_snippets:
             assert snippet in out
@@ -372,7 +370,7 @@ class TestCli:
 
     def test_parse_args_sklearn_pipe_custom_defaults(self, parse_args, pipe_sklearn):
         defaults = {'features__scale__copy': 123, 'clf__fit_intercept': 456}
-        kwargs = {'features__scale__copy': 555, 'clf__normalize': 789}
+        kwargs = {'features__scale__copy': 555, 'clf__n_jobs': 5}
         parsed = parse_args(kwargs, defaults)
         pipe = parsed(pipe_sklearn)
         scaler = pipe.steps[0][1].transformer_list[0][1]
@@ -381,4 +379,4 @@ class TestCli:
         # cmd line args have precedence over defaults
         assert scaler.copy == 555
         assert clf.fit_intercept == 456
-        assert clf.normalize == 789
+        assert clf.n_jobs == 5


### PR DESCRIPTION
The reason is that the `normalize` parameter was removed from `LinearRegression`.