### PR TITLE
Add PyTorch v2.0.0 to CI, update docs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,13 +17,8 @@ jobs:
       fail-fast: false  # don't cancel all jobs when one fails
       matrix:
         python_version: ['3.7', '3.8', '3.9', '3.10']
-        torch_version: ['1.10.2+cpu', '1.11.0+cpu', '1.12.1+cpu', '1.13.0+cpu']
+        torch_version: ['1.11.0+cpu', '1.12.1+cpu', '1.13.1+cpu', '2.0.0+cpu']
         os: [ubuntu-latest]
-        exclude:
-          - python_version: '3.10'
-            torch_version: '1.9.1+cpu'
-          - python_version: '3.10'
-            torch_version: '1.10.2+cpu'
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -244,10 +244,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.10.2
 - 1.11.0
 - 1.12.1
-- 1.13.0
+- 1.13.1
+- 2.0.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -98,10 +98,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.10.2
 - 1.11.0
 - 1.12.1
-- 1.13.0
+- 1.13.1
+- 2.0.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of


### PR DESCRIPTION
Also, use PyTorch 1.13.1 instead of 1.13.0 and drop 1.10.

Locally, this worked with Python 3.10.