### PR TITLE
Issue #1080 : Fixing Parsing code for documentation retrieval in Python 3.13.

### DIFF
--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -42,7 +42,7 @@ neural_net_clf_additional_attribute = """classes_ : array, shape (n_classes, )
 
 
 def get_neural_net_clf_doc(doc):
-    doc = neural_net_clf_doc_start + " " + doc.split("\n ", 4)[-1]
+    doc = neural_net_clf_doc_start + " " + doc.split("\n ", 3)[-1]
     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
     start, end = pattern.search(doc).span()
     doc = doc[:start] + neural_net_clf_additional_text + doc[end:]
@@ -251,7 +251,7 @@ neural_net_binary_clf_criterion_text = """
 
 
 def get_neural_net_binary_clf_doc(doc):
-    doc = neural_net_binary_clf_doc_start + " " + doc.split("\n ", 4)[-1]
+    doc = neural_net_binary_clf_doc_start + " " + doc.split("\n ", 3)[-1]
     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
     start, end = pattern.search(doc).span()
     doc = doc[:start] + neural_net_binary_clf_criterion_text + doc[end:]

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -43,6 +43,9 @@ neural_net_clf_additional_attribute = """classes_ : array, shape (n_classes, )
 
 def get_neural_net_clf_doc(doc):
     indentation = "    "
+    # dedent/indent roundtrip required for consistent indention in both
+    # Python <3.13 and Python >=3.13
+    # Because <3.13 => not automatic dedent, but it is the case in >=3.13
     doc = neural_net_clf_doc_start + " " + textwrap.indent(textwrap.dedent(doc.split("\n", 5)[-1]), indentation)
     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
     start, end = pattern.search(doc).span()
@@ -251,6 +254,9 @@ neural_net_binary_clf_criterion_text = """
 
 def get_neural_net_binary_clf_doc(doc):
     indentation = "    "
+    # dedent/indent roundtrip required for consistent indention in both
+    # Python <3.13 and Python >=3.13
+    # Because <3.13 => not automatic dedent, but it is the case in >=3.13
     doc = neural_net_binary_clf_doc_start + " " + textwrap.indent(textwrap.dedent(doc.split("\n", 5)[-1]), indentation)
     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
     start, end = pattern.search(doc).span()

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -43,7 +43,7 @@ neural_net_clf_additional_attribute = """classes_ : array, shape (n_classes, )
 
 def get_neural_net_clf_doc(doc):
     doc = neural_net_clf_doc_start + " " + doc.split("\n ", 4)[-1]
-    pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+){1,99}')
+    pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
     start, end = pattern.search(doc).span()
     doc = doc[:start] + neural_net_clf_additional_text + doc[end:]
     doc = doc + neural_net_clf_additional_attribute
@@ -252,7 +252,7 @@ neural_net_binary_clf_criterion_text = """
 
 def get_neural_net_binary_clf_doc(doc):
     doc = neural_net_binary_clf_doc_start + " " + doc.split("\n ", 4)[-1]
-    pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+){1,99}')
+    pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
     start, end = pattern.search(doc).span()
     doc = doc[:start] + neural_net_binary_clf_criterion_text + doc[end:]
     return doc

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -36,7 +36,7 @@ neural_net_clf_additional_text = """
       skorch behavior should be restored, i.e. raising an
       ``AttributeError``, pass an empty list."""
 
-neural_net_clf_additional_attribute = """classes_ : array, shape (n_classes, )
+neural_net_clf_additional_attribute = """    classes_ : array, shape (n_classes, )
       A list of class labels known to the classifier.
 
 """
@@ -50,7 +50,7 @@ def get_neural_net_clf_doc(doc):
     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
     start, end = pattern.search(doc).span()
     doc = doc[:start] + neural_net_clf_additional_text + doc[end:]
-    doc = doc + textwrap.indent(neural_net_clf_additional_attribute, indentation)
+    doc = doc + neural_net_clf_additional_attribute
     return doc
 
 # pylint: disable=missing-docstring

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -43,7 +43,7 @@ neural_net_clf_additional_attribute = """classes_ : array, shape (n_classes, )
 
 def get_neural_net_clf_doc(doc):
     indentation = "    "
-    doc = neural_net_clf_doc_start + " " + textwrap.indent(doc.split("\n", 5)[-1], indentation)
+    doc = neural_net_clf_doc_start + " " + textwrap.indent(textwrap.dedent(doc.split("\n", 5)[-1]), indentation)
     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
     start, end = pattern.search(doc).span()
     doc = doc[:start] + neural_net_clf_additional_text + doc[end:]
