### PR TITLE
FIX Make skorch work with sklearn 1.6.0

### DIFF
--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -231,6 +231,12 @@ class NeuralNetClassifier(NeuralNet, ClassifierMixin):
         """
         return self.predict_proba(X).argmax(axis=1)
 
+    def __sklearn_tags__(self):
+        # TODO: this is just the bare minimum, more tags should be added
+        tags = super().__sklearn_tags__()
+        tags.estimator_type = 'classifier'
+        return tags
+
 
 neural_net_binary_clf_doc_start = """NeuralNet for binary classification tasks
 
@@ -379,3 +385,9 @@ class NeuralNetBinaryClassifier(NeuralNet, ClassifierMixin):
         """
         y_proba = self.predict_proba(X)
         return (y_proba[:, 1] > self.threshold).astype('uint8')
+
+    def __sklearn_tags__(self):
+        # TODO: this is just the bare minimum, more tags should be added
+        tags = super().__sklearn_tags__()
+        tags.estimator_type = 'classifier'
+        return tags

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -2725,3 +2725,11 @@ class NeuralNet:
 
         parts.append(')')
         return '\n'.join(parts)
+
+    def __sklearn_tags__(self):
+        # TODO: this is just the bare minimum, more tags should be added for
+        # NeuralNet, NeuralNetClassifier, etc. See:
+        # https://scikit-learn.org/dev/developers/develop.html#estimator-tags
+        # https://scikit-learn.org/dev/modules/generated/sklearn.utils.Tags.html#sklearn.utils.Tags
+        tags = BaseEstimator.__sklearn_tags__(self)
+        return tags

--- a/skorch/probabilistic.py
+++ b/skorch/probabilistic.py
@@ -657,6 +657,12 @@ class ExactGPRegressor(_GPRegressorPredictMixin, GPBase):
         self.partial_fit(X, y, **fit_params)
         return self
 
+    def __sklearn_tags__(self):
+        # TODO: this is just the bare minimum, more tags should be added
+        tags = super().__sklearn_tags__()
+        tags.estimator_type = 'regressor'
+        return tags
+
 
 gp_regr_doc_start = """Gaussian Process regressor
 
@@ -728,6 +734,12 @@ class GPRegressor(_GPRegressorPredictMixin, GPBase):
             likelihood=likelihood,
             **kwargs
         )
+
+    def __sklearn_tags__(self):
+        # TODO: this is just the bare minimum, more tags should be added
+        tags = super().__sklearn_tags__()
+        tags.estimator_type = 'regressor'
+        return tags
 
 
 gp_binary_clf_doc_start = """Gaussian Process binary classifier
@@ -911,6 +923,12 @@ class GPBinaryClassifier(GPBase):
         """
         y_proba = self.predict_proba(X)
         return (y_proba[:, 1] > self.threshold).astype('uint8')
+
+    def __sklearn_tags__(self):
+        # TODO: this is just the bare minimum, more tags should be added
+        tags = super().__sklearn_tags__()
+        tags.estimator_type = 'classifier'
+        return tags
 
 
 # BB: I could never get any reasonable results using ``SoftmaxLikelihood``. In

--- a/skorch/regressor.py
+++ b/skorch/regressor.py
@@ -80,3 +80,9 @@ class NeuralNetRegressor(NeuralNet, RegressorMixin):
         # this is actually a pylint bug:
         # https://github.com/PyCQA/pylint/issues/1085
         return super(NeuralNetRegressor, self).fit(X, y, **fit_params)
+
+    def __sklearn_tags__(self):
+        # TODO: this is just the bare minimum, more tags should be added
+        tags = super().__sklearn_tags__()
+        tags.estimator_type = 'regressor'
+        return tags

--- a/skorch/tests/test_helper.py
+++ b/skorch/tests/test_helper.py
@@ -437,6 +437,7 @@ class TestSliceDataset:
             self, slds, y, classifier_module):
         from sklearn.model_selection import GridSearchCV
         from skorch import NeuralNetClassifier
