### PR TITLE
Drop Python 3.8, add Python 3.12

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false  # don't cancel all jobs when one fails
       matrix:
-        python_version: ['3.8', '3.9', '3.10', '3.11']
+        python_version: ['3.9', '3.10', '3.11', '3.12']
         torch_version: ['2.1.2+cpu', '2.2.2+cpu', '2.3.1+cpu', '2.4.0+cpu']
         os: [ubuntu-latest]
 

--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ skorch also provides many convenient features, among others:
 Installation
 ============
 
-skorch requires Python 3.8 or higher.
+skorch requires Python 3.9 or higher.
 
 conda installation
 ==================

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -58,7 +58,7 @@ If you want to help developing, run:
     pylint skorch  # static code checks
 
 You may adjust the Python version to any of the supported Python versions, i.e.
-Python 3.8 or higher.
+Python 3.9 or higher.
 
 Using pip
 ^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('requirements-dev.txt') as f:
     tests_require = [l.strip() for l in f]
 
 
-python_requires = '>=3.8'
+python_requires = '>=3.9'
 
 docs_require = [
     'Sphinx',


### PR DESCRIPTION
Python 3.8 is going to be end of life by the end of this month (Oct 2024). PyTorch 2.5 requires Python 3.9 or higher.