@@ -251,7 +251,7 @@ neural_net_binary_clf_criterion_text = """
 
 def get_neural_net_binary_clf_doc(doc):
     indentation = "    "
-    doc = neural_net_binary_clf_doc_start + " " + textwrap.indent(doc.split("\n", 5)[-1], indentation)
+    doc = neural_net_binary_clf_doc_start + " " + textwrap.indent(textwrap.dedent(doc.split("\n", 5)[-1]), indentation)
     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
     start, end = pattern.search(doc).span()
     doc = doc[:start] + neural_net_binary_clf_criterion_text + doc[end:]

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -1,6 +1,7 @@
 """NeuralNet subclasses for classification tasks."""
 
 import re
+import textwrap
 
 import numpy as np
 from sklearn.base import ClassifierMixin
@@ -40,15 +41,14 @@ neural_net_clf_additional_attribute = """classes_ : array, shape (n_classes, )
 
 """
 
-
 def get_neural_net_clf_doc(doc):
-    doc = neural_net_clf_doc_start + " " + doc.split("\n ", 3)[-1]
-    pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
-    start, end = pattern.search(doc).span()
-    doc = doc[:start] + neural_net_clf_additional_text + doc[end:]
-    doc = doc + neural_net_clf_additional_attribute
-    return doc
-
+     indentation = "    "
+     doc = neural_net_clf_doc_start + " " + textwrap.indent(textwrap.dedent(doc.split("\n", 5)[-1]), indentation)
+     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
+     start, end = pattern.search(doc).span()
+     doc = doc[:start] + neural_net_clf_additional_text + doc[end:]
+     doc = doc + textwrap.indent(neural_net_clf_additional_attribute, indentation)
+     return doc
 
 # pylint: disable=missing-docstring
 class NeuralNetClassifier(ClassifierMixin, NeuralNet):
@@ -249,14 +249,13 @@ neural_net_binary_clf_criterion_text = """
       Probabilities above this threshold is classified as 1. ``threshold``
       is used by ``predict`` and ``predict_proba`` for classification."""
 
-
 def get_neural_net_binary_clf_doc(doc):
-    doc = neural_net_binary_clf_doc_start + " " + doc.split("\n ", 3)[-1]
-    pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
-    start, end = pattern.search(doc).span()
-    doc = doc[:start] + neural_net_binary_clf_criterion_text + doc[end:]
-    return doc
-
+     indentation = "    "
+     doc = neural_net_binary_clf_doc_start + " " + textwrap.indent(textwrap.dedent(doc.split("\n", 5)[-1]), indentation)
+     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
+     start, end = pattern.search(doc).span()
+     doc = doc[:start] + neural_net_binary_clf_criterion_text + doc[end:]
+     return doc
 
 class NeuralNetBinaryClassifier(ClassifierMixin, NeuralNet):
     # pylint: disable=missing-docstring

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -42,13 +42,13 @@ neural_net_clf_additional_attribute = """classes_ : array, shape (n_classes, )
 """
 
 def get_neural_net_clf_doc(doc):
-     indentation = "    "
-     doc = neural_net_clf_doc_start + " " + textwrap.indent(textwrap.dedent(doc.split("\n", 5)[-1]), indentation)
-     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
-     start, end = pattern.search(doc).span()
-     doc = doc[:start] + neural_net_clf_additional_text + doc[end:]
-     doc = doc + textwrap.indent(neural_net_clf_additional_attribute, indentation)
-     return doc
+    indentation = "    "
+    doc = neural_net_clf_doc_start + " " + textwrap.indent(doc.split("\n", 5)[-1], indentation)
+    pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
+    start, end = pattern.search(doc).span()
+    doc = doc[:start] + neural_net_clf_additional_text + doc[end:]
+    doc = doc + textwrap.indent(neural_net_clf_additional_attribute, indentation)
+    return doc
 
 # pylint: disable=missing-docstring
 class NeuralNetClassifier(ClassifierMixin, NeuralNet):
@@ -250,12 +250,12 @@ neural_net_binary_clf_criterion_text = """
       is used by ``predict`` and ``predict_proba`` for classification."""
 
 def get_neural_net_binary_clf_doc(doc):
-     indentation = "    "
-     doc = neural_net_binary_clf_doc_start + " " + textwrap.indent(textwrap.dedent(doc.split("\n", 5)[-1]), indentation)
-     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
-     start, end = pattern.search(doc).span()
-     doc = doc[:start] + neural_net_binary_clf_criterion_text + doc[end:]
-     return doc
+    indentation = "    "
+    doc = neural_net_binary_clf_doc_start + " " + textwrap.indent(doc.split("\n", 5)[-1], indentation)
+    pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
+    start, end = pattern.search(doc).span()
+    doc = doc[:start] + neural_net_binary_clf_criterion_text + doc[end:]
+    return doc
 
 class NeuralNetBinaryClassifier(ClassifierMixin, NeuralNet):
     # pylint: disable=missing-docstring

--- a/skorch/regressor.py
+++ b/skorch/regressor.py
@@ -25,7 +25,7 @@ neural_net_reg_criterion_text = """
 
 
 def get_neural_net_reg_doc(doc):
