### PR TITLE
MNT: Update CI, add Python 3.11

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false  # don't cancel all jobs when one fails
       matrix:
-        python_version: ['3.8', '3.9', '3.10']
-        torch_version: ['1.11.0+cpu', '1.12.1+cpu', '1.13.1+cpu', '2.0.0+cpu']
+        python_version: ['3.8', '3.9', '3.10', '3.11']
+        torch_version: ['1.11.0+cpu', '1.12.1+cpu', '1.13.1+cpu', '2.0.1+cpu']
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,9 +21,9 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python_version }}
     - name: Install dependencies

--- a/README.rst
+++ b/README.rst
@@ -247,7 +247,7 @@ minor PyTorch versions, which currently are:
 - 1.11.0
 - 1.12.1
 - 1.13.1
-- 2.0.0
+- 2.0.1
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -101,7 +101,7 @@ minor PyTorch versions, which currently are:
 - 1.11.0
 - 1.12.1
 - 1.13.1
-- 2.0.0
+- 2.0.1
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of


### PR DESCRIPTION
- use latest versions of `checkout` and `setup-python` GH actions
- add Python 3.11 to CI