### PR TITLE
ENH Add automatic device selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `device='auto'` to select CUDA when available and CPU otherwise.
+
 ### Changed
 
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `device='auto'` to select CUDA when available and CPU otherwise.
+- Add `device='auto'` to select hardware acceleration like CUDA when
+  available, and CPU otherwise.
 
 ### Changed
 

--- a/docs/user/neuralnet.rst
+++ b/docs/user/neuralnet.rst
@@ -298,8 +298,8 @@ As the name suggests, this determines which computation device should
 be used. If set to ``'cuda'``, the incoming data will be transferred to
 CUDA before being passed to the PyTorch :class:`~torch.nn.Module`. The
 device parameter adheres to the general syntax of the PyTorch device
-parameter. If you want to prevent skorch from handling the device, set
-``device=None``.
+parameter. If set to ``'auto'``, CUDA is used if available and CPU otherwise.
+If you want to prevent skorch from handling the device, set ``device=None``.
 
 initialize()
 ^^^^^^^^^^^^

--- a/docs/user/neuralnet.rst
+++ b/docs/user/neuralnet.rst
@@ -298,8 +298,9 @@ As the name suggests, this determines which computation device should
 be used. If set to ``'cuda'``, the incoming data will be transferred to
 CUDA before being passed to the PyTorch :class:`~torch.nn.Module`. The
 device parameter adheres to the general syntax of the PyTorch device
-parameter. If set to ``'auto'``, CUDA is used if available and CPU otherwise.
-If you want to prevent skorch from handling the device, set ``device=None``.
+parameter. If set to ``'auto'``, hardware acceleration like CUDA is being
+used if available, and CPU otherwise. If you want to prevent skorch from
+handling the device, set ``device=None``.
 
 initialize()
 ^^^^^^^^^^^^

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -48,6 +48,7 @@ from skorch.utils import _infer_predict_nonlinearity
 from skorch.utils import FirstStepAccumulator
 from skorch.utils import TeeGenerator
 from skorch.utils import _check_f_arguments
+from skorch.utils import _check_device_auto
 from skorch.utils import check_is_fitted
 from skorch.utils import duplicate_items
 from skorch.utils import get_map_location
@@ -218,7 +219,8 @@ class NeuralNet(BaseEstimator):
     device : str, torch.device, or None (default='cpu')
       The compute device to be used. If set to 'cuda' in order to use
       GPU acceleration, data in torch tensors will be pushed to cuda
-      tensors before being sent to the module. If set to None, then
+      tensors before being sent to the module. If set to 'auto', CUDA
+      is used if available and CPU otherwise. If set to None, then
       all compute devices will be left unmodified.
 
     compile : bool (default=False)
@@ -2719,6 +2721,9 @@ class NeuralNet(BaseEstimator):
             warnings.warn(msg, DeviceWarning)
             return map_device
 
+        if requested_device == 'auto':
+            return map_device
+
         type_1 = torch.device(requested_device)
         type_2 = torch.device(map_device)
         if type_1 != type_2:
@@ -2796,7 +2801,9 @@ class NeuralNet(BaseEstimator):
 
                 if isinstance(f_name, (str, os.PathLike)):
                     state_dict = {}
-                    with safe_open(f_name, framework='pt', device=self.device) as f:
+                    with safe_open(
+                            f_name, framework='pt',
+                            device=_check_device_auto(self.device)) as f:
                         for key in f.keys():
                             state_dict[key] = f.get_tensor(key)
                 else:

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -48,7 +48,7 @@ from skorch.utils import _infer_predict_nonlinearity
 from skorch.utils import FirstStepAccumulator
 from skorch.utils import TeeGenerator
 from skorch.utils import _check_f_arguments
-from skorch.utils import _check_device_auto
+from skorch.utils import _check_device
 from skorch.utils import check_is_fitted
 from skorch.utils import duplicate_items
 from skorch.utils import get_map_location
@@ -2803,8 +2803,9 @@ class NeuralNet(BaseEstimator):
                 if isinstance(f_name, (str, os.PathLike)):
                     state_dict = {}
                     with safe_open(
-                            f_name, framework='pt',
-                            device=_check_device_auto(self.device)) as f:
+                            f_name,
+                            framework='pt',
+                            device=_check_device(self.device)) as f:
                         for key in f.keys():
                             state_dict[key] = f.get_tensor(key)
                 else:

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -219,9 +219,10 @@ class NeuralNet(BaseEstimator):
     device : str, torch.device, or None (default='cpu')
       The compute device to be used. If set to 'cuda' in order to use
       GPU acceleration, data in torch tensors will be pushed to cuda
-      tensors before being sent to the module. If set to 'auto', CUDA
-      is used if available and CPU otherwise. If set to None, then
-      all compute devices will be left unmodified.
+      tensors before being sent to the module. If set to 'auto',
+      hardware acceleration like CUDA is being used if available, and
+      CPU otherwise. If set to None, then all compute devices will be
+      left unmodified.
 
     compile : bool (default=False)
       If set to ``True``, compile all modules using ``torch.compile``. For this

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -468,6 +468,21 @@ class TestNeuralNet:
         net = net.initialize()
         assert net.module_.sequential[0].weight.device.type.startswith(device)
 
