### PR TITLE
training: fixed EarlyStopping._calc_new_threshold to account for negative scores

### DIFF
--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -460,7 +460,7 @@ class EarlyStopping(Callback):
     def _calc_new_threshold(self, score):
         """Determine threshold based on score."""
         if self.threshold_mode == 'rel':
-            abs_threshold_change = self.threshold * score
+            abs_threshold_change = self.threshold * np.abs(score)
         else:
             abs_threshold_change = self.threshold
 


### PR DESCRIPTION
This fix is meant to account for training models with potentially negative scores as we see in the case of cost functions based on the log likelihood. The current fix ensures that `abs_threshold_change` is always positive, guaranteeing the intended monotonicity of the threshold.