### PR TITLE
Don't fail when pickling models which haven't been trained further

### DIFF
--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -669,7 +669,7 @@ class ProgressBar(Callback):
         # don't save away the temporary pbar_ object which gets created on
         # epoch begin anew anyway. This avoids pickling errors with tqdm.
         state = self.__dict__.copy()
-        del state['pbar_']
+        state.pop('pbar_', None)
         return state
 
 

--- a/skorch/tests/callbacks/test_logging.py
+++ b/skorch/tests/callbacks/test_logging.py
@@ -770,6 +770,17 @@ class TestProgressBar:
         net = pickle.loads(dump)
         net.fit(*data)
 
+    def test_pickle_without_fit(self, net_cls, progressbar_cls, data):
+        # pickling should work even if the net hasn't been fit.
+        import pickle
+
+        net = net_cls(callbacks=[
+            progressbar_cls(),
+        ])
+        dump = pickle.dumps(net)
+
+        net = pickle.loads(dump)
+
 
 @pytest.mark.skipif(
     not tensorboard_installed, reason='tensorboard is not installed')

--- a/skorch/tests/callbacks/test_logging.py
+++ b/skorch/tests/callbacks/test_logging.py
@@ -772,6 +772,7 @@ class TestProgressBar:
 
     def test_pickle_without_fit(self, net_cls, progressbar_cls, data):
         # pickling should work even if the net hasn't been fit.
+        # see https://github.com/skorch-dev/skorch/pull/1034.
         import pickle
 
         net = net_cls(callbacks=[


### PR DESCRIPTION
`pbar_` is only set in `on_epoch_begin`, so if `on_epoch_begin` is never called there will be a failure in saving the model.