### PR TITLE
Custom sklearn estimators implementing `__sklearn_is_fitted__`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Implement `__sklearn_is_fitted__` for skorch models, following [sklearn custom model protocol](https://scikit-learn.org/stable/auto_examples/developing_estimators/sklearn_is_fitted.html#sphx-glr-auto-examples-developing-estimators-sklearn-is-fitted-py) (#1119)
+
 ## [1.2.0]
 
 ### Added

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1377,6 +1377,14 @@ class NeuralNet(BaseEstimator):
         )
         check_is_fitted(self, attributes, *args, **kwargs)
 
+    def __sklearn_is_fitted__(self):
+        """This method is called when sklearn's ``check_is_fitted`` is used.
+        
+        Explained here: 
+        https://scikit-learn.org/stable/auto_examples/developing_estimators/sklearn_is_fitted.html
+        """
+        return self.check_is_fitted()
+
     def trim_for_prediction(self):
         """Remove all attributes not required for prediction.
 

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1383,7 +1383,15 @@ class NeuralNet(BaseEstimator):
         Explained here: 
         https://scikit-learn.org/stable/auto_examples/developing_estimators/sklearn_is_fitted.html
         """
-        return self.check_is_fitted()
+        from skorch.exceptions import NotInitializedError
+        try:
+            self.check_is_fitted()
+        except NotInitializedError:
+            from sklearn.exceptions import NotFittedError
+            raise NotFittedError(
+                f"This {self.__class__.__name__} instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before using this estimator."
+            )
 
     def trim_for_prediction(self):
         """Remove all attributes not required for prediction.

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -19,6 +19,7 @@ import warnings
 
 import numpy as np
 from sklearn.base import BaseEstimator
+from sklearn.exceptions import NotFittedError
 import torch
 from torch.utils.data import DataLoader
 
@@ -30,6 +31,7 @@ from skorch.dataset import ValidSplit
 from skorch.dataset import get_len
 from skorch.dataset import unpack_data
 from skorch.exceptions import DeviceWarning
+from skorch.exceptions import NotInitializedError
 from skorch.exceptions import SkorchAttributeError
 from skorch.exceptions import SkorchTrainingImpossibleError
 from skorch.history import History
@@ -1383,11 +1385,9 @@ class NeuralNet(BaseEstimator):
         Explained here: 
         https://scikit-learn.org/stable/auto_examples/developing_estimators/sklearn_is_fitted.html
         """
-        from skorch.exceptions import NotInitializedError
         try:
             self.check_is_fitted()
         except NotInitializedError:
