### PR TITLE
Fix return_url of HfApi client's upload_file method

### DIFF
--- a/skorch/hf.py
+++ b/skorch/hf.py
@@ -1277,6 +1277,10 @@ class HfHubStorage:
             repo_id=self.repo_id,
             **self.kwargs
         )
+        if hasattr(return_url, 'commit_url'):
+            # starting from huggingface_hub, the return type is now a CommitInfo
+            # object instead of a string
+            return_url = return_url.commit_url
         self._buffer = None
         self._needs_flush = False
 


### PR DESCRIPTION
Since v0.20 of `huggingface_hub`, the attribute is a `CommitInfo` object (which is a `dataclass`), not a string anymore.