### PR TITLE
Report the current epoch in Checkpoint's sink message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `ValidSplit` now raises a clear error when it receives an `IterableDataset`, instead of an opaque `TypeError` about a missing length (#594)
+- `Checkpoint`'s sink message now reports the epoch the checkpoint was actually taken in, instead of the following one
 
 ## [1.4.0]
 

--- a/skorch/callbacks/training.py
+++ b/skorch/callbacks/training.py
@@ -235,7 +235,7 @@ class Checkpoint(Callback):
         if do_checkpoint:
             self.save_model(net)
             self._sink("A checkpoint was triggered in epoch {}.".format(
-                len(net.history) + 1
+                len(net.history)
             ), net.verbose)
 
     def _f_kwargs(self):

--- a/skorch/tests/callbacks/test_training.py
+++ b/skorch/tests/callbacks/test_training.py
@@ -95,6 +95,19 @@ class TestCheckpoint:
         assert sink.call_count == len(net.history)
         assert all((x is True) for x in net.history[:, 'event_another'])
 
+    def test_sink_message_reports_the_current_epoch(
+            self, save_params_mock, net_cls, checkpoint_cls, data):
+        sink = Mock()
+        net = net_cls(callbacks=[checkpoint_cls(monitor=None, sink=sink)])
+        net.fit(*data)
+
+        epochs = net.history[:, 'epoch']
+        expected = [
+            call("A checkpoint was triggered in epoch {}.".format(epoch))
+            for epoch in epochs
+        ]
+        assert sink.call_args_list == expected
+
     @pytest.mark.parametrize('message,files', [
         ('Unable to save module state to params.pt, '
          'Exception: encoding error',


### PR DESCRIPTION
`Checkpoint.on_epoch_end` formats its message with `len(net.history) + 1`:

```python
if do_checkpoint:
    self.save_model(net)
    self._sink("A checkpoint was triggered in epoch {}.".format(
        len(net.history) + 1
    ), net.verbose)
```

but `on_epoch_begin` has already appended the row and recorded the epoch as `len(self.history)`:

```python
def on_epoch_begin(self, net, dataset_train=None, dataset_valid=None, **kwargs):
    self.history.new_epoch()
    self.history.record('epoch', len(self.history))
```

so during epoch N the message names N + 1. A three-epoch run with `sink=print`:

```
A checkpoint was triggered in epoch 2.
  epoch    train_loss    cp     dur
-------  ------------  ----  ------
      1        0.7081     +  0.0024
A checkpoint was triggered in epoch 3.
      2        0.3480     +  0.0010
A checkpoint was triggered in epoch 4.
      3        0.2223     +  0.0009

history epoch column: [1, 2, 3]
saved files          : ['params_1.pt', 'params_2.pt', 'params_3.pt']
```

The last line reports epoch 4 for a run of `max_epochs=3`, and the same call writes `params_3.pt`. With this change the messages read 1, 2, 3 and line up with both the epoch column and the filenames.

`EarlyStopping` in this module already reports `net.history[-1, 'epoch']` for its own message, which is the same value.

Only the message text changes — the saved files, the history values and when a checkpoint fires are all untouched. No existing test asserts this string.

Added `test_sink_message_reports_the_current_epoch`, which builds the expected calls from `net.history[:, 'epoch']` so it stays correct if the epoch numbering ever changes. It fails on `master` and passes here.
