### PR TITLE
Add DistributedHistory for multi-gpu training

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,12 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for compiled PyTorch modules using the `torch.compile` function, introduced in [PyTorch 2.0 release](https://pytorch.org/get-started/pytorch-2.0/), which can greatly improve performance on new GPU architectures; to use it, initialize your net with the `compile=True` argument, further compilation arguments can be specified using the dunder notation, e.g. `compile__dynamic=True`
+- Add a class [`DistributedHistory`](https://skorch.readthedocs.io/en/latest/history.html#skorch.history.DistributedHistory) which should be used when training in a multi GPU setting (#955)
 
 ### Changed
 
 ### Fixed
 - Fixed install command to work with recent changes in Google Colab. (#928)
-
 - Fixes a couple of bugs related to using non-default modules and criteria (#927)
 
 ## [0.12.1] - 2022-11-18

--- a/docs/user/history.rst
+++ b/docs/user/history.rst
@@ -84,3 +84,68 @@ current epoch. To write a value to the current batch, use
     history.record_batch('my-batch-score', 456)
     # overwrite entry of current batch
     history.record_batch('my-batch-score', 789)
+
+Distributed history
+-------------------
+
+When training a net in a distributed setting, e.g. when using
+:class:`torch.nn.parallel.DistributedDataParallel`, directly or indirectly with
+the help of :class:`.AccelerateMixin`, the default history class should not be
+used. This is because each process will have its own history instance with no
+syncing happening between processes. Therefore, the information in the histories
+can diverge. When steering the training process through the histories, the
+resulting differences can cause trouble. When using early stopping, for
+instance, one process could receive the signal to stop but not the other.
+
+To avoid this, use the :class:`.DistributedHistory` class provided by skorch. It
+will take care of syncing the distributed batch information across processes,
+which will prevent the issue just described.
+
+This class needs to be initialized with a `distributed store provided by PyTorch
+<https://pytorch.org/docs/stable/distributed.html#distributed-key-value-store>`_.
+We have only tested :class:`torch.distributed.TCPStore` so far, so if unsure,
+use that one, though :class:`torch.distributed.FileStore` should also work. The
+:class:`.DistributedHistory` also needs to be initialized with its rank and the
+world size (number of processes) so that it has all the required information to
+perform the syncing. When using ``accelerate``, that information can be
+retrieved from the ``Accelerator`` instance.
+
+A typical training script without ``accelerate`` may contain a function like
+this:
+
+.. code:: python
+
+    from torch.distributed import TCPStore
+    from torch.nn.parallel import DistributedDataParallel
+
+    def train(rank, world_size, is_master):
+        store = TCPStore(
+            "127.0.0.1", port=1234, world_size=world_size)
+        dist_history = DistributedHistory(
+            store=store, rank=rank, world_size=world_size)
+        net = NeuralNetClassifier(..., history=dist_history)
+        net.fit(X, y)
+
+When using :class:`.AccelerateMixin`, it could look like this instead:
+
+.. code:: python
+
+    from accelerate import Accelerator
+    from skorch.hf import AccelerateMixin
+
+    accelerator = Accelerator(...)
+
+    def train(accelerator):
+        is_master = accelerator.is_main_process
+        world_size = accelerator.num_processes
+        rank = accelerator.process_index
+        store = TCPStore(
+            "127.0.0.1", port=1234, world_size=world_size, is_master=is_master)
+        dist_history = DistributedHistory(
+            store=store, rank=rank, world_size=world_size)
+        net = AcceleratedNet(..., history=dist_history)
+        net.fit(X, y)
+
+When using ``accelerate`` in a non-distributed setting (e.g. to take advantage
+of mixed precision training), it is not necessary to use
+:class:`.DistributedHistory`, the normal history class will do.

--- a/docs/user/history.rst
+++ b/docs/user/history.rst
@@ -138,7 +138,7 @@ When using :class:`.AccelerateMixin`, it could look like this instead:
     def train(accelerator):
         is_master = accelerator.is_main_process
         world_size = accelerator.num_processes
-        rank = accelerator.process_index
+        rank = accelerator.local_process_index
         store = TCPStore(
             "127.0.0.1", port=1234, world_size=world_size, is_master=is_master)
         dist_history = DistributedHistory(

--- a/skorch/history.py
+++ b/skorch/history.py
@@ -371,7 +371,7 @@ class DistributedHistory:
     >>> def train(accelerator):
     ...     is_master = accelerator.is_main_process
     ...     world_size = accelerator.num_processes
-    ...     rank = accelerator.process_index
+    ...     rank = accelerator.local_process_index
     ...     store = TCPStore(
     ...         "127.0.0.1", port=1234, world_size=world_size, is_master=is_master)
     ...     dist_history = DistributedHistory(

--- a/skorch/history.py
+++ b/skorch/history.py
@@ -1,6 +1,7 @@
 """Contains history class and helper functions."""
 
 import json
+import pickle
 
 from skorch.utils import open_file_like
 
@@ -301,3 +302,225 @@ class History(list):
             items, = items
 
         return items
+
+
+class DistributedHistory:
+    """History for use in training using multiple processes
+
+    When using skorch with :class:`.AccelerateMixin` for multi GPU training, use
+    this class instead of the default :class:`.History` class.
+
+    When using PyTorch :class:`torch.nn.parallel.DistributedDataParallel`, the
+    whole training process is forked and batches are processed in parallel. That
+    means that the standard :class:`.History` does not see all the batches that
+    are being processed, which results in the different processes having
+    histories that are out of sync. This is bad because the history is used as a
+    reference to influence the training, e.g. to control early stopping.
+
+    This class solves the problem by using a distributed store from PyTorch,
+    e.g. :class:`torch.distributed.TCPStore`, to synchronize the batch
+    information across processes. This ensures that the information stored in
+    the individual history copies is identical for ``history[:, 'batches']``.
+    When it comes to the epoch-level information, it can still diverge between
+    processes (e.g. the recorded duration of the epoch).
+
+    To use this class, instantiate it and pass it as the ``history`` argument to
+    the net.
+
+    Click here for more information on `PyTorch distributed key-value stores
+    <https://pytorch.org/docs/stable/distributed.html#distributed-key-value-store>`_.
+
+    Notes
+    -----
+    If using this class results in the processes hanging or timing out, double
+    check that the ``rank`` and ``world_size`` arguments are set correctly.
+    Otherwise, the history instances will be waiting for records that are
+    actually never written.
+
+    If the speed of the processes is very uneven, there can also be timeouts. To
+    increase the waiting time, pass a corresponding ``timeout`` argument to the
+    ``store`` instance.
+
+    Objects stored with this history make a json roundtrip. Therefore, if you
+    store objects that don't survive a json roundtrip (say, numpy arrays), don't
+    use this class.
+
+    The PyTorch ``Store`` classes cannot be pickled. Therefore, if a net using
+    this history class is pickled, the ``store`` attribute is discarded so that
+    the pickling does not fail. This means, however, that an unpickled net
+    cannot be used for further training without manually setting the ``store``
+    attribute on the ``history``.
+
+    Examples
+    --------
+    >>> # general
+    >>> from skorch import NeuralNetClassifier
+    >>> from torch.distributed import TCPStore
+    >>> from torch.nn.parallel import DistributedDataParallel
+    >>> def train(rank, world_size, is_master):
+    ...     store = TCPStore(
+    ...         "127.0.0.1", port=1234, world_size=world_size)
+    ...     dist_history = DistributedHistory(
+    ...         store=store, rank=rank, world_size=world_size)
+    ...     net = NeuralNetClassifier(..., history=dist_history)
+    ...     net.fit(X, y)
+    >>> # with accelerate
+    >>> from accelerate import Accelerator
+    >>> from skorch.hf import AccelerateMixin
+    >>> accelerator = Accelerator(...)
+    >>> def train(accelerator):
+    ...     is_master = accelerator.is_main_process
+    ...     world_size = accelerator.num_processes
+    ...     rank = accelerator.process_index
+    ...     store = TCPStore(
+    ...         "127.0.0.1", port=1234, world_size=world_size, is_master=is_master)
+    ...     dist_history = DistributedHistory(
+    ...         store=store, rank=rank, world_size=world_size)
+    ...     net = AcceleratedNet(..., history=dist_history)
+    ...     net.fit(X, y)
+
+    Parameters
+    ----------
+    store : torch.distributed.Store
+      The torch distributed ``Store`` instance,
+      :class:`torch.distributed.TCPStore` has been tested to work.
+
+    rank : int
+      The rank of this process.
+
+    world_size : int
+      The number of processes in the training.
+
+    Attributes
+    ----------
+    history : skorch.history.History
+      The actual skorch ``History`` object can be accessed using the
+      :class:`.History` attribute. You should call ``net.history.sync()`` to
+      ensure that all data is synced into the history before reading from it.
+
+    """
+    def __init__(self, *args, store, rank, world_size):
+        self.store = store
+        self.rank = rank
+        self.world_size = world_size
+
+        self._history = History(*args)
+        self._cur_batch = 0
+        self._sync_queue = []
+
+    @property
+    def history(self):
+        self.sync()
+        return self._history
+
+    def to_list(self):
+        return self.history.to_list()
+
+    @classmethod
+    def from_file(cls, f):
+        raise NotImplementedError
+
+    def to_file(self, f):
+        return self.history.to_file(f)
+
+    def __len__(self):
+        return len(self.history)
+
+    def __delitem__(self, i):
+        raise NotImplementedError
+
+    def new_epoch(self):
+        self.sync()
+        self._history.new_epoch()
+        self._cur_batch = 0
+
+    def new_batch(self):
+        self.sync()
+        self._history.new_batch()
+        self._cur_batch += 1
+
+    def record(self, attr, value):
+        self._history.record(attr, value)
+
+    def record_batch(self, attr, value):
+        """Add a new value to the given column for the current
+        batch.
+
+        Instead of writing to the history directly, write to the distributed
+        store. Then, once the history is being read from, the values from the
+        store are synchronized.
+
+        This class "remembers" which values were written to the store by
+        creating a key that uniquely identifies the values. Choosing a correct
+        key is crucial here, since it must not only be unique (say, a uuid), but
+        also sufficient to replay the history so that they can be recorded
+        correctly.
+
+        When the structure of the key is changed, it must be changed accordingly
+        inside of the sync method.
+
+        """
+        rank = self.rank
+        batch = self._cur_batch
+        epoch = len(self._history)
+        key = [epoch, batch, rank, attr]
+        self.store.set(json.dumps(key), json.dumps(value))
+
+        # the queue not only stores the keys for this process, but the keys for
+        # all processes
+        for rank in range(self.world_size):
+            key = [epoch, batch, rank, attr]
+            self._sync_queue.append(key)
+
+    def __getitem__(self, i):
+        self.sync()
+        return self._history[i]
+
+    def sync(self):
+        """Collect batch records across all ranks from store and write them to
+        the history
+
+        Syncing is not a single atomic operation, if something breaks the flow,
+        we can end up with an inconsistent state.
+
+        """
+        if not self._sync_queue:
+            return
+
+        # this ensures that that the values are visited in a stable order
+        # grouped by batches: order by batch count and within the batches in the
+        # order of the rank and within the ranks in the alphabetical order of
+        # the attributes
+        keys_sorted = sorted(self._sync_queue)
+        keys_json = [json.dumps(key) for key in keys_sorted]
+        self.store.wait(keys_json)
+
+        batch_prev = None
+        rank_prev = None
+
+        for (_, batch, rank, attr), key_json in zip(keys_sorted, keys_json):
+            if batch_prev is None:
+                batch_prev = batch
+            if rank_prev is None:
+                rank_prev = rank
+
+            # each time the batch counter or rank changes, it means that the
+            # next batch needs to be started
+            if (batch != batch_prev) or (rank != rank_prev):
+                self._history.new_batch()
+                batch_prev = batch
+                rank_prev = rank
+
+            val = json.loads(self.store.get(key_json))
+            self._history.record_batch(attr, val)
+
+        self._sync_queue.clear()
+
+    def __getstate__(self):
+        # unfortunately, TCPStore is not pickleable
+        state = self.__dict__.copy()
+        try:
+            pickle.dumps(state['store'])
+        except TypeError:
+            state['store'] = None
+        return state

--- a/skorch/history.py
+++ b/skorch/history.py
@@ -429,6 +429,9 @@ class DistributedHistory:
     def __delitem__(self, i):
         raise NotImplementedError
 
+    def clear(self):
+        self.history.clear()
+
     def new_epoch(self):
         self.sync()
         self._history.new_epoch()

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -628,6 +628,8 @@ class NeuralNet:
         """Initializes the history."""
         if self.history_ is None:
             self.history_ = History()
+        else:
+            self.history_.clear()
         return self
 
     def _format_reinit_msg(self, name, kwargs=None, triggered_directly=True):

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -626,7 +626,8 @@ class NeuralNet:
 
     def initialize_history(self):
         """Initializes the history."""
-        self.history_ = History()
+        if self.history_ is None:
+            self.history_ = History()
         return self
 
     def _format_reinit_msg(self, name, kwargs=None, triggered_directly=True):

--- a/skorch/tests/test_history.py
+++ b/skorch/tests/test_history.py
@@ -432,6 +432,14 @@ class TestDistributedHistoryMultiprocessing:
         from skorch.toy import make_classifier
         from skorch._version import Version
 
+        # TODO: remove this once PyTorch 1.11 is no longer supported
+        version_torch = Version(torch.__version__)
+        if version_torch < Version('1.12.0'):
+            # This test is flaky with PyTorch 1.11 and when using pytest on CI.
+            # Running directly, i.e. without pytest, does not appear to cause
+            # issues.
+            pytest.skip(msg="Skipping multiprocessing for PyTorch < 1.12")
+
         X, y = make_classification(
             500, 20, n_informative=10, random_state=0, flip_y=0.1
         )

--- a/skorch/tests/test_history.py
+++ b/skorch/tests/test_history.py
@@ -430,6 +430,14 @@ class TestDistributedHistoryMultiprocessing:
     @pytest.mark.parametrize('nprocs', [1, 2, 3, 4])
     def test_distributed_history(self, nprocs):
         from skorch.toy import make_classifier
+        from skorch._version import Version
+
+        # TODO: remove this once PyTorch 1.11 is no longer supported
+        version_torch = Version(torch.__version__)
+        if version_torch < Version('1.12.0'):
+            # This test fails with 'Segmentation fault (core dumped)' using
+            # PyTorch 1.11 and pytest on CI
+            pytest.skip(msg="Skipping for PyTorch < 1.12")
 
         X, y = make_classification(
             500, 20, n_informative=10, random_state=0, flip_y=0.1

--- a/skorch/tests/test_history.py
+++ b/skorch/tests/test_history.py
@@ -1,9 +1,15 @@
 """Tests for history.py."""
 
+import pickle
+import time
+from functools import partial
+from multiprocessing import Pool
+
 import numpy as np
 import pytest
-
-from skorch.history import History
+import torch
+from torch.distributed import TCPStore
+from sklearn.datasets import make_classification
 
 
 class TestHistory:
@@ -11,10 +17,28 @@ class TestHistory:
     test_epochs = 3
     test_batches = 4
 
+    @pytest.fixture(scope='class', params=['single', 'distributed'])
+    def history_cls(self, request):
+        # run tests once with default History, once with DistributedHistory
+        from skorch.history import DistributedHistory, History
+
+        if request.param == 'single':
+            return History
+
+        if request.param == 'distributed':
+            from torch.distributed import TCPStore
+
+            store = TCPStore("127.0.0.1", port=1234, world_size=1, is_master=True)
+            return partial(
+                DistributedHistory, store=store, rank=0, world_size=1
+            )
+
+        raise ValueError("Incorrect pytest request parameter '{request.param}'")
+
     @pytest.fixture
-    def history(self):
+    def history(self, history_cls):
         """Return a history filled with epoch and batch data."""
-        h = History()
+        h = history_cls()
         for num_epoch in range(self.test_epochs):
             h.new_epoch()
             h.record('duration', 1)
@@ -32,8 +56,8 @@ class TestHistory:
     def ref(self, history):
         return history.to_list()
 
-    def test_list_initialization(self):
-        h = History([1, 2, 3])
+    def test_list_initialization(self, history_cls):
+        h = history_cls([1, 2, 3])
         assert len(h) == 3
 
     def test_history_length(self, history):
@@ -200,22 +224,30 @@ class TestHistory:
                     "4 indices are possible.")
         assert msg == expected
 
-    def test_history_save_load_cycle_file_obj(self, history, tmpdir):
+    def test_history_save_load_cycle_file_obj(self, history_cls, history, tmpdir):
+        if hasattr(history, 'store'):
+            # DistributedHistory does not support loading from file
+            pytest.skip()
+
         history_f = tmpdir.mkdir('skorch').join('history.json')
 
         with open(str(history_f), 'w') as f:
             history.to_file(f)
 
         with open(str(history_f), 'r') as f:
-            new_history = History.from_file(f)
+            new_history = history_cls.from_file(f)
 
         assert history == new_history
 
-    def test_history_save_load_cycle_file_path(self, history, tmpdir):
+    def test_history_save_load_cycle_file_path(self, history_cls, history, tmpdir):
+        if hasattr(history, 'store'):
+            # DistributedHistory does not support loading from file
+            pytest.skip()
+
         history_f = tmpdir.mkdir('skorch').join('history.json')
 
         history.to_file(str(history_f))
-        new_history = History.from_file(str(history_f))
+        new_history = history_cls.from_file(str(history_f))
 
         assert history == new_history
 
@@ -229,8 +261,8 @@ class TestHistory:
         # pylint: disable=unidiomatic-typecheck
         assert type(loss_loss) is type_ and len(loss_loss) == 2
 
-    def test_history_key_in_other_epoch(self):
-        h = History()
+    def test_history_key_in_other_epoch(self, history_cls):
+        h = history_cls()
         for has_valid in (True, False):
             h.new_epoch()
             h.new_batch()
@@ -243,14 +275,14 @@ class TestHistory:
             # pylint: disable=pointless-statement
             h[-1, 'batches', -1, 'valid_loss']
 
-    def test_history_no_epochs_index(self):
-        h = History()
+    def test_history_no_epochs_index(self, history_cls):
+        h = history_cls()
         with pytest.raises(IndexError):
             # pylint: disable=pointless-statement
             h[-1, 'batches']
 
-    def test_history_jagged_batches(self):
-        h = History()
+    def test_history_jagged_batches(self, history_cls):
+        h = history_cls()
         for num_batch in (1, 2):
             h.new_epoch()
             for _ in range(num_batch):
@@ -262,16 +294,23 @@ class TestHistory:
         ([], False),
         (np.array([]), True),
     ])
-    def test_history_retrieve_empty_list(self, value, check_warn, recwarn):
-        h = History()
+    def test_history_retrieve_empty_list(self, value, history_cls, check_warn, recwarn):
+        h = history_cls()
+        if hasattr(h, 'store') and isinstance(value, np.ndarray):
+            # DistributedHistory does not support numpy arrays because they
+            # cannot be json serialized
+            pytest.skip()
+
         h.new_epoch()
         h.record('foo', value)
         h.new_batch()
         h.record_batch('batch_foo', value)
 
         # Make sure we can access our object
-        assert h[-1, 'foo'] is value
-        assert h[-1, 'batches', -1, 'batch_foo'] is value
+        out = h[-1, 'foo']
+        assert (out is value) or (out == value)
+        out = h[-1, 'batches', -1, 'batch_foo']
+        assert (out is value) or (out == value)
 
         # There should be no warning about comparison to an empty ndarray
         if check_warn:
@@ -281,8 +320,8 @@ class TestHistory:
         (False, slice(None)),
         (True, slice(1, None)),
     ])
-    def test_history_no_epochs_key(self, has_epoch, epoch_slice):
-        h = History()
+    def test_history_no_epochs_key(self, has_epoch, epoch_slice, history_cls):
+        h = history_cls()
         if has_epoch:
             h.new_epoch()
 
@@ -298,8 +337,8 @@ class TestHistory:
         (False, slice(None)),
         (True, slice(1, None)),
     ])