-    doc = neural_net_reg_doc_start + " " + doc.split("\n ", 4)[-1]
+    doc = neural_net_reg_doc_start + " " + doc.split("\n ", 3)[-1]
     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
     start, end = pattern.search(doc).span()
     doc = doc[:start] + neural_net_reg_criterion_text + doc[end:]

--- a/skorch/regressor.py
+++ b/skorch/regressor.py
@@ -25,12 +25,12 @@ neural_net_reg_criterion_text = """
       Mean squared error loss."""
 
 def get_neural_net_reg_doc(doc):
-     indentation = "    "
-     doc = neural_net_reg_doc_start + " " + textwrap.indent(textwrap.dedent(doc.split("\n", 5)[-1]), indentation)
-     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
-     start, end = pattern.search(doc).span()
-     doc = doc[:start] + neural_net_reg_criterion_text + doc[end:]
-     return doc
+    indentation = "    "
+    doc = neural_net_reg_doc_start + " " + textwrap.indent(doc.split("\n", 5)[-1], indentation)
+    pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
+    start, end = pattern.search(doc).span()
+    doc = doc[:start] + neural_net_reg_criterion_text + doc[end:]
+    return doc
 
 # pylint: disable=missing-docstring
 class NeuralNetRegressor(RegressorMixin, NeuralNet):

--- a/skorch/regressor.py
+++ b/skorch/regressor.py
@@ -26,6 +26,9 @@ neural_net_reg_criterion_text = """
 
 def get_neural_net_reg_doc(doc):
     indentation = "    "
+    # dedent/indent roundtrip required for consistent indention in both
+    # Python <3.13 and Python >=3.13
+    # Because <3.13 => not automatic dedent, but it is the case in >=3.13
     doc = neural_net_reg_doc_start + " " + textwrap.indent(textwrap.dedent(doc.split("\n", 5)[-1]), indentation)
     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
     start, end = pattern.search(doc).span()

--- a/skorch/regressor.py
+++ b/skorch/regressor.py
@@ -1,6 +1,7 @@
 """NeuralNet subclasses for regression tasks."""
 
 import re
+import textwrap
 
 from sklearn.base import RegressorMixin
 import torch
@@ -23,14 +24,13 @@ neural_net_reg_criterion_text = """
     criterion : torch criterion (class, default=torch.nn.MSELoss)
       Mean squared error loss."""
 
-
 def get_neural_net_reg_doc(doc):
-    doc = neural_net_reg_doc_start + " " + doc.split("\n ", 3)[-1]
-    pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
-    start, end = pattern.search(doc).span()
-    doc = doc[:start] + neural_net_reg_criterion_text + doc[end:]
-    return doc
-
+     indentation = "    "
+     doc = neural_net_reg_doc_start + " " + textwrap.indent(textwrap.dedent(doc.split("\n", 5)[-1]), indentation)
+     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
+     start, end = pattern.search(doc).span()
+     doc = doc[:start] + neural_net_reg_criterion_text + doc[end:]
+     return doc
 
 # pylint: disable=missing-docstring
 class NeuralNetRegressor(RegressorMixin, NeuralNet):

--- a/skorch/regressor.py
+++ b/skorch/regressor.py
@@ -26,7 +26,7 @@ neural_net_reg_criterion_text = """
 
 def get_neural_net_reg_doc(doc):
     doc = neural_net_reg_doc_start + " " + doc.split("\n ", 4)[-1]
-    pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+){1,99}')
+    pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
     start, end = pattern.search(doc).span()
     doc = doc[:start] + neural_net_reg_criterion_text + doc[end:]
     return doc

--- a/skorch/regressor.py
+++ b/skorch/regressor.py
@@ -26,7 +26,7 @@ neural_net_reg_criterion_text = """
 
 def get_neural_net_reg_doc(doc):
     indentation = "    "
-    doc = neural_net_reg_doc_start + " " + textwrap.indent(doc.split("\n", 5)[-1], indentation)
+    doc = neural_net_reg_doc_start + " " + textwrap.indent(textwrap.dedent(doc.split("\n", 5)[-1]), indentation)
     pattern = re.compile(r'(\n\s+)(criterion .*\n)(\s.+|.){1,99}')
     start, end = pattern.search(doc).span()
     doc = doc[:start] + neural_net_reg_criterion_text + doc[end:]


### PR DESCRIPTION
Fixes parsing code so that documentation from NeuralNet is properly processed when adapting the documentation for NeuralNetClassifier, NeuralNetBinaryClassifier and NeuralNetRegressor classes in Python 3.13 and below.
See [Issue #1080 ](https://github.com/skorch-dev/skorch/issues/1080) for more details.