-            from sklearn.exceptions import NotFittedError
             raise NotFittedError(
                 f"This {self.__class__.__name__} instance is not fitted yet. "
                 "Call 'fit' with appropriate arguments before using this estimator."

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -253,7 +253,7 @@ class TestNeuralNetBinaryClassifier:
         clone(net_fit)
 
     @pytest.mark.parametrize('method', INFERENCE_METHODS)
-    def test_not_fitted_raises(self, net_cls, module_cls, data, method):
+    def test_not_init_raises(self, net_cls, module_cls, data, method):
         from skorch.exceptions import NotInitializedError
         net = net_cls(module_cls)
         X = data[0]
@@ -263,6 +263,19 @@ class TestNeuralNetBinaryClassifier:
 
         msg = ("This NeuralNetBinaryClassifier instance is not initialized "
                "yet. Call 'initialize' or 'fit' with appropriate arguments "
+               "before using this method.")
+        assert exc.value.args[0] == msg
+
+    def test_not_fitted_raises(self, net_cls, module_cls):
+        from sklearn.utils.validation import check_is_fitted
+        from sklearn.exceptions import NotFittedError
+    
+        net = net_cls(module_cls)
+        with pytest.raises(NotFittedError) as exc:
+            check_is_fitted(net)
+
+        msg = ("This NeuralNetBinaryClassifier instance is not initialized yet. "
+               "Call 'initialize' or 'fit' with appropriate arguments "
                "before using this method.")
         assert exc.value.args[0] == msg
 

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -274,9 +274,9 @@ class TestNeuralNetBinaryClassifier:
         with pytest.raises(NotFittedError) as exc:
             check_is_fitted(net)
 
-        msg = ("This NeuralNetBinaryClassifier instance is not initialized yet. "
-               "Call 'initialize' or 'fit' with appropriate arguments "
-               "before using this method.")
+        msg = ("This NeuralNetBinaryClassifier instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before "
+                "using this estimator.")
         assert exc.value.args[0] == msg
 
     def test_net_learns(self, net_cls, module_cls, data):

--- a/skorch/tests/test_classifier.py
+++ b/skorch/tests/test_classifier.py
@@ -274,9 +274,11 @@ class TestNeuralNetBinaryClassifier:
         with pytest.raises(NotFittedError) as exc:
             check_is_fitted(net)
 
-        msg = ("This NeuralNetBinaryClassifier instance is not fitted yet. "
-                "Call 'fit' with appropriate arguments before "
-                "using this estimator.")
+        msg = (
+            "This NeuralNetBinaryClassifier instance is not fitted yet. "
+            "Call 'fit' with appropriate arguments before "
+            "using this estimator."
+        )
         assert exc.value.args[0] == msg
 
     def test_net_learns(self, net_cls, module_cls, data):

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -315,9 +315,11 @@ class TestNeuralNet:
         with pytest.raises(NotFittedError) as exc:
             check_is_fitted(net)
 
-        msg = ("This NeuralNetClassifier instance is not fitted yet. "
-                "Call 'fit' with appropriate arguments before "
-                "using this estimator.")
+        msg = (
+            "This NeuralNetClassifier instance is not fitted yet. "
+            "Call 'fit' with appropriate arguments before "
+            "using this estimator."
+        )
         assert exc.value.args[0] == msg
 
     def test_not_fitted_other_attributes(self, module_cls):

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -294,13 +294,26 @@ class TestNeuralNet:
         pass
 
     @pytest.mark.parametrize('method', INFERENCE_METHODS)
-    def test_not_fitted_raises(self, net_cls, module_cls, data, method):
+    def test_not_init_raises(self, net_cls, module_cls, data, method):
         from skorch.exceptions import NotInitializedError
         net = net_cls(module_cls)
         X = data[0]
         with pytest.raises(NotInitializedError) as exc:
             # we call `list` because `forward_iter` is lazy
             list(getattr(net, method)(X))
+
+        msg = ("This NeuralNetClassifier instance is not initialized yet. "
+               "Call 'initialize' or 'fit' with appropriate arguments "
+               "before using this method.")
+        assert exc.value.args[0] == msg
+
+    def test_not_fitted_raises(self, net_cls, module_cls):
+        from sklearn.utils.validation import check_is_fitted
+        from sklearn.exceptions import NotFittedError
+    
+        net = net_cls(module_cls)
+        with pytest.raises(NotFittedError) as exc:
+            check_is_fitted(net)
 
         msg = ("This NeuralNetClassifier instance is not initialized yet. "
                "Call 'initialize' or 'fit' with appropriate arguments "

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -315,9 +315,9 @@ class TestNeuralNet:
         with pytest.raises(NotFittedError) as exc:
             check_is_fitted(net)
 
-        msg = ("This NeuralNetClassifier instance is not initialized yet. "
-               "Call 'initialize' or 'fit' with appropriate arguments "
-               "before using this method.")
+        msg = ("This NeuralNetClassifier instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before "
+                "using this estimator.")
         assert exc.value.args[0] == msg
 
     def test_not_fitted_other_attributes(self, module_cls):

--- a/skorch/tests/test_regressor.py
+++ b/skorch/tests/test_regressor.py
@@ -91,9 +91,11 @@ class TestNeuralNetRegressor:
         with pytest.raises(NotFittedError) as exc:
             check_is_fitted(net)
 
-        msg = ("This NeuralNetRegressor instance is not fitted yet. "
-                "Call 'fit' with appropriate arguments before "
-                "using this estimator.")
+        msg = (
+            "This NeuralNetRegressor instance is not fitted yet. "
+            "Call 'fit' with appropriate arguments before "
+            "using this estimator."
+        )
         assert exc.value.args[0] == msg
 
     def test_net_learns(self, net, net_cls, data, module_cls):

--- a/skorch/tests/test_regressor.py
+++ b/skorch/tests/test_regressor.py
@@ -70,7 +70,7 @@ class TestNeuralNetRegressor:
         assert not recwarn.list
 
     @pytest.mark.parametrize('method', INFERENCE_METHODS)
-    def test_not_fitted_raises(self, net_cls, module_cls, data, method):
+    def test_not_init_raises(self, net_cls, module_cls, data, method):
         from skorch.exceptions import NotInitializedError
         net = net_cls(module_cls)
         X = data[0]
@@ -80,6 +80,19 @@ class TestNeuralNetRegressor:
 
         msg = ("This NeuralNetRegressor instance is not initialized "
                "yet. Call 'initialize' or 'fit' with appropriate arguments "
+               "before using this method.")
+        assert exc.value.args[0] == msg
+
+    def test_not_fitted_raises(self, net_cls, module_cls):
+        from sklearn.utils.validation import check_is_fitted
+        from sklearn.exceptions import NotFittedError
+    
+        net = net_cls(module_cls)
+        with pytest.raises(NotFittedError) as exc:
+            check_is_fitted(net)
+
+        msg = ("This NeuralNetRegressor instance is not initialized yet. "
+               "Call 'initialize' or 'fit' with appropriate arguments "
                "before using this method.")
         assert exc.value.args[0] == msg
 

--- a/skorch/tests/test_regressor.py
+++ b/skorch/tests/test_regressor.py
@@ -91,9 +91,9 @@ class TestNeuralNetRegressor:
         with pytest.raises(NotFittedError) as exc:
             check_is_fitted(net)
 
-        msg = ("This NeuralNetRegressor instance is not initialized yet. "
-               "Call 'initialize' or 'fit' with appropriate arguments "
-               "before using this method.")
+        msg = ("This NeuralNetRegressor instance is not fitted yet. "
+                "Call 'fit' with appropriate arguments before "
+                "using this estimator.")
         assert exc.value.args[0] == msg
 
     def test_net_learns(self, net, net_cls, data, module_cls):


### PR DESCRIPTION
Closes #1118 

Things to note:

- I saw the docstring [here](https://github.com/skorch-dev/skorch/blob/44c35271e9b82e136d998c16cc442d3e2204910f/skorch/hf.py#L66) so I made this `__sklearn_is_fitted__` docstring similar
- renamed the existing `test_not_fitted_raises` into `test_not_init_raises` but looking for advice on your preferences. 
- also not sure if a `test_not_fitted_raises` test is needed in all 3 of `tests/test_net.py`, `tests/test_regressor.py` and `tests/test_classifier.py` as the one in `tests/test_net.py` cover it. Again, seeking maintainers' preferences here. 

cc @BenjaminBossan 