### PR TITLE
Update: PyTorch v2.7.0

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false  # don't cancel all jobs when one fails
       matrix:
         python_version: ['3.9', '3.10', '3.11', '3.12']
-        torch_version: ['2.3.1+cpu', '2.4.1+cpu', '2.5.1+cpu', '2.6.0+cpu']
+        torch_version: ['2.4.1+cpu', '2.5.1+cpu', '2.6.0+cpu', '2.7.0+cpu']
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,14 +31,12 @@ jobs:
       with:
         python-version: ${{ matrix.python_version }}
     - name: Install dependencies
-      # TODO remove numpy version constraint once we no longer support PyTorch < 2.3
       # TODO remove triton 3.1 install if torch < 2.6 no longer supported, see #1093
       # TODO remove triton 3.2 install if torch < 2.7 no longer supported
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements-dev.txt
         python -m pip install -r requirements.txt
-        python -m pip install --force-reinstall -U "numpy<2.0.0"
         python -m pip install pytest-pretty
         python -m pip install torch==${{ matrix.torch_version }} -f https://download.pytorch.org/whl/torch
         TORCH_VERSION_MAJOR_MINOR=$(python -c "import torch; v=torch.__version__.split('+')[0]; print('.'.join(v.split('.')[:2]))")

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Install dependencies
       # TODO remove numpy version constraint once we no longer support PyTorch < 2.3
       # TODO remove triton 3.1 install if torch < 2.6 no longer supported, see #1093
+      # TODO remove triton 3.2 install if torch < 2.7 no longer supported
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements-dev.txt
@@ -43,6 +44,8 @@ jobs:
         TORCH_VERSION_MAJOR_MINOR=$(python -c "import torch; v=torch.__version__.split('+')[0]; print('.'.join(v.split('.')[:2]))")
         if [[ $(echo "$TORCH_VERSION_MAJOR_MINOR < 2.6" | bc -l) -eq 1 ]]; then
           python -m pip install "triton==3.1"
+        elif [[ $(echo "$TORCH_VERSION_MAJOR_MINOR < 2.7" | bc -l) -eq 1 ]]; then
+          python -m pip install "triton==3.2"
         fi
         python -m pip list
     - name: Install skorch

--- a/README.rst
+++ b/README.rst
@@ -239,10 +239,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 2.3.1
 - 2.4.1
 - 2.5.1
 - 2.6.0
+- 2.7.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -98,10 +98,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 2.3.1
 - 2.4.1
 - 2.5.1
 - 2.6.0
+- 2.7.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of


### PR DESCRIPTION
- Dropped 2.3.1
- For PyTorch 2.6, install triton 3.2
- Drop numpy<2.0 install (no longer required for PyTorch)