+        from skorch.utils import to_numpy
 
         net = NeuralNetClassifier(
             classifier_module,
@@ -450,12 +451,13 @@ class TestSliceDataset:
         gs = GridSearchCV(
             net, params, refit=False, cv=3, scoring='accuracy', error_score='raise'
         )
-        gs.fit(slds, y)  # does not raise
+        gs.fit(slds, to_numpy(y))  # does not raise
 
     def test_grid_search_with_slds_and_internal_split_works(
             self, slds, y, classifier_module):
         from sklearn.model_selection import GridSearchCV
         from skorch import NeuralNetClassifier
+        from skorch.utils import to_numpy
 
         net = NeuralNetClassifier(classifier_module)
         params = {
@@ -465,7 +467,7 @@ class TestSliceDataset:
         gs = GridSearchCV(
             net, params, refit=True, cv=3, scoring='accuracy', error_score='raise'
         )
-        gs.fit(slds, y)  # does not raise
+        gs.fit(slds, to_numpy(y))  # does not raise
 
     def test_grid_search_with_slds_X_and_slds_y(
             self, slds, slds_y, classifier_module):


### PR DESCRIPTION
The new sklearn version now requires the estimator to expose a method `__sklearn_tags__`. This PR implements a bare minimum of sklearn tags to make the tests pass again.

Probably this list of tags can be improved to be more precise.

Moreover, some tests now started failing. To be precise, using `GridSearchCV` with y being a torch tensor fails, as sklearn performs a check on the devices of `y` vs `y_pred` (a numpy array) and determines that the devices differ. The error message is:

<details>

<summary>Error</summary>

```
skorch/tests/test_helper.py:470: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../anaconda3/envs/skorch/lib/python3.12/site-packages/sklearn/base.py:1389: in wrapper
    return fit_method(estimator, *args, **kwargs)
../../anaconda3/envs/skorch/lib/python3.12/site-packages/sklearn/model_selection/_search.py:1023: in fit
    self._run_search(evaluate_candidates)
../../anaconda3/envs/skorch/lib/python3.12/site-packages/sklearn/model_selection/_search.py:1570: in _run_search
    evaluate_candidates(ParameterGrid(self.param_grid))
../../anaconda3/envs/skorch/lib/python3.12/site-packages/sklearn/model_selection/_search.py:969: in evaluate_candidates
    out = parallel(
../../anaconda3/envs/skorch/lib/python3.12/site-packages/sklearn/utils/parallel.py:77: in __call__
    return super().__call__(iterable_with_config)
../../anaconda3/envs/skorch/lib/python3.12/site-packages/joblib/parallel.py:1918: in __call__
    return output if self.return_generator else list(output)
../../anaconda3/envs/skorch/lib/python3.12/site-packages/joblib/parallel.py:1847: in _get_sequential_output
    res = func(*args, **kwargs)
../../anaconda3/envs/skorch/lib/python3.12/site-packages/sklearn/utils/parallel.py:139: in __call__
    return self.function(*args, **kwargs)
../../anaconda3/envs/skorch/lib/python3.12/site-packages/sklearn/model_selection/_validation.py:888: in _fit_and_score
    test_scores = _score(
../../anaconda3/envs/skorch/lib/python3.12/site-packages/sklearn/model_selection/_validation.py:949: in _score
    scores = scorer(estimator, X_test, y_test, **score_params)
../../anaconda3/envs/skorch/lib/python3.12/site-packages/sklearn/metrics/_scorer.py:288: in __call__
    return self._score(partial(_cached_call, None), estimator, X, y_true, **_kwargs)
../../anaconda3/envs/skorch/lib/python3.12/site-packages/sklearn/metrics/_scorer.py:388: in _score
    return self._sign * self._score_func(y_true, y_pred, **scoring_kwargs)
../../anaconda3/envs/skorch/lib/python3.12/site-packages/sklearn/utils/_param_validation.py:216: in wrapper
    return func(*args, **kwargs)
../../anaconda3/envs/skorch/lib/python3.12/site-packages/sklearn/metrics/_classification.py:224: in accuracy_score
    xp, _, device = get_namespace_and_device(y_true, y_pred, sample_weight)
../../anaconda3/envs/skorch/lib/python3.12/site-packages/sklearn/utils/_array_api.py:614: in get_namespace_and_device
    arrays_device = device(*array_list, **skip_remove_kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

remove_none = False, remove_types = []
array_list = [tensor([1, 1, 1, 1, 0, 0, 1, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1,
        1, 0, 1, 0, 0, 1, 0, 0, 0, 0]), array([1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1,
       0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1])]
device_ = device(type='cpu')

    def device(*array_list, remove_none=True, remove_types=(str,)):
        """Hardware device where the array data resides on.
    
        If the hardware device is not the same for all arrays, an error is raised.
    
        Parameters
        ----------
        *array_list : arrays
            List of array instances from NumPy or an array API compatible library.
    
        remove_none : bool, default=True
            Whether to ignore None objects passed in array_list.
    
        remove_types : tuple or list, default=(str,)
            Types to ignore in array_list.
    
        Returns
        -------
        out : device
            `device` object (see the "Device Support" section of the array API spec).
        """
        array_list = _remove_non_arrays(
            *array_list, remove_none=remove_none, remove_types=remove_types
        )
    
        if not array_list:
            return None
    
        device_ = _single_array_device(array_list[0])
    
        # Note: here we cannot simply use a Python `set` as it requires
        # hashable members which is not guaranteed for Array API device
        # objects. In particular, CuPy devices are not hashable at the
        # time of writing.
        for array in array_list[1:]:
            device_other = _single_array_device(array)
            if device_ != device_other:
>               raise ValueError(
                    f"Input arrays use different devices: {str(device_)}, "
                    f"{str(device_other)}"
                )
E               ValueError: Input arrays use different devices: cpu, cpu
```

</details>

The tests have now been amended to cast `y` to a numpy array. It is unfortunate that this used not be necessary but now is.

I think we can live with that, as it's an edge case. I tested that with normal fitting, passing a `torch.tensor` as `y` is no problem.

_Note_: The commit message says sklearn 1.5 but it's in fact 1.6.