### PR TITLE
Add PyTorch 2.2.0 to CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,11 +21,9 @@ jobs:
       fail-fast: false  # don't cancel all jobs when one fails
       matrix:
         python_version: ['3.8', '3.9', '3.10', '3.11']
-        torch_version: ['1.12.1+cpu', '1.13.1+cpu', '2.0.1+cpu', '2.1.0+cpu']
+        torch_version: ['1.13.1+cpu', '2.0.1+cpu', '2.1.2+cpu', '2.2.0+cpu']
         os: [ubuntu-latest]
         exclude:
-          - python_version: '3.11'
-            torch_version: '1.12.1+cpu'
           - python_version: '3.11'
             torch_version:  '2.0.1+cpu'
 

--- a/README.rst
+++ b/README.rst
@@ -244,10 +244,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.12.1
 - 1.13.1
 - 2.0.1
-- 2.1.0
+- 2.1.2
+- 2.2.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -98,10 +98,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 1.12.1
 - 1.13.1
 - 2.0.1
-- 2.1.0
+- 2.1.2
+- 2.2.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of


### PR DESCRIPTION
Also:

- Remove 1.12.1
- Check 2.1.2 instead of 2.1.0
- Update docs