+    @pytest.mark.parametrize('cuda_available, expected', [
+        (False, 'cpu'),
+        (True, 'cuda'),
+    ])
+    def test_device_auto(
+            self, net_cls, module_cls, cuda_available, expected):
+        if cuda_available and not torch.cuda.is_available():
+            pytest.skip()
+
+        with patch('torch.cuda.is_available', lambda *_: cuda_available):
+            net = net_cls(module=module_cls, device='auto')
+            net = net.initialize()
+
+        assert net.module_.sequential[0].weight.device.type == expected
+
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="no cuda device")
     @pytest.mark.parametrize(
         'save_dev, cuda_available, load_dev, expect_warning',

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -346,17 +346,33 @@ class TestNeuralNet:
         y_pred = net.predict(X)
         assert accuracy_score(y, y_pred) > ACCURACY_EXPECTED
 
-    def test_device_auto_fit_predict(self, net_cls, module_cls, data):
+    @pytest.mark.parametrize('cuda_available, expected', [
+        (False, 'cpu'),
+        (True, 'cuda'),
+    ])
+    def test_device_auto_fit_predict(
+            self, net_cls, module_cls, data, cuda_available, expected):
+        if cuda_available and not torch.cuda.is_available():
+            pytest.skip()
+
         X, y = data
-        net = net_cls(
-            module_cls,
-            max_epochs=10,
-            lr=0.1,
-            device='auto',
-        )
-        net.fit(X, y)
-        y_pred = net.predict(X)
+        with patch('torch.cuda.is_available', lambda *_: cuda_available):
+            net = net_cls(
+                module_cls,
+                max_epochs=10,
+                lr=0.1,
+                device='auto',
+            )
+            net.fit(X, y)
+            y_pred = net.predict(X)
+            y_forward = net.forward(X, device='auto')
+
         assert accuracy_score(y, y_pred) > ACCURACY_EXPECTED
+        assert all(
+            param.device.type == expected
+            for _, param in net.get_all_learnable_params()
+        )
+        assert y_forward.device.type == expected
 
     def test_forward(self, net_fit, data):
         X = data[0]

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -346,6 +346,18 @@ class TestNeuralNet:
         y_pred = net.predict(X)
         assert accuracy_score(y, y_pred) > ACCURACY_EXPECTED
 
+    def test_device_auto_fit_predict(self, net_cls, module_cls, data):
+        X, y = data
+        net = net_cls(
+            module_cls,
+            max_epochs=10,
+            lr=0.1,
+            device='auto',
+        )
+        net.fit(X, y)
+        y_pred = net.predict(X)
+        assert accuracy_score(y, y_pred) > ACCURACY_EXPECTED
+
     def test_forward(self, net_fit, data):
         X = data[0]
         n = len(X)

--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -1,6 +1,7 @@
 """Test for utils.py"""
 
 from copy import deepcopy
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -32,6 +33,21 @@ class TestToTensor:
 
         t = to_tensor(t, device='cpu')
         assert t.device.type == 'cpu'
+
+    @pytest.mark.parametrize('cuda_available, expected', [
+        (False, 'cpu'),
+        (True, 'cuda'),
+    ])
+    def test_device_setting_auto(
+            self, to_tensor, cuda_available, expected):
+        if cuda_available and not torch.cuda.is_available():
+            pytest.skip()
+
+        x = np.ones((2, 3, 4))
+        with patch('torch.cuda.is_available', lambda *_: cuda_available):
+            t = to_tensor(x, device='auto')
+
+        assert t.device.type == expected
 
     def tensors_equal(self, x, y):
         """"Test that tensors in diverse containers are equal."""
@@ -247,6 +263,10 @@ class TestToDevice:
         if None is device_input:
             assert tensor.device.type == prev_device
 
+        elif device_input == 'auto':
+            expected = 'cuda' if torch.cuda.is_available() else 'cpu'
+            assert tensor.device.type == expected
+
         else:
             assert tensor.device.type == device_input
 
@@ -270,6 +290,35 @@ class TestToDevice:
 
         x = to_device(x, device=device_to)
         self.check_device_type(x, device_to, prev_device)
+
+    @pytest.mark.parametrize('cuda_available, expected', [
+        (False, 'cpu'),
+        (True, 'cuda'),
+    ])
+    def test_check_device_auto(
+            self, to_device, x, cuda_available, expected):
+        if cuda_available and not torch.cuda.is_available():
+            pytest.skip()
+
+        with patch('torch.cuda.is_available', lambda *_: cuda_available):
+            x = to_device(x, device='auto')
+
+        assert x.device.type == expected
+
+    @pytest.mark.parametrize('cuda_available, expected', [
+        (False, 'cpu'),
+        (True, 'cuda'),
+    ])
+    def test_get_map_location_auto(self, cuda_available, expected):
+        if cuda_available and not torch.cuda.is_available():
+            pytest.skip()
+
+        from skorch.utils import get_map_location
+
+        with patch('torch.cuda.is_available', lambda *_: cuda_available):
+            map_location = get_map_location('auto')
+
+        assert map_location.type == expected
 
     @pytest.mark.parametrize('device_from, device_to', [
         ('cpu', 'cpu'),

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -60,6 +60,12 @@ def is_geometric_data_type(x):
 
 
 # pylint: disable=not-callable
+def _check_device_auto(device):
+    if device == 'auto':
+        return 'cuda' if torch.cuda.is_available() else 'cpu'
+    return device
+
+
 def to_tensor(X, device, accept_sparse=False):
     """Turn input data to torch tensor.
 
@@ -77,7 +83,7 @@ def to_tensor(X, device, accept_sparse=False):
     device : str, torch.device
       The compute device to be used. If set to 'cuda', data in torch
       tensors will be pushed to cuda tensors before being sent to the
-      module.
+      module. If set to 'auto', use CUDA if available and CPU otherwise.
 
     accept_sparse : bool (default=False)
       Whether to accept scipy sparse matrices as input. If False,
@@ -89,6 +95,7 @@ def to_tensor(X, device, accept_sparse=False):
     output : torch Tensor
 
     """
+    device = _check_device_auto(device)
     to_tensor_ = partial(to_tensor, device=device)
 
     if is_torch_data_type(X):
@@ -185,9 +192,11 @@ def to_device(X, device):
 
     device : str, torch.device
         The compute device to be used. If device=None, return the input
-        unmodified
+        unmodified. If device='auto', use CUDA if available and CPU otherwise.
 
     """
+    device = _check_device_auto(device)
+
     if device is None:
         return X
 
@@ -562,6 +571,7 @@ def get_map_location(target_device, fallback_device='cpu'):
     """
     if target_device is None:
         target_device = fallback_device
+    target_device = _check_device_auto(target_device)
 
     map_location = torch.device(target_device)
 

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -59,13 +59,13 @@ def is_geometric_data_type(x):
     return isinstance(x, Data)
 
 
-# pylint: disable=not-callable
 def _check_device_auto(device):
     if device == 'auto':
         return 'cuda' if torch.cuda.is_available() else 'cpu'
     return device
 
 
+# pylint: disable=not-callable
 def to_tensor(X, device, accept_sparse=False):
     """Turn input data to torch tensor.
 
@@ -83,7 +83,8 @@ def to_tensor(X, device, accept_sparse=False):
     device : str, torch.device
       The compute device to be used. If set to 'cuda', data in torch
       tensors will be pushed to cuda tensors before being sent to the
-      module. If set to 'auto', use CUDA if available and CPU otherwise.
+      module. If set to 'auto', hardware acceleration like CUDA is
+      being used if available, and CPU otherwise.
 
     accept_sparse : bool (default=False)
       Whether to accept scipy sparse matrices as input. If False,
@@ -192,7 +193,8 @@ def to_device(X, device):
 
     device : str, torch.device
         The compute device to be used. If device=None, return the input
-        unmodified. If device='auto', use CUDA if available and CPU otherwise.
+        unmodified. If device='auto', hardware acceleration like CUDA
+        is being used if available, and CPU otherwise.
 
     """
     device = _check_device_auto(device)

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -59,7 +59,8 @@ def is_geometric_data_type(x):
     return isinstance(x, Data)
 
 
-def _check_device_auto(device):
+def _check_device(device):
+    """Resolve special device shortcuts."""
     if device == 'auto':
         return 'cuda' if torch.cuda.is_available() else 'cpu'
     return device
@@ -96,7 +97,7 @@ def to_tensor(X, device, accept_sparse=False):
     output : torch Tensor
 
     """
-    device = _check_device_auto(device)
+    device = _check_device(device)
     to_tensor_ = partial(to_tensor, device=device)
 
     if is_torch_data_type(X):
@@ -197,7 +198,7 @@ def to_device(X, device):
         is being used if available, and CPU otherwise.
 
     """
-    device = _check_device_auto(device)
+    device = _check_device(device)
 
     if device is None:
         return X
@@ -573,7 +574,7 @@ def get_map_location(target_device, fallback_device='cpu'):
     """
     if target_device is None:
         target_device = fallback_device
-    target_device = _check_device_auto(target_device)
+    target_device = _check_device(target_device)
 
     map_location = torch.device(target_device)
 


### PR DESCRIPTION
## Summary

Add support for `device='auto'` so skorch selects CUDA when it is available and falls back to CPU otherwise.

This centralizes the resolution in `skorch.utils` and applies it to tensor/device movement, map-location handling, module initialization, and safetensors loading.

Closes #576.

## Testing

- `.venv/bin/python -m pytest skorch/tests/test_utils.py::TestToTensor::test_device_setting_auto skorch/tests/test_utils.py::TestToDevice::test_check_device_auto skorch/tests/test_utils.py::TestToDevice::test_get_map_location_auto skorch/tests/test_net.py::TestNeuralNet::test_device_auto`
- `.venv/bin/python -m pytest skorch/tests/test_utils.py skorch/tests/test_net.py::TestNeuralNet::test_device_torch_device skorch/tests/test_net.py::TestNeuralNet::test_pickle_save_load_device_is_none`
- `git diff --check`