### PR TITLE
FIX/DOC: Fix failing readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,6 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.9"
 
 sphinx:
    configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,3 +4,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+
+sphinx:
+   configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
Resolves #962 

Adding this `.readthedocs.yaml` makes the build [pass again](https://readthedocs.org/projects/skorch/builds/20584952/).

I'm not completely happy with this, because some of the configuration now lives in `.readthedocs.yaml`, and some is what we set on the admin panel of the web ui. It is not clear to me what takes precedence when. Ideally, we should migrate to rely solely on `.readthedocs.yaml` but I don't think it's possible. For example, automation rules cannot be specified on the yaml (https://github.com/readthedocs/readthedocs.org/issues/8287). Therefore, if the build error can be fixed without adding a `.readthedocs.yaml`, I'd prefer that.