### PR TITLE
Issue #1081: Fix PyPI Readme Rendering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,25 +9,20 @@ A scikit-learn compatible neural network library that wraps PyTorch.
 
 .. |build| image:: https://github.com/skorch-dev/skorch/workflows/tests/badge.svg
     :alt: Test Status
-    :scale: 100%
 
 .. |coverage| image:: https://github.com/skorch-dev/skorch/blob/master/assets/coverage.svg
     :alt: Test Coverage
-    :scale: 100%
 
 .. |docs| image:: https://readthedocs.org/projects/skorch/badge/?version=latest
     :alt: Documentation Status
-    :scale: 100%
     :target: https://skorch.readthedocs.io/en/latest/?badge=latest
 
 .. |huggingface| image:: https://github.com/skorch-dev/skorch/actions/workflows/test-hf-integration.yml/badge.svg
     :alt: Hugging Face Integration
-    :scale: 100%
     :target: https://github.com/skorch-dev/skorch/actions/workflows/test-hf-integration.yml
 
 .. |powered| image:: https://github.com/skorch-dev/skorch/blob/master/assets/powered.svg
     :alt: Powered by
-    :scale: 100%
     :target: https://github.com/ottogroup/
 
 =========

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ python_files = test*py
 
 [metadata]
 description-file = README.rst
+long-description-content-type = text/x-rst
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
The readme renderer refuses to render scaled images (in this particular case, badges), as a result the [skorch PyPi page](https://pypi.org/project/skorch/0.2.0/) is displayed as plain text. This is easily fixed by removing scaling from badges in the README. On top of that, Explicitly specifying RST content type for the long description solves a warning during rendering.
See #1081 for more info.