### PR TITLE
fix: raise a clear error when ValidSplit gets an IterableDataset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `ValidSplit` now raises a clear error when it receives an `IterableDataset`, instead of an opaque `TypeError` about a missing length (#594)
+
 ## [1.4.0]
 
 ### Added

--- a/skorch/dataset.py
+++ b/skorch/dataset.py
@@ -314,14 +314,14 @@ class ValidSplit:
         # pylint: disable=invalid-name
         try:
             len_dataset = get_len(dataset)
-        except TypeError:
+        except TypeError as exc:
             if not isinstance(dataset, torch.utils.data.IterableDataset):
                 raise
             raise ValueError(
                 "Cannot perform a CV split on an IterableDataset because it has "
                 "no length. Set train_split=None to disable the internal "
                 "validation split, or pass a train_split that supports "
-                "IterableDataset.") from None
+                "IterableDataset.") from exc
         if y is not None:
             len_y = get_len(y)
             if len_dataset != len_y:

--- a/skorch/dataset.py
+++ b/skorch/dataset.py
@@ -311,15 +311,17 @@ class ValidSplit:
         if self.stratified and not self._is_stratified(cv):
             raise bad_y_error
 
-        if isinstance(dataset, torch.utils.data.IterableDataset):
+        # pylint: disable=invalid-name
+        try:
+            len_dataset = get_len(dataset)
+        except TypeError:
+            if not isinstance(dataset, torch.utils.data.IterableDataset):
+                raise
             raise ValueError(
                 "Cannot perform a CV split on an IterableDataset because it has "
                 "no length. Set train_split=None to disable the internal "
                 "validation split, or pass a train_split that supports "
-                "IterableDataset.")
-
-        # pylint: disable=invalid-name
-        len_dataset = get_len(dataset)
+                "IterableDataset.") from None
         if y is not None:
             len_y = get_len(y)
             if len_dataset != len_y:

--- a/skorch/dataset.py
+++ b/skorch/dataset.py
@@ -311,6 +311,13 @@ class ValidSplit:
         if self.stratified and not self._is_stratified(cv):
             raise bad_y_error
 
+        if isinstance(dataset, torch.utils.data.IterableDataset):
+            raise ValueError(
+                "Cannot perform a CV split on an IterableDataset because it has "
+                "no length. Set train_split=None to disable the internal "
+                "validation split, or pass a train_split that supports "
+                "IterableDataset.")
+
         # pylint: disable=invalid-name
         len_dataset = get_len(dataset)
         if y is not None:

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2160,6 +2160,58 @@ class TestNeuralNet:
         assert exc.value.args[0] == msg
 
     @pytest.fixture
+    def iterable_dataset_cls(self):
+        class MyIterableDataset(torch.utils.data.IterableDataset):
+            def __init__(self, X, y):
+                super().__init__()
+                self.X = X
+                self.y = y
+
+            def __iter__(self):
+                return iter(zip(self.X, self.y))
+
+        return MyIterableDataset
+
+    def test_fit_with_iterable_dataset_and_train_split_raises(
+            self, net_cls, module_cls, iterable_dataset_cls, data):
+        from skorch.dataset import ValidSplit
+
+        net = net_cls(
+            module_cls,
+            max_epochs=1,
+            train_split=ValidSplit(stratified=False),
+        )
+        ds = iterable_dataset_cls(*data)
+        with pytest.raises(ValueError) as exc:
+            net.fit(ds, None)
+
+        msg = ("Cannot perform a CV split on an IterableDataset because it has "
+               "no length. Set train_split=None to disable the internal "
+               "validation split, or pass a train_split that supports "
+               "IterableDataset.")
+        assert exc.value.args[0] == msg
+
+    def test_fit_with_iterable_dataset_no_train_split(
+            self, net_cls, module_cls, iterable_dataset_cls, data):
+        net = net_cls(module_cls, max_epochs=1, train_split=None)
+        ds = iterable_dataset_cls(*data)
+        net.fit(ds, None)  # does not raise
+
+        assert 'train_loss' in net.history[-1]
+
+    def test_fit_with_iterable_dataset_and_custom_train_split(
+            self, net_cls, module_cls, iterable_dataset_cls, data):
+        # a train_split that never indexes the dataset must keep working
+        def train_split(dataset, **kwargs):
+            return dataset, dataset
+
+        net = net_cls(module_cls, max_epochs=1, train_split=train_split)
+        ds = iterable_dataset_cls(*data)
+        net.fit(ds, None)  # does not raise
+
+        assert 'valid_loss' in net.history[-1]
+
+    @pytest.fixture
     def dataset_1_item(self):
         class Dataset(torch.utils.data.Dataset):
             def __len__(self):

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2190,6 +2190,7 @@ class TestNeuralNet:
                "validation split, or pass a train_split that supports "
                "IterableDataset.")
         assert exc.value.args[0] == msg
+        assert isinstance(exc.value.__cause__, TypeError)
 
     def test_fit_with_iterable_dataset_no_train_split(
             self, net_cls, module_cls, iterable_dataset_cls, data):

--- a/skorch/tests/test_net.py
+++ b/skorch/tests/test_net.py
@@ -2199,6 +2199,39 @@ class TestNeuralNet:
 
         assert 'train_loss' in net.history[-1]
 
+    @pytest.fixture
+    def sized_iterable_dataset_cls(self):
+        class MySizedIterableDataset(torch.utils.data.IterableDataset):
+            def __init__(self, X, y):
+                super().__init__()
+                self.X = X
+                self.y = y
+
+            def __iter__(self):
+                return iter(zip(self.X, self.y))
+
+            def __len__(self):
+                return len(self.y)
+
+            def __getitem__(self, i):
+                return self.X[i], self.y[i]
+
+        return MySizedIterableDataset
+
+    def test_fit_with_sized_iterable_dataset_and_train_split(
+            self, net_cls, module_cls, sized_iterable_dataset_cls, data):
+        from skorch.dataset import ValidSplit
+
+        net = net_cls(
+            module_cls,
+            max_epochs=1,
+            train_split=ValidSplit(stratified=False),
+        )
+        ds = sized_iterable_dataset_cls(*data)
+        net.fit(ds, None)  # does not raise
+
+        assert 'valid_loss' in net.history[-1]
+
     def test_fit_with_iterable_dataset_and_custom_train_split(
             self, net_cls, module_cls, iterable_dataset_cls, data):
         # a train_split that never indexes the dataset must keep working


### PR DESCRIPTION
Closes #594.

`ValidSplit` needs `len()` and `Subset`, so an `IterableDataset` currently dies with an opaque `TypeError` about a missing length. It now raises a `ValueError` naming the cause and pointing at `train_split=None`.

Per the request on the issue that the error only be raised if really needed, the check sits in `ValidSplit.__call__` rather than in `NeuralNet` - a custom `train_split` that tolerates an `IterableDataset` keeps working, and there is a test covering that.

### Review fixes applied
- 961a68a: intercept the `TypeError` from `get_len` instead of checking `isinstance` up front, so an `IterableDataset` subclass that defines `__len__` still splits normally; any other error is reraised untouched. Added a test for that case.
- 729cdcf: chain the original `TypeError` (`from exc` instead of `from None`) so the traceback keeps it; test asserts `__cause__`.
