### PR TITLE
Add option to keep the dictionary/SliceDict input packed and skip `_merge_x_and_fit_params` call

### DIFF
--- a/skorch/net.py
+++ b/skorch/net.py
@@ -283,6 +283,7 @@ class NeuralNet:
             warm_start=False,
             verbose=1,
             device='cpu',
+            unpack_dict_input=True,
             **kwargs
     ):
         self.module = module
@@ -300,6 +301,7 @@ class NeuralNet:
         self.warm_start = warm_start
         self.verbose = verbose
         self.device = device
+        self.unpack_dict_input = unpack_dict_input
 
         self._check_deprecated_params(**kwargs)
         history = kwargs.pop('history', None)
@@ -1426,7 +1428,7 @@ class NeuralNet:
 
         """
         x = to_tensor(x, device=self.device)
-        if isinstance(x, Mapping):
+        if isinstance(x, Mapping) and self.unpack_dict_input:
             x_dict = self._merge_x_and_fit_params(x, fit_params)
             return self.module_(**x_dict)
         return self.module_(x, **fit_params)


### PR DESCRIPTION
First things first, thanks for building this awesome open-source library. It's really great.

I'm creating this untested pull request as a suggestion to implement a new feature:

Give the user the option to NOT unpack input variables that are dictionaries. I would actually argue that dictionary should never be unpacked by skorch. If someone uses a dict like structure to store the data, they probably want to keep it like that.

In some situations, it is convenient to be able to pass a dictionary/SliceDict as an argument to the `forward()` call of the pytorch Module. Below I created a minimal example, which shows the issue.
The expected behavior with dict/SliceDict was explained here https://github.com/skorch-dev/skorch/issues/672.

Minimal example:

```
import torch
from torch import nn
from skorch.helper import SliceDict
from skorch import NeuralNetRegressor

vocab_sizes = {
    "user_id": 1_000,
    "user_gender": 7,
    "user_country": 200,
    "item_id": 5_000,
    "item_category": 150,
}


class SomeModule(nn.Module):
    def __init__(self, embedding_dim, vocab_sizes):
        super().__init__()
        self.embedding_dim = embedding_dim
        self.vocab_sizes = vocab_sizes
        self.embeddings = nn.ModuleDict()
        # embedding inputs
        for name, vocab_size in self.vocab_sizes.items():
            self.embeddings[name] = nn.Embedding(
                vocab_size, embedding_dim, sparse=False
            )

    def forward(self, input_dict):
        x_embed_inputs = dict()
        for name in self.vocab_sizes.keys():
            x_embed_inputs[name] = torch.squeeze(
                self.embeddings[name](input_dict[name]), dim=1
            )
        x_embed_user = torch.sum(
            torch.stack(
                [
                    x_embed_inputs[name]
                    for name in self.vocab_sizes.keys()
                    if name.startswith("user_")
                ]
            ),
            dim=0,
        )
        x_embed_item = torch.sum(
            torch.stack(
                [
                    x_embed_inputs[name]
                    for name in self.vocab_sizes.keys()
                    if name.startswith("item_")
                ]
            ),
            dim=0,
        )
        dot = torch.mul(x_embed_user, x_embed_item).sum(dim=1)
        return dot


if __name__ == "__main__":
    embedding_dim = 3
    n_samples = 1_000
    input_dict = SliceDict(
        **{
            name: torch.randint(vocab_size, (n_samples, 1))
            for name, vocab_size in vocab_sizes.items()
        }
    )
    print(input_dict)
    y = torch.rand(1_000, 1)
    module = SomeModule(embedding_dim=embedding_dim, vocab_sizes=vocab_sizes)
    out = module(input_dict)
    print(out.shape)

    net = NeuralNetRegressor(
        module=SomeModule(embedding_dim=embedding_dim, vocab_sizes=vocab_sizes),
        criterion=torch.nn.MSELoss(),
        lr=0.01,
    )
    net.fit(input_dict, y)
```

In this case, I really want to flexibly add and remove some of the inputs from `vocab_sizes`: some columns might be one-hot-encoded instead of passed to an embedding layer etc... (Outside of this toy example, `vocab_sizes` would not be hardcoded but computed from a training set).

The reason why this cannot work with the current implementation is because the dictionary (or any Mapping type input) is always unpacked when passed to the `infer()` method.

A quick way to go around this would be to make the unpacking of the dictionary optional the way I implemented it in this PR. 
I'm not sure that's the best way but happy to try to help if the team thinks this would be a good feature to add.
