### PR TITLE
FIX NeuralNetBinaryClassifier with torch.compile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 
+- Fix an issue with using `NeuralNetBinaryClassifier` with `torch.compile` (#1058)
+
 ## [1.0.0] - 2024-05-27
 
 The 1.0.0 release of skorch is here. We think that skorch is at a very stable point, which is why a 1.0.0 release is appropriate. There are no plans to add any breaking changes or major revisions in the future. Instead, our focus now is to keep skorch up-to-date with the latest versions of PyTorch and scikit-learn, and to fix any bugs that may arise.

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -660,6 +660,8 @@ def _infer_predict_nonlinearity(net):
         return _identity
 
     criterion = getattr(net, net._criteria[0] + '_')
+    # unwrap optimizer in case of torch.compile being used
+    criterion = getattr(criterion, '_orig_mod', criterion)
 
     if isinstance(criterion, CrossEntropyLoss):
         return partial(torch.softmax, dim=-1)


### PR DESCRIPTION
Fixes #1057

`NeuralNetBinaryClassifier` was not working with `torch.compile` because the non-linearity was not correctly inferred. This inference depends on the instance type of the criterion. However, when using `torch.compile`, the criterion is wrapped, resulting in the `isinstance` check to miss. Now, we unwrap the criterion before checking the instance type.