### PR TITLE
FIX New pytest version errors on warning test

### DIFF
--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -468,6 +468,7 @@ class TestNeuralNet:
             cuda_available,
             load_dev,
             expect_warning,
+            recwarn,
     ):
         from skorch.exceptions import DeviceWarning
         net = net_cls(module=module_cls, device=save_dev).initialize()
@@ -479,9 +480,12 @@ class TestNeuralNet:
 
         with patch('torch.cuda.is_available', lambda *_: cuda_available):
             with open(str(p), 'rb') as f:
-                expected_warning = DeviceWarning if expect_warning else None
-                with pytest.warns(expected_warning) as w:
+                if not expect_warning:
                     m = pickle.load(f)
+                    assert not recwarn.list
+                else:
+                    with pytest.warns(DeviceWarning) as w:
+                        m = pickle.load(f)
 
         assert torch.device(m.device) == torch.device(load_dev)
 


### PR DESCRIPTION
We had a test that basically called `pytest.warns(None)`, which newer pytest versions don't allow. Instead, now using recwarn to assert that there is _no_ error.

The suggested `pytest.does_not_warn()` (pytest issues 9404) does not appear to work.