### PR TITLE
Fix small bug in _get_params_callbacks

### DIFF
--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1934,7 +1934,7 @@ class NeuralNet:
             return params
 
         callbacks_ = getattr(self, 'callbacks_', [])
-        for key, val in chain(callbacks_, self._default_callbacks):
+        for key, val in chain(self._default_callbacks, callbacks_):
             name = 'callbacks__' + key
             params[name] = val
             if val is None:  # callback deactivated


### PR DESCRIPTION
Swap the order of default callbacks and current callbacks passed to `itertools.chain` in _get_params_callbacks.

We want the default callbacks first so that the current callbacks can override them. The fixed code now matches the order in _yield_callbacks.
