### PR TITLE
Fix LRScheduler pickling dragging along CUDA optimizer reference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ValidSplit` now raises a clear error when it receives an `IterableDataset`, instead of an opaque `TypeError` about a missing length (#594)
 - `Checkpoint`'s sink message now reports the epoch the checkpoint was actually taken in, instead of the following one
+- Fix pickling a net with an `LRScheduler` callback dragging along a reference to the (potentially CUDA-resident) optimizer, which could prevent loading nets trained on CUDA on a CPU-only machine (#1096)
 
 ## [1.4.0]
 

--- a/skorch/callbacks/lr_scheduler.py
+++ b/skorch/callbacks/lr_scheduler.py
@@ -124,6 +124,19 @@ class LRScheduler(Callback):
         self.batch_idx_ = 0
         return self
 
+    def __getstate__(self):
+        # Don't pickle lr_scheduler_: Torch's LR schedulers keep a reference
+        # to the optimizer they were created for, which means that pickling
+        # it would drag along a duplicate of net.optimizer_, including its
+        # device-dependent tensors (e.g. Adam's running averages). This
+        # would prevent nets trained on CUDA from being unpickled on a
+        # CPU-only machine, since net.optimizer_ is otherwise handled
+        # correctly via cuda_dependent_attributes_. lr_scheduler_ is
+        # recreated in on_train_begin anyway, so it's safe to drop it here.
+        state = self.__dict__.copy()
+        state['lr_scheduler_'] = None
+        return state
+
     def _get_policy_cls(self):
         if isinstance(self.policy, str):
             return getattr(sys.modules[__name__], self.policy)

--- a/skorch/tests/callbacks/test_lr_scheduler.py
+++ b/skorch/tests/callbacks/test_lr_scheduler.py
@@ -1,8 +1,10 @@
 """Tests for lr_scheduler.py"""
+import pickle
 from unittest.mock import Mock
 
 import numpy as np
 import pytest
+import torch
 from sklearn.base import clone
 from torch.optim import SGD
 from torch.optim.lr_scheduler import CosineAnnealingLR
@@ -133,6 +135,51 @@ class TestLRCallbacks:
         net.fit(X, y)
         # pylint: disable=protected-access
         assert lr_policy.lr_scheduler_.last_epoch == max_epochs
+
+    def test_lr_scheduler_dropped_from_pickled_state(
+            self, classifier_module, classifier_data,
+    ):
+        # See issue #1096. torch's LR schedulers keep a reference to the
+        # optimizer they were created for. Since the LRScheduler callback
+        # lives in net.callbacks_, which is not covered by
+        # cuda_dependent_attributes_, pickling it used to drag along a
+        # duplicate of net.optimizer_ (including any device-dependent
+        # tensors, e.g. Adam's running averages). This defeated the
+        # purpose of stripping net.optimizer_ out as a cuda dependent
+        # attribute and broke loading CUDA-trained nets on CPU-only
+        # machines.
+        X, y = classifier_data
+        lr_policy = LRScheduler(policy='StepLR', step_size=1)
+        net = NeuralNetClassifier(
+            classifier_module(),
+            max_epochs=2,
+            optimizer=torch.optim.Adam,
+            callbacks=[('lr_scheduler', lr_policy)],
+        )
+        net.fit(X, y)
+
+        assert lr_policy.lr_scheduler_.optimizer is net.optimizer_
+
+        # lr_scheduler_ must not be part of the pickled state, since it
+        # references the (potentially CUDA-resident) optimizer directly.
+        state = lr_policy.__getstate__()
+        assert state['lr_scheduler_'] is None
+
+        # after a full round trip, the reference should be gone and the
+        # net should remain fully usable
+        net_loaded = pickle.loads(pickle.dumps(net))
+        lr_loaded = dict(net_loaded.callbacks_)['lr_scheduler']
+        assert lr_loaded.lr_scheduler_ is None
+
+        y_pred = net_loaded.predict(X)
+        assert y_pred.shape[0] == X.shape[0]
+
+        # resuming training recreates lr_scheduler_ tied to the (loaded)
+        # optimizer
+        net_loaded.partial_fit(X, y)
+        lr_loaded = dict(net_loaded.callbacks_)['lr_scheduler']
+        assert lr_loaded.lr_scheduler_ is not None
+        assert lr_loaded.lr_scheduler_.optimizer is net_loaded.optimizer_
 
     @pytest.mark.parametrize('policy, kwargs', [
         (CyclicLR, {'base_lr': 1e-3, 'max_lr': 6e-3, 'step_every': 'batch'}),


### PR DESCRIPTION
Fixes #1096.

`net.optimizer_` is handled as a CUDA-dependent attribute when pickling a net, so it can be safely loaded on a CPU-only machine. However, when using the `LRScheduler` callback, `lr_scheduler_.optimizer` is the same optimizer object, and this reference lives inside `net.callbacks_`, which is not covered by that CUDA-dependent handling. Pickling the net therefore serialized a second, independent copy of the optimizer (including any device tensors, e.g. Adam's running averages) through the ordinary pickle path, causing CUDA-trained nets with an `LRScheduler` callback to fail to load on CPU-only machines.

`lr_scheduler_` is recreated from `net.optimizer_` in `on_train_begin` anyway, so it doesn't need to be part of the pickled state. This adds a small `__getstate__` to `LRScheduler` that drops it before pickling, following the same pattern already used by `EarlyStopping` and `ProgressBar` for their own transient state.

Added a test that reproduces the reference leak with a stateful optimizer (Adam) and confirms it's gone after a pickle round-trip, and that resuming training afterwards still works correctly.