### PR TITLE
Fix install via test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,13 @@ with open('VERSION', 'r') as f:
 with open('requirements.txt') as f:
     install_requires = [l.strip() for l in f]
 
+with open('requirements-dev.txt') as f:
+    tests_require = [l.strip() for l in f]
+
 
 python_requires = '>=3.8'
 
-tests_require = [
+tests_require += [
     'pytest',
     'pytest-cov',
 ]

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,6 @@ with open('requirements-dev.txt') as f:
 
 python_requires = '>=3.8'
 
-tests_require += [
-    'pytest',
-    'pytest-cov',
-]
-
 docs_require = [
     'Sphinx',
     'sphinx_rtd_theme',


### PR DESCRIPTION
Ensures `requirements-dev.txt` is used if installed via `pip install -e .[testing]`