-    def test_history_no_batches_key(self, has_batch, batch_slice):
-        h = History()
+    def test_history_no_batches_key(self, has_batch, batch_slice, history_cls):
+        h = history_cls()
         h.new_epoch()
         if has_batch:
             h.new_batch()
@@ -316,11 +355,125 @@ class TestHistory:
         (False, slice(None)),
         (True, slice(1, None)),
     ])
-    def test_history_no_epochs_batches(self, has_epoch, epoch_slice):
-        h = History()
+    def test_history_no_epochs_batches(self, has_epoch, epoch_slice, history_cls):
+        h = history_cls()
         if has_epoch:
             h.new_epoch()
 
         # Expect a list of zero epochs since 'batches' always exists
         assert h[epoch_slice, 'batches'] == []
         assert h[epoch_slice, 'batches', -1] == []
+
+    def test_pickle(self, history):
+        loaded = pickle.loads(pickle.dumps(history))
+
+        # The store cannot be pickled, so it is set to None
+        if not hasattr(history, 'store'):
+            assert history.to_list() == loaded.to_list()
+        else:
+            assert loaded.store is None
+
+
+class TestDistributedHistoryMultiprocessing:
+    """Testing DistributedHistory with multiprocessing
+
+    This is not a proper test for how DistributedHistory should be used in the
+    wild, which would be in a multi-GPU setting using DDP (possibly through
+    accelerate). However, since we cannot test this setting in CI, this is the
+    next best approximation.
+
+    Since DDP creates forks of the main process, each one would have its own
+    history instance, leading in them diverging. This can be bad, e.g. if the
+    history is used to steer the training (think early stopping). This test
+    intends to show that the histories do not diverge.
+
+    In a sense, this test actually tests incorrect behavior because the
+    different processes all write the exact same content to the history.
+    However, if DDP was used, each process would see different batches and thus
+    write different records to their histories. So when reading this test,
+    imagine that this would be what's truly happening.
+
+    This test is very high level, unlike TestHistory. For instance, there is no
+    attempt at testing "weird" read and write patterns, like creating multiple
+    empty batches. It is very much assumed that the history is used "correctly",
+    as in a normal skorch fit loop.
+
+    """
+    @pytest.fixture
+    def data(self, classifier_data):
+        X, y = classifier_data
+        return X[:100], y[:100]
+
+    @staticmethod
+    def train(args):
+        from skorch import NeuralNetClassifier
+        from skorch.history import DistributedHistory
+
+        time.sleep(0.5)  # wait a bit, else broken pipe error may occur
+
+        torch.manual_seed(0)
+        rank, nprocs, module, (X, y) = args
+
+        # let's hope the port is free
+        store = TCPStore(
+            '127.0.0.1', 8890 + nprocs, world_size=nprocs, is_master=(rank == 0)
+        )
+        dist_history = DistributedHistory(store=store, rank=rank, world_size=nprocs)
+        net = NeuralNetClassifier(module, max_epochs=2, history=dist_history)
+        net.history = dist_history
+        net.fit(X, y)
+
+        time.sleep(0.5)  # wait a bit, else broken pipe error may occur
+
+        return net
+
+    @pytest.mark.parametrize('nprocs', [1, 2, 3, 4])
+    def test_distributed_history(self, nprocs):
+        from skorch.toy import make_classifier
+
+        X, y = make_classification(
+            500, 20, n_informative=10, random_state=0, flip_y=0.1
+        )
+        X = X.astype(np.float32)
+        y = y.astype(np.int64)
+
+        torch.set_num_threads(1)
+        module = make_classifier(
+            input_units=20,
+            hidden_units=10,
+            num_hidden=2,
+            dropout=0.5,
+        )
+
+        args = zip(range(nprocs), [nprocs] * nprocs, [module] * nprocs, [(X, y)] * nprocs)
+        with Pool(nprocs) as pool:
+            nets = pool.map(self.train, args)
+
+        # expected entries for training batches:
+        # - 500 samples, 400 used for train, 100 for valid
+        # - batch size is 128, i.e. 4 batches per epoch for train
+        # - the 100 valid samples fit into 1 batch
+        # note that when using DDP correctly, since batches are split across the
+        # processes, there would *not* be nprocs times more entries.
+        train_batches = 4
+        valid_batches = 1
+        for net in nets:
+            h = net.history
+            assert len(h[0, 'batches', :, 'train_loss']) == train_batches * nprocs
+            assert len(h[1, 'batches', :, 'train_loss']) == train_batches * nprocs
+            assert len(h[0, 'batches', :, 'valid_loss']) == valid_batches * nprocs
+            assert len(h[1, 'batches', :, 'valid_loss']) == valid_batches * nprocs
+
+        # the batch information is synchronized, so should be identical; the
+        # epoch information is *not* synchronized and can diverge, most notably
+        # with things like the duration
+        for net0, net1 in zip(nets, nets[1:]):
+            train_loss0 = net0.history[:, 'batches', :, 'train_loss']
+            train_loss1 = net1.history[:, 'batches', :, 'train_loss']
+            assert train_loss0 == train_loss1
+
+            valid_loss0 = net0.history[:, 'batches', :, 'valid_loss']
+            valid_loss1 = net1.history[:, 'batches', :, 'valid_loss']
+            assert valid_loss0 == valid_loss1
+
+            assert net0.history[:, 'dur'] != net1.history[:, 'dur']

