### PR TITLE
Accelerate bug in specific versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-accelerate>=0.11.0,!=0.20.*,!=0.21.0
+accelerate>=0.22.0
 fire
 flaky
 future>=0.17.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-accelerate>=0.11.0,!=0.20,!=0.21
+accelerate>=0.11.0,!=0.20.*,!=0.21.0
 fire
 flaky
 future>=0.17.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-accelerate>=0.11.0
+accelerate>=0.11.0,!=0.20,!=0.21
 fire
 flaky
 future>=0.17.1


### PR DESCRIPTION
In versions 0.20.* and 0.21.0 (latest), there was/is a bug in `unwrap_model` when called with `keep_fp32_wrapper=False`. This results in `forward` not working after unwrapping the model, which can affect skorch users who use `AccelerateMixin`.

The bug has been fixed in this PR:

https://github.com/huggingface/accelerate/pull/1838

However, there was no release yet. Therefore, I exclude the specific accelerate versions with that bug. Using a version <0.20 or a future release should work.

To catch this type of issue sooner, I added a test that will trigger the bug.