### PR TITLE
FIX: Torch install in HF integratin test workflow

### DIFF
--- a/.github/workflows/test-hf-integration.yml
+++ b/.github/workflows/test-hf-integration.yml
@@ -20,7 +20,8 @@ jobs:
     - name: Install Requirements
       run: |
         python -m pip install -r requirements.txt
-        python -m pip install transformers tokenizers huggingface_hub torch
+        python -m pip install torch -f https://download.pytorch.org/whl/torch_stable.html
+        python -m pip install transformers tokenizers huggingface_hub
         python -m pip install .
     - name: run HF integration test
       env:


### PR DESCRIPTION
For some reason, the existing install instruction started failing recently. Try a different one akin to what is used for the unit tests.