### PR TITLE
DOC: Attempt at fixing theme on RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,7 +126,7 @@ def setup(app):
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
+if True or not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
     html_theme = 'sphinx_rtd_theme'
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,8 @@
 import os
 import sys
 
+import sphinx_rtd_theme
+
 sys.path.insert(0, os.path.abspath('..'))
 
 
@@ -110,7 +112,6 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -126,10 +127,8 @@ def setup(app):
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-if True or not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 
 # -- Options for HTMLHelp output ------------------------------------------


### PR DESCRIPTION
Resolves #1018

Now always enforce the use of `sphinx_rtd_theme`. Previously, this was not done when the docs were built on RTD, instead using the default theme. I'm not really sure why that was so, maybe the default theme already was `sphinx_rtd_theme` but was changed later?

The docs after this change can be found here:

https://skorch.readthedocs.io/en/docs-try-fixing-rtd-theme/

At first I was suspicious if the change in `conf.py` was really the cause of the fix or if this was not instead somehow related to the `latest` version of the docs. Therefore, I created an empty PR #1020 and checked its docs. Those use the false theme, as can be witnessed here:

https://skorch.readthedocs.io/en/docs-experimental-branch-to-check-theme/

Therefore, I think the provided fix should also work for the `latest`, and any other, doc version.