### PR TITLE
Setup pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+# pre-commit package installation is necessary to use pre-commit.
+# $ pip install pre-commit
+# $ pre-commit install
+
+default_language_version:
+  python: python3
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        args: [
+            "--max-line-length=99",
+            "--ignore=D204,D401",
+            "--statistics",
+        ]
+  - repo: https://github.com/pycqa/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ dev = [
     "pylint",
     "flake8",
     "future>=0.17.1",
+    "pre-commit",
+    "black",
+    "isort",
+    "radon"
 ]
 
 test = [
@@ -96,11 +100,6 @@ omit = [
 show_missing = true
 skip_covered = false
 
-[tool.flake8]
-max-line-length = 88
-docstring-convention = "numpy"
-ignore = "D204,D401"
-
 [tool.pytest.ini_options]
 addopts = [
     "--cov=skorch",
@@ -108,6 +107,39 @@ addopts = [
 ]
 python_files = "test*.py"
 testpaths = ["skorch/tests"]
+
+[tool.black]
+line-length = 119
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+  | docs
+)/
+'''
+
+[tool.flake8]
+max-line-length = 88
+docstring-convention = "numpy"
+ignore = "D204,D401"
+exclude = ["venv"]
+
+# radon(code-complexity tool)
+radon-max-cc = 10
+
+[tool.isort]
+profile = "black"
+multi_line_output = "VERTICAL_HANGING_INDENT"
+force_grid_wrap = 2
+line_length = 99
 
 [tool.pylint.main]
 load-plugins = "pylint.extensions.no_self_use"


### PR DESCRIPTION
Fixes #1109

As described in the issue, I've setup pre-commit with black+isort+flake8 configuration. I've also added [radon](https://pypi.org/project/radon/) as a seperate checker from pre-commit for cyclomatic complexity and to help maintain readability as well. The current rating is A(2.5044124477473293) which is really good, so no major action needs to be taken for now.

For the pre-commit hooks, the following formatters/linters are setup:

1. black: It auto-formats code to a strict, consistent style.

2. flake8: It lints for style, formatting, and some basic code quality issues.

3. isort: It automatically sorts imports by PEP8 standards and custom rules.

After executing `pre-commit run --all-files`, it modified 70+ files with changes, so I decided to not include the changes in this PR for now.

Could you please review?

cc: @BenjaminBossan