### PR TITLE
Fix invalid escape sequence '\s' in Dataset docstring

### DIFF
--- a/skorch/dataset.py
+++ b/skorch/dataset.py
@@ -105,8 +105,7 @@ def unpack_data(data):
 
 
 class Dataset(torch.utils.data.Dataset):
-    # pylint: disable=anomalous-backslash-in-string
-    """General dataset wrapper that can be used in conjunction with
+    r"""General dataset wrapper that can be used in conjunction with
     PyTorch :class:`~torch.utils.data.DataLoader`.
 
     The dataset will always yield a tuple of two values, the first
@@ -168,8 +167,7 @@ class Dataset(torch.utils.data.Dataset):
         return self._len
 
     def transform(self, X, y):
-        # pylint: disable=anomalous-backslash-in-string
-        """Additional transformations on ``X`` and ``y``.
+        r"""Additional transformations on ``X`` and ``y``.
 
         By default, they are cast to PyTorch :class:`~torch.Tensor`\s.
         Override this if you want a different behavior.


### PR DESCRIPTION
Following the issue I've presented in https://github.com/skorch-dev/skorch/issues/999