### PR TITLE
Better error message when NeuralNetClassifier misses the classes_ attribute

### DIFF
--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -98,7 +98,21 @@ class NeuralNetClassifier(NeuralNet, ClassifierMixin):
                 raise AttributeError("{} has no attribute 'classes_'".format(
                     self.__class__.__name__))
             return self.classes
-        return self.classes_inferred_
+
+        try:
+            return self.classes_inferred_
+        except AttributeError as exc:
+            # It's not easily possible to track exactly what circumstances led
+            # to this, so try to make an educated guess and provide a possible
+            # solution.
+            msg = (
+                f"{self.__class__.__name__} could not infer the classes from y; "
+                "this error probably occurred because the net was trained without y "
+                "and some function tried to access the '.classes_' attribute; "
+                "a possible solution is to provide the 'classes' argument when "
+                f"initializing {self.__class__.__name__}"
+            )
+            raise AttributeError(msg) from exc
 
     # pylint: disable=signature-differs
     def check_data(self, X, y):


### PR DESCRIPTION
See #1003 

On `NeuralNetClassifier`, when `classes_` is accessed but does not exist, we try to use `classes_inferred_` instead. If that is also not defined, users currently just get an `AttributeError` that `classes_inferred_` does not exist. This can be very confusing.

This PR intercepts the error, provides a (hopefully) helpful error message, then reraises. It is unfortunately not easily possible to deduce what exactly went wrong to get to this point, thus the error message makes an educated guess.