### PR TITLE
Add version logging to NeptuneLogger

### DIFF
--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -285,11 +285,11 @@ class NeptuneLogger(Callback):
     @staticmethod
     def _model_summary_file(model):
         try:
-            # neptune-client=0.9.0+ package structure
-            from neptune.new.types import File
-        except ImportError:
             # neptune-client>=1.0.0 package structure
             from neptune.types import File
+        except ImportError:
+            # neptune-client=0.9.0+ package structure
+            from neptune.new.types import File
 
         return File.from_content(str(model), extension='txt')
 

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -176,6 +176,18 @@ class NeptuneLogger(Callback):
         self.keys_ignored = keys_ignored
         self.base_namespace = base_namespace
 
+        self._log_integration_version()
+
+    def _log_integration_version(self) -> None:
+        try:
+            from importlib.metadata import version
+            skorch_version = version("skorch")
+        except ImportError:
+            import pkg_resources
+            skorch_version = pkg_resources.get_distribution('skorch').version
+
+        self.run['source_code/integrations/skorch'] = skorch_version
+
     @property
     def _metric_logger(self):
         return self.run[self._base_namespace]

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -176,17 +176,10 @@ class NeptuneLogger(Callback):
         self.keys_ignored = keys_ignored
         self.base_namespace = base_namespace
 
-        self._log_integration_version()
-
     def _log_integration_version(self) -> None:
-        try:
-            from importlib.metadata import version
-            skorch_version = version("skorch")
-        except ImportError:
-            import pkg_resources
-            skorch_version = pkg_resources.get_distribution('skorch').version
+        from skorch import __version__
 
-        self.run['source_code/integrations/skorch'] = skorch_version
+        self.run['source_code/integrations/skorch'] = __version__
 
     @property
     def _metric_logger(self):
@@ -207,6 +200,8 @@ class NeptuneLogger(Callback):
             self._base_namespace = self.base_namespace[:-1]
         else:
             self._base_namespace = self.base_namespace
+
+        self._log_integration_version()
 
         return self
 

--- a/skorch/tests/callbacks/test_logging.py
+++ b/skorch/tests/callbacks/test_logging.py
@@ -74,6 +74,9 @@ class TestNeptune:
     def test_experiment_closed_automatically(self, net_fitted, mock_experiment):
         assert mock_experiment.stop.call_count == 1
 
+    def test_version_logged(self, net_fitted, mock_experiment):
+        assert mock_experiment.exists("source_code/integrations/skorch")
+
     def test_experiment_log_call_counts(self, net_fitted, mock_experiment):
         # (3 x dur + 3 x train_loss + 3 x valid_loss + 3 x valid_acc = 12) + base metrics
         assert mock_experiment.__getitem__.call_count == 12 + self.NUM_BASE_METRICS


### PR DESCRIPTION
- added version logging
- changed import order in one of the methods to avoid unnecessary warnings
