### PR TITLE
Update: PyTorch v2.8.0

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false  # don't cancel all jobs when one fails
       matrix:
         python_version: ['3.9', '3.10', '3.11', '3.12']
-        torch_version: ['2.4.1+cpu', '2.5.1+cpu', '2.6.0+cpu', '2.7.0+cpu']
+        torch_version: ['2.5.1+cpu', '2.6.0+cpu', '2.7.1+cpu', '2.8.0+cpu']
         os: [ubuntu-latest]
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -233,10 +233,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 2.4.1
 - 2.5.1
 - 2.6.0
-- 2.7.0
+- 2.7.1
+- 2.8.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -93,10 +93,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 2.4.1
 - 2.5.1
 - 2.6.0
-- 2.7.0
+- 2.7.1
+- 2.8.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of


### PR DESCRIPTION
- drop 2.4.1
- update 2.7.0 -> 2.7.1