### PR TITLE
Exclude _version.py from coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
 omit = 
        skorch/tests/*
-
+       skorch/_version.py


### PR DESCRIPTION
We vendor the code in `_version.py` from scipy. It is thus not necessary for us to have tests for it (it's tested in scipy). Still, it was included in the coverage report, resulting in artificially lowered test coverage. This fix removes the module from being counted for coverage.