### PR TITLE
Accelerate some adjustment for mixed precision

### DIFF
--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -151,17 +151,16 @@ class LRScheduler(Callback):
 
         """
         accelerator_maybe = getattr(net, 'accelerator', None)
-        if not accelerator_maybe:
-            if score is None:
-                lr_scheduler.step()
-            else:
-                lr_scheduler.step(score)
+        accelerator_step_skipped = (
+            accelerator_maybe and accelerator_maybe.optimizer_step_was_skipped
+        )
+        if accelerator_step_skipped:
+            return
+
+        if score is None:
+            lr_scheduler.step()
         else:
-            if not accelerator_maybe.optimizer_step_was_skipped:
-                if score is None:
-                    lr_scheduler.step()
-                else:
-                    lr_scheduler.step(score)
+            lr_scheduler.step(score)
 
     def on_epoch_end(self, net, **kwargs):
         if self.step_every != 'epoch':

--- a/skorch/hf.py
+++ b/skorch/hf.py
@@ -997,9 +997,10 @@ class AccelerateMixin:
     def train_step_single(self, batch, **fit_params):
         self._set_training(True)
         Xi, yi = unpack_data(batch)
-        y_pred = self.infer(Xi, **fit_params)
-        loss = self.get_loss(y_pred, yi, X=Xi, training=True)
-        self.accelerator.backward(loss)
+        with self.accelerator.autocast():
+            y_pred = self.infer(Xi, **fit_params)
+            loss = self.get_loss(y_pred, yi, X=Xi, training=True)
+            self.accelerator.backward(loss)
         return {
             'loss': loss,
             'y_pred': y_pred,

--- a/skorch/tests/callbacks/test_lr_scheduler.py
+++ b/skorch/tests/callbacks/test_lr_scheduler.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock
 
 import numpy as np
 import pytest
-import torch
 from sklearn.base import clone
 from torch.optim import SGD
 from torch.optim.lr_scheduler import CosineAnnealingLR
@@ -12,7 +11,7 @@ from torch.optim.lr_scheduler import LambdaLR
 from torch.optim.lr_scheduler import MultiStepLR
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torch.optim.lr_scheduler import StepLR
-from torch.optim.lr_scheduler import CyclicLR as TorchCyclicLR
+from torch.optim.lr_scheduler import CyclicLR
 
 from skorch import NeuralNetClassifier
 from skorch.callbacks.lr_scheduler import WarmRestartLR, LRScheduler
@@ -28,7 +27,7 @@ class TestLRCallbacks:
         expected = np.array([1.0, 1.0, 0.1, 0.1, 0.01, 0.01])
         assert np.allclose(expected, lrs)
 
-    @pytest.mark.parametrize('policy', [TorchCyclicLR])
+    @pytest.mark.parametrize('policy', [CyclicLR])
     def test_simulate_lrs_batch_step(self, policy):
         lr_sch = LRScheduler(
             policy, base_lr=1, max_lr=5, step_size_up=4, step_every='batch')
@@ -96,7 +95,7 @@ class TestLRCallbacks:
         assert lr_policy.lr_scheduler_.last_epoch == max_epochs
 
     @pytest.mark.parametrize('policy, kwargs', [
-        (TorchCyclicLR, {'base_lr': 1e-3, 'max_lr': 6e-3, 'step_every': 'batch'}),
+        (CyclicLR, {'base_lr': 1e-3, 'max_lr': 6e-3, 'step_every': 'batch'}),
     ])
     def test_lr_callback_batch_steps_correctly(
             self,
@@ -125,7 +124,7 @@ class TestLRCallbacks:
         assert lr_policy.batch_idx_ == expected
 
     @pytest.mark.parametrize('policy, kwargs', [
-        (TorchCyclicLR, {'base_lr': 1e-3, 'max_lr': 6e-3, 'step_every': 'batch'}),
+        (CyclicLR, {'base_lr': 1e-3, 'max_lr': 6e-3, 'step_every': 'batch'}),
     ])
     def test_lr_callback_batch_steps_correctly_fallback(
             self,
@@ -177,7 +176,7 @@ class TestLRCallbacks:
 
     def test_lr_scheduler_set_params(self, classifier_module, classifier_data):
         scheduler = LRScheduler(
-            TorchCyclicLR, base_lr=123, max_lr=999, step_every='batch')
+            CyclicLR, base_lr=123, max_lr=999, step_every='batch')
         net = NeuralNetClassifier(
             classifier_module,
             max_epochs=0,
@@ -212,7 +211,7 @@ class TestLRCallbacks:
         batch_size = 128
 
         scheduler = LRScheduler(
-            TorchCyclicLR,
+            CyclicLR,
             base_lr=1,
             max_lr=5,
             step_size_up=4,

--- a/skorch/tests/test_hf.py
+++ b/skorch/tests/test_hf.py
@@ -725,6 +725,7 @@ class TestAccelerate:
             def __init__(self):
                 self.device_placement = True
                 self.print = print
+                self.optimizer_step_was_skipped = False
 
             def prepare(self, *args):
                 for arg in args:
@@ -744,6 +745,11 @@ class TestAccelerate:
             # pylint: disable=unused-argument
             @contextmanager
             def accumulate(self, model):
+                yield
+
+            # pylint: disable=unused-argument
+            @contextmanager
+            def autocast(self, cache_enabled=False, autocast_handler=None):
                 yield
 
         # pylint: disable=missing-docstring,arguments-differ


### PR DESCRIPTION
This PR makes 3 adjustments. Checking the individual commits may help with reviewing.

1. [Use accelerator.autocast when computing loss](https://github.com/skorch-dev/skorch/commit/c6b94cce548c7846cd13e35d5a32de66ebfc93da)

According to the accelerate docs, loss computation should be performed within the `accelerator.autocast` context manager:

https://huggingface.co/docs/accelerate/v0.21.0/en/quicktour#mixed-precision-training

I tested if this makes a difference by running the [this notebook](https://nbviewer.org/github/skorch-dev/skorch/blob/master/notebooks/Hugging_Face_Finetuning.ipynb) with fp16 precision.

I found no difference at all: The runtime was practically the same and the losses were identical. Still, I think it's better to have this than not, as it is recommended by the accelerate docs.

2. [Update LR scheduler callback to work w/ accelerate](https://github.com/skorch-dev/skorch/commit/ba5f15323920b331c99da476bdff37c326c1cb37)

According to the same docs, the LR scheduler step should sometimes be skipped when using mixed precision training because accelerate may skip update steps internally. Therefore, I updated the LR scheduler callback to check if the net has an accelerator and if it does, to check if a step is necessary.

This is actually quite hard to test because the necessity of stepping depends on accelerate's internal logic, which we don't want to test, and which might change in the future. Therefore, the added test just runs training with accelerate, mixed precision, and some LR schedulers, verifying that there is no error.

When running these tests + the normal LR scheduler tests locally on a machine that supports fp16, I get 100% line coverage of `lr_scheduler.py`. I think this is good enough.

3. [Non-functional clean ups related to LR schedulers](https://github.com/skorch-dev/skorch/commit/0cf1dc30eab8a840898626dcace5e3652e25a85b)

While working on the fixes in this PR, I also cleaned up some LR scheduler code. These clean ups are non-functional.

1. We imported `CyclicLR` as `TorchCyclicLR`. I'm not sure why but it is somehow related to very old PyTorch versions we no longer support, so I removed this.
2. Fixed some indentations in conditional checks to improve readability.