### PR TITLE
Bugfixes: Bugs stemming from the use of non-standard modules and criteria

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixes a couple of bugs related to using non-default modules and criteria (#???)
+
 ## [0.12.1] - 2022-11-18
 
 ### Changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixes a couple of bugs related to using non-default modules and criteria (#???)
+- Fixes a couple of bugs related to using non-default modules and criteria (#927)
 
 ## [0.12.1] - 2022-11-18
 

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -120,6 +120,8 @@ class NeuralNetClassifier(NeuralNet, ClassifierMixin):
 
     # pylint: disable=arguments-differ
     def get_loss(self, y_pred, y_true, *args, **kwargs):
+        # we can assume that the attribute criterion_ exists; if users define
+        # custom criteria, they have to override get_loss anyway
         if isinstance(self.criterion_, torch.nn.NLLLoss):
             eps = torch.finfo(y_pred.dtype).eps
             y_pred = torch.log(y_pred + eps)

--- a/skorch/helper.py
+++ b/skorch/helper.py
@@ -1,6 +1,7 @@
 """Helper functions and classes for users.
 
-They should not be used in skorch directly.
+They are intended to be used by end users but should not be depeneded upon for
+skorch-internal usage.
 
 """
 from collections.abc import Sequence
@@ -11,11 +12,20 @@ from sklearn.base import BaseEstimator
 from sklearn.base import TransformerMixin
 import torch
 
-from skorch.cli import parse_args  # pylint: disable=unused-import
+from skorch.cli import parse_args
 from skorch.utils import _make_split
 from skorch.utils import to_numpy
 from skorch.utils import is_torch_data_type
 from skorch.utils import to_tensor
+
+
+__all__ = [
+    "SliceDict",
+    "SliceDataset",
+    "DataFrameTransformer",
+    "predefined_split",
+    "parse_args",
+]
 
 
 class SliceDict(dict):

--- a/skorch/helper.py
+++ b/skorch/helper.py
@@ -1,6 +1,6 @@
 """Helper functions and classes for users.
 
-They are intended to be used by end users but should not be depeneded upon for
+They are intended to be used by end users but should not be depended upon for
 skorch-internal usage.
 
 """

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1248,7 +1248,12 @@ class NeuralNet:
           When the given attributes are not present.
 
         """
-        attributes = attributes or ['module_']
+        # first check attributes argument, but if it's empty, check that the
+        # indicated _modules exist, and if those are not defined, assume that
+        # the standard 'module_' attribute should exist
+        attributes = (
+            attributes or [module + '_' for module in self._modules] or ['module_']
+        )
         check_is_fitted(self, attributes, *args, **kwargs)
 
     def trim_for_prediction(self):

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2801,7 +2801,7 @@ class TestNeuralNet:
     def test_custom_non_default_module_with_check_is_fitted(
             self, net_cls, module_cls
     ):
-        # This is a regression test for a bug fixed in #???. In check_is_fitted
+        # This is a regression test for a bug fixed in #927. In check_is_fitted
         # we made the assumption that there is a 'module_' attribute, but we
         # should not assume that. Here we test that even if such an attribute
         # doesn't exist, a properly initialized net will not raise an error when
@@ -3162,7 +3162,7 @@ class TestNeuralNet:
     def test_custom_criterion_attribute_name_predict_works(
             self, net_cls, module_cls, data
     ):
-        # This is a regression test for bugfix in #???. We should not assume
+        # This is a regression test for bugfix in #927. We should not assume
         # that there is always an attribute called 'criterion_' when trying to
         # infer the predict nonlinearity.
         from skorch.utils import to_tensor
@@ -3633,7 +3633,7 @@ class TestNeuralNet:
     ):
         # Regression test for bugfix so we don't assume that there is always
         # just a single criterion when trying to infer the predict nonlinearity
-        # (#???). Instead, if there are multiple criteria, don't apply any
+        # (#927). Instead, if there are multiple criteria, don't apply any
         # predict nonlinearity. In this test, criterion_ is CrossEntropyLoss, so
         # normally we would apply softmax, but since there is a second criterion
         # here, we shouldn't. To test that the identity function is used, we

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2798,6 +2798,27 @@ class TestNeuralNet:
         assert net.optimizer_.state_dict()['param_groups'][0]['lr'] == 456
         assert net.myoptimizer_.state_dict()['param_groups'][0]['lr'] == 1
 
+    def test_custom_non_default_module_with_check_is_fitted(
+            self, net_cls, module_cls
+    ):
+        # This is a regression test for a bug fixed in #???. In check_is_fitted
+        # we made the assumption that there is a 'module_' attribute, but we
+        # should not assume that. Here we test that even if such an attribute
+        # doesn't exist, a properly initialized net will not raise an error when
+        # check_is_fitted is called.
+        class MyNet(net_cls):
+            """Net without a 'module_' attribute"""
+            def initialize_module(self):
+                kwargs = self.get_params_for('module')
+                module = self.initialized_instance(self.module, kwargs)
+                # pylint: disable=attribute-defined-outside-init
+                self.mymodule_ = module
+                return self
+
+        net = MyNet(module_cls).initialize()
+        # does not raise
+        net.check_is_fitted()
+
     def test_setattr_custom_module_no_duplicates(self, net_cls, module_cls):
         # the 'module' attribute is set twice but that shouldn't lead
         # to duplicates in prefixes_ or cuda_dependent_attributes_
@@ -3137,6 +3158,30 @@ class TestNeuralNet:
         ).initialize()
         assert net.criterion_ is criterion
         assert net.criterion2_ is not criterion2
+
+    def test_custom_criterion_attribute_name_predict_works(
+            self, net_cls, module_cls, data
+    ):
+        # This is a regression test for bugfix in #???. We should not assume
+        # that there is always an attribute called 'criterion_' when trying to
+        # infer the predict nonlinearity.
+        from skorch.utils import to_tensor
+
+        class MyNet(net_cls):
+            def initialize_criterion(self):
+                kwargs = self.get_params_for('criterion')
+                criterion = self.initialized_instance(self.criterion, kwargs)
+                # pylint: disable=attribute-defined-outside-init
+                self.mycriterion_ = criterion  # non-default name
+
+            def get_loss(self, y_pred, y_true, *args, **kwargs):
+                y_true = to_tensor(y_true, device=self.device)
+                return self.mycriterion_(y_pred, y_true)
+
+        net = MyNet(module_cls).initialize()
+        X, y = data[0][:10], data[1][:10]
+        net.fit(X, y)
+        net.predict(X)
 
     def test_custom_module_is_init_when_default_module_already_is(
             self, net_cls, module_cls,
@@ -3582,6 +3627,45 @@ class TestNeuralNet:
 
         with pytest.raises(TypeError, match=msg):
             net.predict_proba(np.zeros((3, 3)))
+
+    def test_predict_nonlinearity_is_identity_with_multiple_criteria(
+            self, net_cls, module_cls, data
+    ):
+        # Regression test for bugfix so we don't assume that there is always
+        # just a single criterion when trying to infer the predict nonlinearity
+        # (#???). Instead, if there are multiple criteria, don't apply any
+        # predict nonlinearity. In this test, criterion_ is CrossEntropyLoss, so
+        # normally we would apply softmax, but since there is a second criterion
+        # here, we shouldn't. To test that the identity function is used, we
+        # check that predict_proba and forward return the same values.
+        from skorch.utils import to_numpy, to_tensor
+
+        class MyNet(net_cls):
+            def initialize_criterion(self):
+                # pylint: disable=attribute-defined-outside-init
+                kwargs = self.get_params_for('criterion')
+                criterion = self.initialized_instance(nn.CrossEntropyLoss, kwargs)
+                self.criterion_ = criterion  # non-default name
+
+                kwargs = self.get_params_for('criterion2')
+                criterion2 = self.initialized_instance(nn.NLLLoss, kwargs)
+                self.criterion2_ = criterion2
+
+            def get_loss(self, y_pred, y_true, *args, **kwargs):
+                y_true = to_tensor(y_true, device=self.device)
+                loss = self.criterion_(y_pred, y_true)
+                loss2 = self.criterion2_(y_pred, y_true)
+                return loss + loss2
+
+        net = MyNet(module_cls).initialize()
+        X, y = data[0][:10], data[1][:10]
+        net.fit(X, y)
+
+        # test that predict_proba and forward return the same values, hence no
+        # nonlinearity was applied
+        y_proba = net.predict_proba(X)
+        y_forward = to_numpy(net.forward(X))
+        assert np.allclose(y_proba, y_forward)
 
     def test_customize_net_with_custom_dataset_that_returns_3_values(self, data):
         # Test if it's possible to easily customize NeuralNet to work

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -646,7 +646,11 @@ def _infer_predict_nonlinearity(net):
     # based on the criterion, not the class of the net. We still pass
     # the whole net as input in case we want to modify this at a
     # future point in time.
-    criterion = net.criterion_
+    if len(net._criteria) != 1:
+        # don't know which criterion to consider, don't try to guess
+        return _identity
+
+    criterion = getattr(net, net._criteria[0] + '_')
 
     if isinstance(criterion, CrossEntropyLoss):
         return partial(torch.softmax, dim=-1)


### PR DESCRIPTION
These bugfixes were originally provided in #912 but are now moved to their own PR.

1. Inferring the predict nonlinearity made the assumption that a `net.criterion_` exists. However, this might not always be the case. Now, this function works even if the criterion attribute has a different name. Moreover, when more than one criterion is defined, the identity function will be returned.
2. The second bug is that in `check_is_fitted`, we made the check dependent on the `module_` attribute. Again, we should not assume that it always exists, as users may define different names. Now, those custom names will be checked, and only if those don't exist is it assumed that the `module_` attribute should exist.
3. The `helper.py` module now defines an `__all__` attribute. This seems to be necessary for sphinx to build documentation for objects that are imported to, but not defined in, `helper.py`. Specifically, this is the case for the `parse_args` CLI feature.
4. Fixed a small bug in `on_grad_computed`, which has `training=False` as default argument but during training, it should be set to `True`. Thankfully, it had no consequences in our code since it's only used by `GradientNormClipping`, which doesn't check that argument.