### PR TITLE
[skip ci] Try to fix broken API docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 docutils<0.18
 gpytorch>=1.5
 numpy>=1.13.3
+tabulate>=0.7.7
 torch>=1.11.0
 transformers
 sphinx-rtd-theme==0.4.0


### PR DESCRIPTION
Adding tabulate to the doc requirements seems to fix the broken API docs reported in #967.

Here is an example page on latest that is currently broken: https://skorch.readthedocs.io/en/latest/callbacks.html

Here is the same page on this branch which is fixed: https://skorch.readthedocs.io/en/docs-fix-broken-api-docs/callbacks.html

I'm not quite sure why the missing dependency wasn't a problem earlier but now is, but adding it should do no harm.