### PR TITLE
Fix issues with sklearn 1.4

### DIFF
--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -100,7 +100,7 @@ def convert_sklearn_metric_function(scoring):
 
         # those are scoring objects returned by make_scorer starting
         # from sklearn 0.22
-        scorer_names = ('_PredictScorer', '_ProbaScorer', '_ThresholdScorer')
+        scorer_names = ('_PredictScorer', '_ProbaScorer', '_ThresholdScorer', '_Scorer')
         if (
                 hasattr(module, 'startswith') and
                 module.startswith('sklearn.metrics.') and

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -97,7 +97,7 @@ class NeuralNetClassifier(NeuralNet, ClassifierMixin):
             if not len(self.classes):
                 raise AttributeError("{} has no attribute 'classes_'".format(
                     self.__class__.__name__))
-            return self.classes
+            return np.asarray(self.classes)
 
         try:
             return self.classes_inferred_
@@ -301,7 +301,7 @@ class NeuralNetBinaryClassifier(NeuralNet, ClassifierMixin):
 
     @property
     def classes_(self):
-        return [0, 1]
+        return np.array([0, 1])
 
     # pylint: disable=signature-differs
     def check_data(self, X, y):

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1597,7 +1597,7 @@ class NeuralNet:
             yp = nonlin(yp)
             y_probas.append(to_numpy(yp))
         y_proba = np.concatenate(y_probas, 0)
-        return y_proba
+        return y_proba.astype(np.float64)
 
     def predict(self, X):
         """Where applicable, return class labels for samples in X.

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1597,7 +1597,7 @@ class NeuralNet:
             yp = nonlin(yp)
             y_probas.append(to_numpy(yp))
         y_proba = np.concatenate(y_probas, 0)
-        return y_proba.astype(np.float64)
+        return y_proba
 
     def predict(self, X):
         """Where applicable, return class labels for samples in X.

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -172,7 +172,7 @@ class TestNeuralNet:
         expected = "NeuralNetClassifier has no attribute 'classes_'"
         assert msg == expected
 
-    @pytest.mark.xfail(strict=True)
+    @pytest.mark.xfail
     def test_with_calibrated_classifier_cv(self, net_fit, data):
         # TODO: This fails with sklearn 1.4.0 because CCCV does not work when
         # y_proba is float32. This will be fixed in
@@ -381,7 +381,7 @@ class TestNeuralNetBinaryClassifier:
         net.predict_proba(X)
         assert mock.call_count > 0
 
-    @pytest.mark.xfail(strict=True)
+    @pytest.mark.xfail
     def test_with_calibrated_classifier_cv(self, net_fit, data):
         # TODO: This fails with sklearn 1.4.0 because CCCV does not work when
         # y_proba is float32. This will be fixed in

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -172,7 +172,12 @@ class TestNeuralNet:
         expected = "NeuralNetClassifier has no attribute 'classes_'"
         assert msg == expected
 
+    @pytest.mark.xfail(strict=True)
     def test_with_calibrated_classifier_cv(self, net_fit, data):
+        # TODO: This fails with sklearn 1.4.0 because CCCV does not work when
+        # y_proba is float32. This will be fixed in
+        # https://github.com/scikit-learn/scikit-learn/pull/28247, at which
+        # point the test should pass again and the xfail can be removed.
         from sklearn.calibration import CalibratedClassifierCV
         cccv = CalibratedClassifierCV(net_fit, cv=2)
         cccv.fit(*data)
@@ -376,7 +381,12 @@ class TestNeuralNetBinaryClassifier:
         net.predict_proba(X)
         assert mock.call_count > 0
 
+    @pytest.mark.xfail(strict=True)
     def test_with_calibrated_classifier_cv(self, net_fit, data):
+        # TODO: This fails with sklearn 1.4.0 because CCCV does not work when
+        # y_proba is float32. This will be fixed in
+        # https://github.com/scikit-learn/scikit-learn/pull/28247, at which
+        # point the test should pass again and the xfail can be removed.
         from sklearn.calibration import CalibratedClassifierCV
         cccv = CalibratedClassifierCV(net_fit, cv=2)
         cccv.fit(*data)

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -134,7 +134,7 @@ class TestNeuralNet:
 
     def test_pass_classes_explicitly_overrides(self, net_cls, module_cls, data):
         net = net_cls(module_cls, max_epochs=0, classes=['foo', 'bar']).fit(*data)
-        assert net.classes_ == ['foo', 'bar']
+        assert (net.classes_ == np.array(['foo', 'bar'])).all()
 
     def test_classes_are_set_with_tensordataset_explicit_y(
             self, net_cls, module_cls, data


### PR DESCRIPTION
Some skorch tests fail with sklearn v1.4. This commit fixes them:

1. Inheritance structure of scorers seems to have changed.
2. `classes_` attribute should always be numpy array
3. `CalibratedClassifierCV` only works with the output of `predict_proba` being float64

To fix the latter, I'm now casting the output of `predict_proba` to float64. However, I'm not sure if this is a good idea, as it might break existing code. I'm just adding it in for now to check if the tests pass.

**Update**: So the tests pass. Regarding the issue with `CalibratedClassifierCV` and float32, here are some suggestions:

1. Always cast to float64 and :crossed_fingers: that nothing breaks
2. Just keep float32 and skip the tests until the [sklearn fix](https://github.com/scikit-learn/scikit-learn/pull/28247) is released
3. Add an argument to `NeuralNet` to optionally cast `y_proba` to float64.

Personally, I'm in favor of 2.