### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/skorch/_doctor.py
+++ b/skorch/_doctor.py
@@ -72,7 +72,7 @@ def add_activation_hooks(net, match_fn=None):
 
     If an output is not a simple array, it is disambiguated. E.g. if it's a
     list, the name get a suffix of ``[i]`` where ``i`` designates the index in
-    the list. Similary, when the output is a dict, a ``[key]`` suffix is added,
+    the list. Similarly, when the output is a dict, a ``[key]`` suffix is added,
     where ``[key]`` is the key of the corresponding value in the dictionary.
 
     Parameters
@@ -249,7 +249,7 @@ class SkorchDoctor(BaseEstimator):
           different parameter groups, or an adaptive optimizer like Adam.
 
         - If gradients are too big, consider using gradient clipping. If the
-          mangitude of gradients shifts over time, you might want to use a
+          magnitude of gradients shifts over time, you might want to use a
           learning rate scheduler.
 
     At the end of the day, ``SkorchDoctor`` will not tell you what you need to
@@ -333,7 +333,7 @@ class SkorchDoctor(BaseEstimator):
 
       If an activation is not a simple array, it is disambiguated. E.g. if it's a
       list, the name get a suffix of ``[i]`` where ``i`` designates the index in
-      the list. Similary, when the output is a dict, a ``[key]`` suffix is
+      the list. Similarly, when the output is a dict, a ``[key]`` suffix is
       added, where ``[key]`` is the key of the corresponding value in the
       dictionary.
 

--- a/skorch/callbacks/logging.py
+++ b/skorch/callbacks/logging.py
@@ -387,7 +387,7 @@ class PrintLog(Callback):
 
     ``PrintLog`` treats keys with the ``'event_'`` prefix in a special
     way. They are assumed to contain information about occasionally
