### PR TITLE
FIX: HF integration test workflow file

### DIFF
--- a/.github/workflows/test-hf-integration.yml
+++ b/.github/workflows/test-hf-integration.yml
@@ -18,10 +18,9 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install Requirements
       run: |
-        python -m pip install -r requirements.txt
         python -m pip install torch -f https://download.pytorch.org/whl/torch_stable.html
         python -m pip install transformers tokenizers huggingface_hub
         python -m pip install .


### PR DESCRIPTION
Due to #1108, `pip install -r requirements.txt` is no longer working. Also, I took the liberty to bump the Python version used to 3.12.