### PR TITLE
ci: update GitHub Actions checkout and setup-python to latest versions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,9 +27,9 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python_version }}
     - name: Install dependencies


### PR DESCRIPTION
## CI: Update GitHub Actions to latest versions

GitHub Actions `actions/checkout` and `actions/setup-python` have newer versions
with bug fixes, performance improvements, and Node.js compatibility updates:

- `actions/checkout@v3` → `@v4` (Node.js 20, improved performance)
- `actions/setup-python@v3`/`v4` → `@v5` (Node.js 20, improved caching)

**Files updated:**
  - `.github/workflows/testing.yml`: checkout: 1 occurrence(s), setup-python: 1 occurrence(s)

**Why this matters:**
- Node.js 16 (used by older action versions) is EOL since September 2024
- GitHub emits deprecation warnings for v3 and older actions in CI logs
- v4/v5 are functionally equivalent drop-in replacements
