### PR TITLE
Update: PyTorch 2.12.0

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false  # don't cancel all jobs when one fails
       matrix:
         python_version: ['3.10', '3.11', '3.12', '3.13']
-        torch_version: ['2.8.0+cpu', '2.9.1+cpu', '2.10.0+cpu', '2.11.0+cpu']
+        torch_version: ['2.9.1+cpu', '2.10.0+cpu', '2.11.0+cpu', '2.12.0+cpu']
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,10 +39,6 @@ jobs:
         python -m pip install '.[test,docs,dev,extended]'
         python -m pip install pytest-pretty 
         python -m pip install torch==${{ matrix.torch_version }} -f https://download.pytorch.org/whl/torch
-        TORCH_VERSION_MAJOR_MINOR=$(python -c "import torch; v=torch.__version__.split('+')[0]; print('.'.join(v.split('.')[:2]))")
-        if [[ $(echo "$TORCH_VERSION_MAJOR_MINOR < 2.9" | bc -l) -eq 1 ]]; then
-          python -m pip install "triton==3.4"
-        fi
         python -m pip list
     - name: Install skorch
       run: |

--- a/README.rst
+++ b/README.rst
@@ -233,10 +233,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 2.8.0
 - 2.9.1
 - 2.10.0
 - 2.11.0
+- 2.12.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -93,10 +93,10 @@ instructions for PyTorch, visit the `PyTorch website
 <http://pytorch.org/>`__. skorch officially supports the last four
 minor PyTorch versions, which currently are:
 
-- 2.8.0
 - 2.9.1
 - 2.10.0
 - 2.11.0
+- 2.12.0
 
 However, that doesn't mean that older versions don't work, just that
 they aren't tested. Since skorch mostly relies on the stable part of


### PR DESCRIPTION
- Add torch 2.12.0 to test matrix and docs
- Remove torch 2.8.0
- Remove logic to downgrade triton, as it is only required for torch <= 2.8.0