### PR TITLE
Add PyTorch 2.4.0 to CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,11 +21,8 @@ jobs:
       fail-fast: false  # don't cancel all jobs when one fails
       matrix:
         python_version: ['3.8', '3.9', '3.10', '3.11']
-        torch_version: ['2.0.1+cpu', '2.1.2+cpu', '2.2.2+cpu', '2.3.0+cpu']
+        torch_version: ['2.1.2+cpu', '2.2.2+cpu', '2.3.1+cpu', '2.4.0+cpu']
         os: [ubuntu-latest]
-        exclude:
-          - python_version: '3.11'
-            torch_version:  '2.0.1+cpu'
 
     steps:
     - uses: actions/checkout@v3
@@ -39,7 +36,7 @@ jobs:
         python -m pip install -r requirements-dev.txt
         python -m pip install -r requirements.txt
         python -m pip install pytest-pretty
-        python -m pip install torch==${{ matrix.torch_version }} -f https://download.pytorch.org/whl/torch_stable.html
+        python -m pip install torch==${{ matrix.torch_version }} -f https://download.pytorch.org/whl/torch
         python -m pip list
     - name: Install skorch
       run: |

--- a/README.rst
+++ b/README.rst
@@ -244,10 +244,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 2.0.1
 - 2.1.2
 - 2.2.2
-- 2.3.0
+- 2.3.1
+- 2.4.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -98,10 +98,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 2.0.1
 - 2.1.2
 - 2.2.2
-- 2.3.0
+- 2.3.1
+- 2.4.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of


### PR DESCRIPTION
Also:

- Remove 2.0.1
- Updgrade 2.3.0 to 2.3.1
- Use index https://download.pytorch.org/whl/torch, as torch_stable does not have 2.4.0 (yet?)