### PR TITLE
FIX Preserve defaultdicts in to_device

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `ValidSplit` now raises a clear error when it receives an `IterableDataset`, instead of an opaque `TypeError` about a missing length (#594)
+- Fix moving `defaultdict` inputs to a device.
 
 ## [1.4.0]
 

--- a/skorch/tests/test_utils.py
+++ b/skorch/tests/test_utils.py
@@ -1,5 +1,6 @@
 """Test for utils.py"""
 
+from collections import defaultdict
 from copy import deepcopy
 from unittest.mock import patch
 
@@ -373,6 +374,18 @@ class TestToDevice:
         assert x_dict.keys() == original_x_dict.keys()
         for k in x_dict:
             assert np.allclose(x_dict[k], original_x_dict[k])
+
+    def test_check_device_defaultdict_torch_tensor(self, to_device, x_dict):
+        x_defaultdict = defaultdict(list, x_dict)
+
+        result = to_device(x_defaultdict, device='cpu')
+
+        assert isinstance(result, defaultdict)
+        assert result.default_factory is list
+        assert result['missing'] == []
+        for key, value in x_dict.items():
+            assert torch.equal(result[key], value)
+            assert result[key].device.type == 'cpu'
 
     @pytest.mark.parametrize('device_from, device_to', [
         ('cpu', 'cpu'),

--- a/skorch/utils.py
+++ b/skorch/utils.py
@@ -4,6 +4,7 @@ Should not have any dependency on other skorch packages.
 
 """
 
+from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from enum import Enum
@@ -205,7 +206,10 @@ def to_device(X, device):
 
     if isinstance(X, Mapping):
         # dict-like but not a dict
-        return type(X)({key: to_device(val, device) for key, val in X.items()})
+        mapped = {key: to_device(val, device) for key, val in X.items()}
+        if isinstance(X, defaultdict):
+            return type(X)(X.default_factory, mapped)
+        return type(X)(mapped)
 
     # PackedSequence class inherits from a namedtuple
     if isinstance(X, (tuple, list)) and (type(X) != PackedSequence):


### PR DESCRIPTION
## Summary

- preserve `collections.defaultdict` instances when recursively moving mapping values
- carry over the original `default_factory`
- add regression coverage and a changelog entry

## Problem

`to_device` supports mapping inputs and reconstructs them with `type(X)(mapping)`. For a `defaultdict`, the first constructor argument is the default factory, so the public utility currently raises:

```text
TypeError: first argument must be callable or None
```

This change uses the `defaultdict(default_factory, mapping)` constructor while retaining the existing behavior for other mapping types.

## Tests

- `python -m pytest skorch/tests/test_utils.py -q -k TestToDevice` (13 passed, 17 skipped)
- `python -m pytest skorch/tests/test_utils.py -q` (105 passed, 22 skipped)
- `git diff --check`

Full-file Flake8/Pylint checks report pre-existing findings in these files; the changed lines introduce no Flake8 diagnostics.

## AI assistance

This pull request was prepared with Codex assistance. I reviewed the reproduced failure, the focused implementation, and the test results before submission.