### PR TITLE
MNT Fix torch install in GH integr. test workflow

### DIFF
--- a/.github/workflows/test-hf-integration.yml
+++ b/.github/workflows/test-hf-integration.yml
@@ -20,7 +20,8 @@ jobs:
     - name: Install Requirements
       run: |
         python -m pip install -r requirements.txt
-        python -m pip install transformers tokenizers huggingface_hub torch
+        python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+        python -m pip install transformers tokenizers huggingface_hub
         python -m pip install .
     - name: run HF integration test
       env:


### PR DESCRIPTION
The integration test GH workflow started failing recently when trying to install PyTorch with pip.

The error is:

> ERROR: Could not find a version that satisfies the requirement torch (from versions: none)
> ERROR: No matching distribution found for torch

(see e.g. [this log](https://github.com/skorch-dev/skorch/actions/runs/6682391483/job/18160262863))

Not 100% sure why, but this fix addresses it by installing PyTorch explicitly from the CPU index URL.

This is the same approach as in our normal unit testing workflow, so it should work.