### PR TITLE
Fix typo in error messages in test_net.py

### DIFF
--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -3475,7 +3475,7 @@ class TestNeuralNet:
                 super().__init__(*args, **kwargs)
                 self.foo_ = module_cls()
 
-        msg = ("Trying to set torch compoment 'foo_' outside of an initialize method. "
+        msg = ("Trying to set torch component 'foo_' outside of an initialize method. "
                "Consider defining it inside 'initialize_module'")
         with pytest.raises(SkorchAttributeError, match=msg):
             MyNet(module_cls)
@@ -3492,7 +3492,7 @@ class TestNeuralNet:
                 self.opti = torch.optim.Adam(self.module_.parameters())
                 return self
 
-        msg = ("Trying to set torch compoment 'opti' outside of an initialize method. "
+        msg = ("Trying to set torch component 'opti' outside of an initialize method. "
                "Consider defining it inside 'initialize_optimizer'")
         with pytest.raises(SkorchAttributeError, match=msg):
             MyNet(module_cls).initialize()


### PR DESCRIPTION


Description:  
This pull request corrects a minor typo in the error messages within the skorch/tests/test_net.py file. The word "component" was previously misspelled as "compoment" in two places. This update ensures the error messages are clear and professional. No functional changes were made to the code.