### PR TITLE
Remove support for python 3.7

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,12 +16,9 @@ jobs:
     strategy:
       fail-fast: false  # don't cancel all jobs when one fails
       matrix:
-        python_version: ['3.7', '3.8', '3.9', '3.10']
+        python_version: ['3.8', '3.9', '3.10']
         torch_version: ['1.11.0+cpu', '1.12.1+cpu', '1.13.1+cpu', '2.0.0+cpu']
         os: [ubuntu-latest]
-        exclude:
-          - python_version: '3.7'
-            torch_version: '2.0.0+cpu'
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ skorch also provides many convenient features, among others:
 Installation
 ============
 
-skorch requires Python 3.7 or higher.
+skorch requires Python 3.8 or higher.
 
 conda installation
 ==================

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -58,7 +58,7 @@ If you want to help developing, run:
     pylint skorch  # static code checks
 
 You may adjust the Python version to any of the supported Python versions, i.e.
-Python 3.7 or higher.
+Python 3.8 or higher.
 
 Using pip
 ^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('requirements.txt') as f:
     install_requires = [l.strip() for l in f]
 
 
-python_requires = '>=3.7'
+python_requires = '>=3.8'
 
 tests_require = [
     'pytest',

--- a/skorch/_doctor.py
+++ b/skorch/_doctor.py
@@ -473,9 +473,7 @@ class SkorchDoctor:
             if self.gradient_recs_[module]:
                 # using the reversed order because gradients are recorded from
                 # last to first, but first to last is more intuitive to show
-                # TODO: When dropping python 3.7, dict keys are reversible, so
-                # no need to call list(keys)
-                keys = list(self.gradient_recs_[module][0].keys())
+                keys = self.gradient_recs_[module][0].keys()
                 names[module] = list(reversed(keys))
             else:
                 names[module] = []

--- a/skorch/tests/test_probabilistic.py
+++ b/skorch/tests/test_probabilistic.py
@@ -638,10 +638,6 @@ class TestGPRegressorVariational(BaseProbabilisticTests):
     # Since GPyTorch v1.10, GPRegressor works with pickle/deepcopy.
 
     def test_pickling(self, gp_fit, data):
-        # TODO: remove once Python 3.7 is no longer supported
-        if version_gpytorch < Version('1.10'):
-            pytest.skip("GPyTorch < 1.10 does not support pickling.")
-
         loaded = pickle.loads(pickle.dumps(gp_fit))
         X, _ = data
 
@@ -650,10 +646,6 @@ class TestGPRegressorVariational(BaseProbabilisticTests):
         assert np.allclose(y_pred_before, y_pred_after)
 
     def test_deepcopy(self, gp_fit, data):
-        # TODO: remove once Python 3.7 is no longer supported
-        if version_gpytorch < Version('1.10'):
-            pytest.skip("GPyTorch < 1.10 does not support deepcopy.")
-
         copied = copy.deepcopy(gp_fit)
         X, _ = data
 


### PR DESCRIPTION
Since it is EOL this month anyway we should drop support and encourage users to upgrade to a more stable python branch.

I removed the TODOs related to python 3.7 to the best of my knowledge.

This is, in part, related to https://github.com/skorch-dev/skorch/pull/982 where `pkg_resources` is replaced with `importlib.metadata` which is only available in python 3.8.