-    occuring events. The ``False`` or ``None`` entries (indicating
+    occurring events. The ``False`` or ``None`` entries (indicating
     that an event did not occur) are not printed, resulting in empty
     cells in the table, and ``True`` entries are printed with ``+``
     symbol. ``PrintLog`` groups all event columns together and pushes
@@ -689,7 +689,7 @@ class TensorBoard(Callback):
     """Logs results from history to TensorBoard
 
     "TensorBoard provides the visualization and tooling needed for machine
-    learning experimentation" (`offical docs
+    learning experimentation" (`official docs
     <https://www.tensorflow.org/tensorboard/>`_).
 
     Use this callback to automatically log all interesting values from your

--- a/skorch/callbacks/scoring.py
+++ b/skorch/callbacks/scoring.py
@@ -167,7 +167,7 @@ class BatchScoring(ScoringBase):
     the score for each batch and then averages the score at the end of
     the epoch. This can be disadvantageous for some scores if the
     batch size is small -- e.g. area under the ROC will return
-    incorrect scores in this case. Therefore, it is recommnded to use
+    incorrect scores in this case. Therefore, it is recommended to use
     :class:`.EpochScoring` unless you really need the scores for each
     batch.
 

--- a/skorch/classifier.py
+++ b/skorch/classifier.py
@@ -42,7 +42,7 @@ neural_net_clf_additional_attribute = """    classes_ : array, shape (n_classes,
 """
 
 def get_neural_net_clf_doc(doc):
-    # dedent/indent roundtrip required for consistent indention in both
+    # dedent/indent roundtrip required for consistent indentation in both
     # Python <3.13 and Python >=3.13
     # Because <3.13 => no automatic dedent, but it is the case in >=3.13
     indentation = "    "
@@ -255,7 +255,7 @@ neural_net_binary_clf_criterion_text = """
       is used by ``predict`` and ``predict_proba`` for classification."""
 
 def get_neural_net_binary_clf_doc(doc):
-    # dedent/indent roundtrip required for consistent indention in both
+    # dedent/indent roundtrip required for consistent indentation in both
     # Python <3.13 and Python >=3.13
     # Because <3.13 => no automatic dedent, but it is the case in >=3.13
     indentation = "    "

--- a/skorch/cli.py
+++ b/skorch/cli.py
@@ -258,7 +258,7 @@ def print_help(model, defaults=None):
     model : sklearn.base.BaseEstimator
       The basic model, e.g. a ``NeuralNet`` or sklearn ``Pipeline``.
 
-    defautls : dict or None (default=None)
+    defaults : dict or None (default=None)
       Optionally, change the default values to use custom
       defaults. Commandline arguments have precedence over defaults.
 

--- a/skorch/dataset.py
+++ b/skorch/dataset.py
@@ -172,7 +172,7 @@ class Dataset(torch.utils.data.Dataset):
         By default, they are cast to PyTorch :class:`~torch.Tensor`\s.
         Override this if you want a different behavior.
 
-        Note: If you use this in conjuction with PyTorch
+        Note: If you use this in conjunction with PyTorch
         :class:`~torch.utils.data.DataLoader`, the latter will call
         the dataset for each row separately, which means that the
         incoming ``X`` and ``y`` each are single rows.

--- a/skorch/helper.py
+++ b/skorch/helper.py
@@ -219,7 +219,7 @@ class SliceDataset(Sequence):
     def transform(self, data):
         """Additional transformations on ``data``.
 
-        Note: If you use this in conjuction with PyTorch
+        Note: If you use this in conjunction with PyTorch
         :class:`~torch.utils.data.DataLoader`, the latter will call
         the dataset for each row separately, which means that the
         incoming ``data`` is a single rows.

--- a/skorch/hf.py
+++ b/skorch/hf.py
@@ -851,7 +851,7 @@ class AccelerateMixin:
 
     .. warning::
 
-        Since accelerate is still quite young and backwards compatiblity
+        Since accelerate is still quite young and backwards compatibility
         breaking features might be added, we treat its integration as an
         experimental feature. When accelerate's API stabilizes, we will consider
         adding it to skorch proper.
@@ -1021,7 +1021,7 @@ class AccelerateMixin:
 
     def _step_optimizer(self, step_fn):
         # We cannot step_fn as a 'closure' to .step because GradScaler doesn't
-        # suppor it:
+        # support it:
         # https://pytorch.org/docs/stable/amp.html#torch.cuda.amp.GradScaler.step
         # Therefore, we need to call step_fn explicitly and step without
         # argument.
@@ -1132,7 +1132,7 @@ class HfHubStorage:
 
     Note that writes to the Hub are synchronous. Therefore, if the time it takes
     to upload the data is long compared to training the model, there can be a
-    signficant slowdown. It is best to use this with
+    significant slowdown. It is best to use this with
     :class:`skorch.callbacks.training.TrainEndCheckpoint`, as that checkpoint
     only uploads the data once, at the end of training. Also, using this writer
     with :class:`skorch.callbacks.training.LoadInitState` is not supported for

--- a/skorch/llm/classifier.py
+++ b/skorch/llm/classifier.py
@@ -393,7 +393,7 @@ class _LlmBase(ClassifierMixin, BaseEstimator):
     def _predict_one(self, text):
         """Make a prediction for a single sample
 
-        The returned probabilites are *not normalized* yet.
+        The returned probabilities are *not normalized* yet.
 
         Raises a ``LowProbabilityError`` if the total probability of all labels
         is 0, or, assuming ``error_low_prob`` is ``'raise'``, when it is below
@@ -534,7 +534,7 @@ class _LlmBase(ClassifierMixin, BaseEstimator):
           The label for each class.
 
         """
-        # y_proba not normalized but it's not neeeded here
+        # y_proba not normalized but it's not needed here
         y_proba = self._predict_proba(X)
         pred_ids = y_proba.argmax(1)
         y_pred = self.classes_[pred_ids]
@@ -704,7 +704,7 @@ class ZeroShotClassifier(_LlmBase):
     ----------
     classes_ : ndarray of shape (n_classes, )
       A list of class labels known to the classifier. This attribute can be used
-      to identify which column in the probabilties returned by ``predict_proba``
+      to identify which column in the probabilities returned by ``predict_proba``
       corresponds to which class.
 
     """
@@ -932,7 +932,7 @@ class FewShotClassifier(_LlmBase):
     ----------
     classes_ : ndarray of shape (n_classes, )
       A list of class labels known to the classifier. This attribute can be used
-      to identify which column in the probabilties returned by ``predict_proba``
+      to identify which column in the probabilities returned by ``predict_proba``
       corresponds to which class.
 
     """

--- a/skorch/net.py
+++ b/skorch/net.py
@@ -1,7 +1,7 @@
 """Neural net base class
 
 This is the most flexible class, not making assumptions on the kind of
-task being peformed. Subclass this to create more specialized and
+task being performed. Subclass this to create more specialized and
 sklearn-conforming classes like NeuralNetClassifier.
 
 """
@@ -144,7 +144,7 @@ class NeuralNet(BaseEstimator):
       this if your data is not supported. You should generally pass the
       uninitialized ``Dataset`` class and define additional arguments to
       X and y by prefixing them with ``dataset__``. It is also possible
-      to pass an initialzed ``Dataset``, in which case no additional
+      to pass an initialized ``Dataset``, in which case no additional
       arguments may be passed.
 
     train_split : None or callable (default=skorch.dataset.ValidSplit(5))
@@ -700,7 +700,7 @@ class NeuralNet(BaseEstimator):
         return self
 
     def _format_reinit_msg(self, name, kwargs=None, triggered_directly=True):
-        """Returns a message that informs about re-initializing a compoment.
+        """Returns a message that informs about re-initializing a component.
 
         Sometimes, the module or optimizer need to be
         re-initialized. Not only should the user receive a message
@@ -1593,7 +1593,7 @@ class NeuralNet(BaseEstimator):
 
         device : string (default='cpu')
           The device to store each inference result on.
-          This defaults to CPU memory since there is genereally
+          This defaults to CPU memory since there is generally
           more memory available there. For performance reasons
           this might be changed to a specific CUDA device,
           e.g. 'cuda:0'.
@@ -1641,7 +1641,7 @@ class NeuralNet(BaseEstimator):
 
         device : string (default='cpu')
           The device to store each inference result on.
-          This defaults to CPU memory since there is genereally
+          This defaults to CPU memory since there is generally
           more memory available there. For performance reasons
           this might be changed to a specific CUDA device,
           e.g. 'cuda:0'.
@@ -2350,7 +2350,7 @@ class NeuralNet(BaseEstimator):
             if '__' not in name and name in names:
                 self._replace_callback(name, params.pop(key))
 
-        # 3. Step parameters and other initilisation arguments
+        # 3. Step parameters and other initialisation arguments
         for key in params.copy():
             name = key[11:]
             part0, part1 = name.split('__')
@@ -2527,12 +2527,12 @@ class NeuralNet(BaseEstimator):
 
         """
         if (self.init_context_ is None) and isinstance(attr, torch.nn.Module):
-            msg = ("Trying to set torch compoment '{}' outside of an initialize method."
+            msg = ("Trying to set torch component '{}' outside of an initialize method."
                    " Consider defining it inside 'initialize_module'".format(name))
             raise SkorchAttributeError(msg)
 
         if (self.init_context_ is None) and isinstance(attr, torch.optim.Optimizer):
-            msg = ("Trying to set torch compoment '{}' outside of an initialize method."
+            msg = ("Trying to set torch component '{}' outside of an initialize method."
                    " Consider defining it inside 'initialize_optimizer'".format(name))
             raise SkorchAttributeError(msg)
 

--- a/skorch/probabilistic.py
+++ b/skorch/probabilistic.py
@@ -231,7 +231,7 @@ class GPBase(NeuralNet):
 
         device : string (default='cpu')
           The device to store each inference result on.
-          This defaults to CPU memory since there is genereally
+          This defaults to CPU memory since there is generally
           more memory available there. For performance reasons
           this might be changed to a specific CUDA device,
           e.g. 'cuda:0'.
@@ -289,7 +289,7 @@ class GPBase(NeuralNet):
 
         device : string (default='cpu')
           The device to store each inference result on.
-          This defaults to CPU memory since there is genereally
+          This defaults to CPU memory since there is generally
           more memory available there. For performance reasons
           this might be changed to a specific CUDA device,
           e.g. 'cuda:0'.
@@ -514,7 +514,7 @@ gp_likelihood_attribute_text = """
 
 def get_exact_gp_regr_doc(doc):
     """Customizes the net docs to avoid duplication."""
-    # dedent/indent roundtrip required for consistent indention in both
+    # dedent/indent roundtrip required for consistent indentation in both
     # Python <3.13 and Python >=3.13
     # Because <3.13 => no automatic dedent, but it is the case in >=3.13
     indentation = "    "
@@ -689,7 +689,7 @@ gp_regr_criterion_text = """
 
 def get_gp_regr_doc(doc):
     """Customizes the net docs to avoid duplication."""
-    # dedent/indent roundtrip required for consistent indention in both
+    # dedent/indent roundtrip required for consistent indentation in both
     # Python <3.13 and Python >=3.13
     # Because <3.13 => no automatic dedent, but it is the case in >=3.13
     indentation = "    "
@@ -765,7 +765,7 @@ gp_binary_clf_criterion_text = """
 
 def get_gp_binary_clf_doc(doc):
     """Customizes the net docs to avoid duplication."""
-    # dedent/indent roundtrip required for consistent indention in both
+    # dedent/indent roundtrip required for consistent indentation in both
     # Python <3.13 and Python >=3.13
     # Because <3.13 => no automatic dedent, but it is the case in >=3.13
     indentation = "    "

--- a/skorch/regressor.py
+++ b/skorch/regressor.py
@@ -26,7 +26,7 @@ neural_net_reg_criterion_text = """
 
 def get_neural_net_reg_doc(doc):
     indentation = "    "
-    # dedent/indent roundtrip required for consistent indention in both
+    # dedent/indent roundtrip required for consistent indentation in both
     # Python <3.13 and Python >=3.13
     # Because <3.13 => not automatic dedent, but it is the case in >=3.13
     doc = neural_net_reg_doc_start + " " + textwrap.indent(textwrap.dedent(doc.split("\n", 5)[-1]), indentation)

--- a/skorch/tests/callbacks/test_scoring.py
+++ b/skorch/tests/callbacks/test_scoring.py
@@ -503,7 +503,7 @@ class TestEpochScoring:
         # expected count should be:
         # fit loop: 1 (train) + 1 (valid) = 2
         # scoring:
-        #   without cahching: 0
+        #   without caching: 0
         #   with caching: 1 per epoch = 3
         assert net.get_iterator.call_count == count
 

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -573,7 +573,7 @@ class TestEarlyStopping:
         val_dataset = TensorDataset(
             torch.as_tensor(X_val).float(), torch.as_tensor(y_val))
 
-        # Fix the network once with early stoppping and fixed seed
+        # Fix the network once with early stopping and fixed seed
         net1 = net_clf_cls(
             classifier_module,
             callbacks=[early_stopping_cb],

--- a/skorch/tests/test_cli.py
+++ b/skorch/tests/test_cli.py
@@ -20,7 +20,7 @@ except ImportError:
     fire_installed = False
 
 
-@pytest.mark.skipif(not fire_installed, reason='fire libarary not installed')
+@pytest.mark.skipif(not fire_installed, reason='fire library not installed')
 class TestCli:
     @pytest.fixture
     def resolve_dotted_name(self):

--- a/skorch/tests/test_dataset.py
+++ b/skorch/tests/test_dataset.py
@@ -556,7 +556,7 @@ class TestTrainSplitIsUsed:
     def net_and_mock(self, module, data, train_split, iterator):
         """Return a NeuralNetClassifier with mocked train and
         validation step which save the args and kwargs the methods are
-        calld with.
+        called with.
 
         """
         from skorch import NeuralNetClassifier

--- a/skorch/tests/test_helper.py
+++ b/skorch/tests/test_helper.py
@@ -400,7 +400,7 @@ class TestSliceDataset:
 
     def test_explicitly_pass_indices_at_init(self, slds_cls, custom_ds, X):
         from skorch.utils import to_numpy
-        # test passing indices directy to __init__
+        # test passing indices directly to __init__
         slds = slds_cls(custom_ds, indices=np.arange(10))
         sliced0 = slds[5:]
         sliced1 = sliced0[2]

--- a/skorch/tests/test_hf.py
+++ b/skorch/tests/test_hf.py
@@ -493,7 +493,7 @@ class TestHuggingfacePretrainedTokenizerWithFit(_HuggingfaceTokenizersBaseTest):
         # original tokenizer. However, for this test, we don't have enough data
         # to reach that vocab size (28996). Therefore, we test instead that the
         # vocab size is considerably greater than the one seen when we set
-        # vocab_size explictly.
+        # vocab_size explicitly.
         from transformers import AutoTokenizer
         from skorch.hf import HuggingfacePretrainedTokenizer
 

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -262,7 +262,7 @@ class TestNeuralNet:
 
         # the following line used to raise this error: "TypeError: Got
         # an unexpected argument optimizer_2__lr, did you mean
-        # optimizer__2__lr?" because it was erronously assumed that
+        # optimizer__2__lr?" because it was erroneously assumed that
         # "optimizer_2__lr" should be dispatched to "optimizer", not
         # "optimizer_2".
         MyNet(module_cls, optimizer_2__lr=0.123)  # should not raise
@@ -1213,7 +1213,7 @@ class TestNeuralNet:
         # test that the error message of set_params includes helpful
         # information instead of, e.g., generator expressions.
         # sklearn 0.2x does not output the parameter names so we can
-        # skip detailled checks of the error message there.
+        # skip detailed checks of the error message there.
 
         sklearn_0_2x_string = "Check the list of available parameters with `estimator.get_params().keys()`"
 
@@ -3466,7 +3466,7 @@ class TestNeuralNet:
                 super().__init__(*args, **kwargs)
                 self.foo_ = module_cls()
 
-        msg = ("Trying to set torch compoment 'foo_' outside of an initialize method. "
+        msg = ("Trying to set torch component 'foo_' outside of an initialize method. "
                "Consider defining it inside 'initialize_module'")
         with pytest.raises(SkorchAttributeError, match=msg):
             MyNet(module_cls)
@@ -3476,14 +3476,14 @@ class TestNeuralNet:
     ):
         from skorch.exceptions import SkorchAttributeError
 
-        # all optimzers should be set within an initialize method
+        # all optimizers should be set within an initialize method
         class MyNet(net_cls):
             def initialize(self):
                 super().initialize()
                 self.opti = torch.optim.Adam(self.module_.parameters())
                 return self
 
-        msg = ("Trying to set torch compoment 'opti' outside of an initialize method. "
+        msg = ("Trying to set torch component 'opti' outside of an initialize method. "
                "Consider defining it inside 'initialize_optimizer'")
         with pytest.raises(SkorchAttributeError, match=msg):
             MyNet(module_cls).initialize()

--- a/skorch/tests/test_probabilistic.py
+++ b/skorch/tests/test_probabilistic.py
@@ -36,7 +36,7 @@ def get_batch_size(dist):
     """Return the shape of the distribution
 
     The method/attribute required to determine the shape depends on the kind of
-    distrubtion.
+    distribution.
 
     """
     shape = getattr(dist, 'shape', None)
@@ -482,7 +482,7 @@ class BaseProbabilisticTests:
         assert gp.likelihood_ is gp_init.likelihood_
 
     ##########################
-    # probabalistic specific #
+    # probabilistic specific #
     ##########################
 
     @pytest.mark.parametrize("n_samples", [1, 2, 10])

--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -923,7 +923,7 @@ class TestInferPredictNonlinearity:
 
     def test_infer_neural_net_classifier_crossentropy_loss(
             self, infer_predict_nonlinearity, net_clf_cls, module_cls):
-        # CrossEntropyLoss criteron: nonlinearity should return valid probabilities
+        # CrossEntropyLoss criterion: nonlinearity should return valid probabilities
         net = net_clf_cls(module_cls, criterion=torch.nn.CrossEntropyLoss).initialize()
         fn = infer_predict_nonlinearity(net)
 

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -653,7 +653,7 @@ def _sigmoid_then_2d(x):
     return _make_2d_probs(prob)
 
 
-# TODO only needed if multiclass GP classfication is added
+# TODO only needed if multiclass GP classification is added
 # def _transpose(x):
     # return x.T
 
@@ -691,7 +691,7 @@ def _infer_predict_nonlinearity(net):
     return _identity
 
     # TODO: Add the code below to _infer_predict_nonlinearity if multiclass GP
-    # classfication is added.
+    # classification is added.
     # likelihood = getattr(net, 'likelihood_', None)
     # if likelihood is None:
     #     return _identity


### PR DESCRIPTION
Fix minor typos found by codespell in comments and docstrings.