### PR TITLE
FIX: Make pd import local in DataFrameTransformer

### DIFF
--- a/skorch/helper.py
+++ b/skorch/helper.py
@@ -370,8 +370,6 @@ class DataFrameTransformer(BaseEstimator, TransformerMixin):
     contains 1 column.
 
     """
-    import pandas as pd
-
     def __init__(
             self,
             treat_int_as_categorical=False,
@@ -399,6 +397,8 @@ class DataFrameTransformer(BaseEstimator, TransformerMixin):
           If a wrong dtype is found.
 
         """
+        import pandas as pd
+
         if 'X' in df:
             raise ValueError(
                 "DataFrame contains a column named 'X', which clashes "
@@ -408,7 +408,7 @@ class DataFrameTransformer(BaseEstimator, TransformerMixin):
         wrong_dtypes = []
 
         for col, dtype in zip(df, df.dtypes):
-            if isinstance(dtype, self.pd.api.types.CategoricalDtype):
+            if isinstance(dtype, pd.api.types.CategoricalDtype):
                 continue
             if np.issubdtype(dtype, np.integer):
                 continue
@@ -447,6 +447,8 @@ class DataFrameTransformer(BaseEstimator, TransformerMixin):
           respective column names as keys.
 
         """
+        import pandas as pd
+
         self._check_dtypes(df)
 
         X_dict = {}
@@ -455,7 +457,7 @@ class DataFrameTransformer(BaseEstimator, TransformerMixin):
         for col, dtype in zip(df, df.dtypes):
             X_col = df[col]
 
-            if isinstance(dtype, self.pd.api.types.CategoricalDtype):
+            if isinstance(dtype, pd.api.types.CategoricalDtype):
                 x = X_col.cat.codes.values
                 if self.int_dtype is not None:
                     x = x.astype(self.int_dtype)


### PR DESCRIPTION
`DataFrameTransformer` requires pandas but we don't want to have a dependency on pandas in skorch. Therefore, the pandas import should be local.

Back when I wrote this class, I thought it would be sufficient to import pandas at a class level, but that is incorrect. Now, pandas is important inside the method bodies.

For most skorch users, this should make no difference. But it will allow skorch users who use something from `helpers.py` to avoid having to install pandas.