--- a/skorch/tests/test_history.py
+++ b/skorch/tests/test_history.py
@@ -21,12 +21,19 @@ class TestHistory:
     def history_cls(self, request):
         # run tests once with default History, once with DistributedHistory
         from skorch.history import DistributedHistory, History
+        from skorch._version import Version
 
         if request.param == 'single':
             return History
 
         if request.param == 'distributed':
-            from torch.distributed import TCPStore
+            # TODO: remove this once PyTorch 1.11 is no longer supported
+            version_torch = Version(torch.__version__)
+            if version_torch < Version('1.12.0'):
+                # Tests with DistributedHistory are flaky with PyTorch 1.11 and when
+                # using pytest on CI. Running directly, i.e. without pytest, does
+                # not appear to cause issues.
+                pytest.skip(msg="Skipping multiprocessing for PyTorch < 1.12")
 
             store = TCPStore("127.0.0.1", port=1234, world_size=1, is_master=True)
             return partial(
@@ -435,9 +442,9 @@ class TestDistributedHistoryMultiprocessing:
         # TODO: remove this once PyTorch 1.11 is no longer supported
         version_torch = Version(torch.__version__)
         if version_torch < Version('1.12.0'):
-            # This test is flaky with PyTorch 1.11 and when using pytest on CI.
-            # Running directly, i.e. without pytest, does not appear to cause
-            # issues.
+            # Tests with DistributedHistory are flaky with PyTorch 1.11 and when
+            # using pytest on CI. Running directly, i.e. without pytest, does
+            # not appear to cause issues.
             pytest.skip(msg="Skipping multiprocessing for PyTorch < 1.12")
 
         X, y = make_classification(

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -1068,6 +1068,25 @@ class TestNeuralNet:
     def test_history_is_filled(self, net_fit):
         assert len(net_fit.history) == net_fit.max_epochs
 
+    def test_initializing_net_with_history(self, net_fit, net_cls, module_cls, data):
+        # It is possible to pass a history instance to the net and have the net
+        # append to said history
+        from skorch.history import History
+
+        history = net_fit.history
+        n_before = len(history)
+        assert n_before > 0  # exclude trivial case of empty history
+
+        new_net = net_cls(module_cls, history=History(history.to_list()), max_epochs=3)
+        X, y = data
+        new_net.fit(X[:100], y[:100])
+        n_after = len(new_net.history)
+
+        # new history should have 3 more epochs, and the start should be
+        # identical
+        assert n_after == n_before + 3
+        assert new_net.history[:n_before] == history
+
     def test_set_params_works(self, net, data):
         X, y = data
         net.fit(X, y)

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -1068,24 +1068,18 @@ class TestNeuralNet:
     def test_history_is_filled(self, net_fit):
         assert len(net_fit.history) == net_fit.max_epochs
 
-    def test_initializing_net_with_history(self, net_fit, net_cls, module_cls, data):
-        # It is possible to pass a history instance to the net and have the net
-        # append to said history
+    def test_initializing_net_with_custom_history(self, net_cls, module_cls, data):
+        # It is possible to pass a custom history instance to the net and have
+        # the net use said history
         from skorch.history import History
 
-        history = net_fit.history
-        n_before = len(history)
-        assert n_before > 0  # exclude trivial case of empty history
+        class MyHistory(History):
+            pass
 
-        new_net = net_cls(module_cls, history=History(history.to_list()), max_epochs=3)
+        net = net_cls(module_cls, history=MyHistory(), max_epochs=3)
         X, y = data
-        new_net.fit(X[:100], y[:100])
-        n_after = len(new_net.history)
-
-        # new history should have 3 more epochs, and the start should be
-        # identical
-        assert n_after == n_before + 3
-        assert new_net.history[:n_before] == history
+        net.fit(X[:100], y[:100])
+        assert isinstance(net.history, MyHistory)
 
     def test_set_params_works(self, net, data):
         X, y = data

--- a/skorch/tests/test_probabilistic.py
+++ b/skorch/tests/test_probabilistic.py
@@ -114,6 +114,21 @@ class VariationalBinaryClassificationModule(gpytorch.models.ApproximateGP):
         return latent_pred
 
 
+class MyBernoulliLikelihood(gpytorch.likelihoods.BernoulliLikelihood):
+    """This class only exists to add a param to BernoulliLikelihood
+
+    BernoulliLikelihood used to have parameters before gpytorch v1.10, but now
+    it does not have any parameters anymore. This is not an issue per se, but
+    there are a few things we cannot test anymore, e.g. that parameters are
+    passed to the likelihood correctly when using grid search. Therefore, create
+    a custom class with a (pointless) parameter.
+
+    """
+    def __init__(self, *args, some_parameter=1, **kwargs):
+        self.some_parameter = some_parameter
+        super().__init__(*args, **kwargs)
+
+
 class BaseProbabilisticTests:
     """Base class for all GP estimators.
 
@@ -220,34 +235,24 @@ class BaseProbabilisticTests:
     # saving and loading #
     ######################
 
-    @pytest.mark.xfail(strict=True)
-    def test_pickling(self, gp_fit):
-        # Currently fails because of issues outside of our control, this test
-        # should alert us to when the issue has been fixed. Some issues have
-        # been fixed in https://github.com/cornellius-gp/gpytorch/pull/1336 but
-        # not all.
-        pickle.dumps(gp_fit)
+    def test_pickling(self, gp_fit, data):
+        loaded = pickle.loads(pickle.dumps(gp_fit))
+        X, _ = data
 
-    def test_pickle_error_msg(self, gp_fit):
-        # Should eventually be replaced by a test that saves and loads the model
-        # using pickle and checks that the predictions are identical
-        msg = ("This GPyTorch model cannot be pickled. The reason is probably this:"
-               " https://github.com/pytorch/pytorch/issues/38137. "
-               "Try using 'dill' instead of 'pickle'.")
-        with pytest.raises(pickle.PicklingError, match=msg):
-            pickle.dumps(gp_fit)
+        y_pred_before = gp_fit.predict(X)
+        y_pred_after = loaded.predict(X)
+        assert np.allclose(y_pred_before, y_pred_after)
 
-    def test_deepcopy(self, gp_fit):
-        # Should eventually be replaced by a test that saves and loads the model
-        # using deepcopy and checks that the predictions are identical
-        msg = ("This GPyTorch model cannot be pickled. The reason is probably this:"
-               " https://github.com/pytorch/pytorch/issues/38137. "
-               "Try using 'dill' instead of 'pickle'.")
-        with pytest.raises(pickle.PicklingError, match=msg):
-            copy.deepcopy(gp_fit)  # doesn't raise
+    def test_deepcopy(self, gp_fit, data):
+        copied = copy.deepcopy(gp_fit)
+        X, _ = data
 
-    def test_clone(self, gp_fit):
-        clone(gp_fit)  # doesn't raise
+        y_pred_before = gp_fit.predict(X)
+        y_pred_after = copied.predict(X)
+        assert np.allclose(y_pred_before, y_pred_after)
+
+    def test_clone(self, gp_fit, data):
+        clone(gp_fit)  # does not raise
 
     def test_save_load_params(self, gp_fit, tmpdir):
         gp2 = clone(gp_fit).initialize()
@@ -335,7 +340,8 @@ class BaseProbabilisticTests:
         params = {
             'lr': [0.01, 0.02],
             'max_epochs': [10, 20],
-            'likelihood__max_plate_nesting': [1, 2],
+            # this parameter does not exist but that's okay
+            'likelihood__some_parameter': [1, 2],
         }
         gp.set_params(verbose=0)
         gs = GridSearchCV(gp, params, refit=True, cv=3, scoring=self.scoring)
@@ -419,12 +425,7 @@ class BaseProbabilisticTests:
     ])
     def test_set_params_uninitialized_net_correct_message(
             self, gp, kwargs, expected, capsys):
-        # When gp is initialized, if module or optimizer need to be
-        # re-initialized, alert the user to the fact what parameters
-        # were responsible for re-initialization. Note that when the
-        # module parameters but not optimizer parameters were changed,
-        # the optimizer is re-initialized but not because the
-        # optimizer parameters changed.
+        # When gp is uninitialized, there is nothing to alert the user to
         gp.set_params(**kwargs)
         msg = capsys.readouterr()[0].strip()
         assert msg == expected
@@ -432,19 +433,21 @@ class BaseProbabilisticTests:
     @pytest.mark.parametrize('kwargs,expected', [
         ({}, ""),
         (
-            {'likelihood__max_plate_nesting': 2},
+            # this parameter does not exist but that's okay
+            {'likelihood__some_parameter': 2},
             ("Re-initializing module because the following "
-             "parameters were re-set: likelihood__max_plate_nesting.\n"
+             "parameters were re-set: likelihood__some_parameter.\n"
              "Re-initializing criterion.\n"
              "Re-initializing optimizer.")
         ),
         (
             {
-                'likelihood__max_plate_nesting': 2,
+                # this parameter does not exist but that's okay
+                'likelihood__some_parameter': 2,
                 'optimizer__momentum': 0.567,
             },
             ("Re-initializing module because the following "
-             "parameters were re-set: likelihood__max_plate_nesting.\n"
+             "parameters were re-set: likelihood__some_parameter.\n"
              "Re-initializing criterion.\n"
              "Re-initializing optimizer.")
         ),
@@ -570,23 +573,6 @@ class TestExactGPRegressor(BaseProbabilisticTests):
         )
         return gpr
 
-    # pickling and deepcopy work for ExactGPRegressor but not for the others, so
-    # override the expected failures here.
-
-    def test_pickling(self, gp_fit):
-        # does not raise
-        pickle.dumps(gp_fit)
-
-    def test_pickle_error_msg(self, gp_fit):
-        # Should eventually be replaced by a test that saves and loads the model
-        # using pickle and checks that the predictions are identical
-        # FIXME
-        pickle.dumps(gp_fit)
-
-    def test_deepcopy(self, gp_fit):
-        # FIXME
-        copy.deepcopy(gp_fit)  # doesn't raise
-
     def test_wrong_module_type_raises(self, gp_cls):
         # ExactGPRegressor requires the module to be an ExactGP, if it's not,
         # raise an appropriate error message to the user.
@@ -649,6 +635,32 @@ class TestGPRegressorVariational(BaseProbabilisticTests):
         assert gpr.batch_size < self.n_samples
         return gpr
 
+    # Since GPyTorch v1.10, GPRegressor works with pickle/deepcopy.
+
+    def test_pickling(self, gp_fit, data):
+        # TODO: remove once Python 3.7 is no longer supported
+        if version_gpytorch < Version('1.10'):
+            pytest.skip("GPyTorch < 1.10 does not support pickling.")
+
+        loaded = pickle.loads(pickle.dumps(gp_fit))
+        X, _ = data
+
+        y_pred_before = gp_fit.predict(X)
+        y_pred_after = loaded.predict(X)
+        assert np.allclose(y_pred_before, y_pred_after)
+
+    def test_deepcopy(self, gp_fit, data):
+        # TODO: remove once Python 3.7 is no longer supported
+        if version_gpytorch < Version('1.10'):
+            pytest.skip("GPyTorch < 1.10 does not support deepcopy.")
+
+        copied = copy.deepcopy(gp_fit)
+        X, _ = data
+
+        y_pred_before = gp_fit.predict(X)
+        y_pred_after = copied.predict(X)
+        assert np.allclose(y_pred_before, y_pred_after)
+
 
 class TestGPBinaryClassifier(BaseProbabilisticTests):
     """Tests for GPBinaryClassifier."""
@@ -686,7 +698,7 @@ class TestGPBinaryClassifier(BaseProbabilisticTests):
         gpc = gp_cls(
             module_cls,
             module__inducing_points=torch.from_numpy(X[:10]),
-
+            likelihood=MyBernoulliLikelihood,
             criterion=gpytorch.mlls.VariationalELBO,
             criterion__num_data=int(0.8 * len(y)),
             batch_size=24,
@@ -694,3 +706,32 @@ class TestGPBinaryClassifier(BaseProbabilisticTests):
         # we want to make sure batching is properly tested
         assert gpc.batch_size < self.n_samples
         return gpc
+
+    # Since GPyTorch v1.10, GPBinaryClassifier is the only estimator left that
+    # still has issues with pickling/deepcopying.
+
+    @pytest.mark.xfail(strict=True)
+    def test_pickling(self, gp_fit, data):
+        # Currently fails because of issues outside of our control, this test
+        # should alert us to when the issue has been fixed. Some issues have
+        # been fixed in https://github.com/cornellius-gp/gpytorch/pull/1336 but
+        # not all.
+        pickle.dumps(gp_fit)
+
+    def test_pickle_error_msg(self, gp_fit, data):
+        # Should eventually be replaced by a test that saves and loads the model
+        # using pickle and checks that the predictions are identical
+        msg = ("This GPyTorch model cannot be pickled. The reason is probably this:"
+               " https://github.com/pytorch/pytorch/issues/38137. "
+               "Try using 'dill' instead of 'pickle'.")
+        with pytest.raises(pickle.PicklingError, match=msg):
+            pickle.dumps(gp_fit)
+
+    def test_deepcopy(self, gp_fit, data):
+        # Should eventually be replaced by a test that saves and loads the model
+        # using deepcopy and checks that the predictions are identical
+        msg = ("This GPyTorch model cannot be pickled. The reason is probably this:"
+               " https://github.com/pytorch/pytorch/issues/38137. "
+               "Try using 'dill' instead of 'pickle'.")
+        with pytest.raises(pickle.PicklingError, match=msg):
+            copy.deepcopy(gp_fit)  # doesn't raise


### PR DESCRIPTION
## Description

(this is more or less copied from the docs)

When training a net in a distributed setting, e.g. when using `torch.nn.parallel.DistributedDataParallel`, directly or indirectly with the help of `AccelerateMixin`, the default history class should not be used. This is because each process will have its own history instance with no syncing happening between processes. Therefore, the information in the histories can diverge. When steering the training process through the histories, the resulting differences can cause trouble. When using early stopping, for instance, one process could receive the signal to stop but not the other.

`DistributedHistory` will take care of syncing the distributed batch information across processes, which will prevent the issue just described.

This class needs to be initialized with a distributed store provided by PyTorch (https://pytorch.org/docs/stable/distributed.html#distributed-key-value-store). I have only tested `torch.distributed.TCPStore` so far, but `torch.distributed.FileStore` should also work. The `DistributedHistory` also needs to be initialized with its rank and the world size (number of processes) so that it has all the required information to perform the syncing. When using `accelerate`, that information can be retrieved from the `Accelerator` instance.

## Comments

1. Even though the batch information, which is split across processes, is synced, the epoch information, which is not split, is *not* synced. E.g. the recorded duration can be different between processes. It is not quite clear what the "correct" behavior should be here, it would probably depend on what is done based on this information.
2. To make it possible to use the new class, I had to change the net initialization code to not create a new history instance (except when it is `None`) -- instead the history is just cleared. Otherwise, calling fit would always overwrite the `DistributedHistory` with a normal `History` object.
3. Unfortunately, `TCPStore` cannot be pickled. Therefore, I set it to `None` when pickling. This is not tragic as long as users pickle the final model and only load it for inference. If they want to keep on training, they would need to set the `net.history.store` manually.
4. To store values in the kv store as strings, I json-serialize the values, which means that certain types are not supported (say, numpy arrays). I guess the values could be pickled, but that seems like overkill.
5. I had some bugs when testing this with certain Python versions with pytest ("Fatal Python error: Aborted"). This did not happen with other Python versions or when not using pytest. Fingers crossed that this works in CI. I also had to add some `time.sleep` calls in the multiprocessing tests to avoid "broken pipe" etc. **Update**: CI had segfaults for PyTorch 1.11, so I'm skipping tests with `DistributedHistory` for that PyTorch version. Maybe the tests are just flaky, but we don't want that.