### PR TITLE
ENH: ReduceLROnPlateau records the learning rate and works on batches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+
+- When using the `ReduceLROnPlateau` learning rate scheduler, we now record the learning rate in the net history (`net.history[:, 'event_lr']` by default). It is now also possible to to step per batch, not only by epoch
+
 ### Fixed
 
 - Fix an issue with using `NeuralNetBinaryClassifier` with `torch.compile` (#1058)


### PR DESCRIPTION
Previously, when using `ReduceLROnPlateau`, we would not record the learning rates in history. The code comment says that's because this class does not expose the `get_last_lr` method. I checked it again and it's now present, so let's use it.

Furthermore, I made a change to enable `ReduceLROnPlateau` to step on each batch (so far, only each epoch was supported). This is consistent with other learning rate schedulers.