### PR TITLE
FIX Python version in hf-integration test

### DIFF
--- a/.github/workflows/test-hf-integration.yml
+++ b/.github/workflows/test-hf-integration.yml
@@ -14,9 +14,11 @@ jobs:
     timeout-minutes: 10  # took 4 min during testing
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
     - name: Install Requirements
       run: |
         python -m pip install -r requirements.txt


### PR DESCRIPTION
Explicitly set Python version to 3.11, was using 3.12 by default, which is not supported by PyTorch.

Also, update versions of checkout and setup-python GitHub actions.